### PR TITLE
feat: add JSON-based multi-MCP server configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,7 @@ GOOGLE_APPLICATION_CREDENTIALS_CONTENT='{
     "universe_domain": "googleapis.com"
   }'
 
-# MCP config
-MCP_SERVER_NAME=template-mcp-server
-MCP_SERVER_URL=http://localhost:5001/mcp
-MCP_TRANSPORT_PROTOCOL=streamable_http
+# MCP servers — define all servers in agent_config/mcp_servers.json.
+# Override the config file path with MCP_SERVERS_CONFIG if needed.
+# MCP_SERVERS_CONFIG=
+MCP_CONNECTION_TIMEOUT=30

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Template Agent
 
 [![Python 3.12+](https://img.shields.io/badge/python-3.12,3.13-blue.svg)](https://www.python.org/downloads/)
-[![Tests](https://github.com/redhat-data-and-ai/template-agent/actions/workflows/test.yml/badge.svg)](https://github.com/redhat-data-and-ai/template-mcp-server/actions/workflows/ci.yml)
-[![Coverage](https://codecov.io/gh/redhat-data-and-ai/template-agent/branch/main/graph/badge.svg)](https://codecov.io/gh/redhat-data-and-ai/template-mcp-server)
+[![Tests](https://github.com/redhat-data-and-ai/template-agent/actions/workflows/test.yml/badge.svg)](https://github.com/redhat-data-and-ai/template-agent/actions/workflows/test.yml)
+[![Coverage](https://codecov.io/gh/redhat-data-and-ai/template-agent/branch/main/graph/badge.svg)](https://codecov.io/gh/redhat-data-and-ai/template-agent)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 A production-ready template for building AI agents with streaming capabilities, conversation management, and enterprise-grade features.
@@ -155,7 +155,7 @@ See the [examples README](./examples/README.md) for detailed usage instructions.
    # Edit .env with your configuration
    ```
 
-5. **Run template-mcp-server** following https://github.com/redhat-data-and-ai/template-mcp-server
+5. **Configure MCP servers** in `template_agent/agent_config/mcp_servers.json` — enable the servers you need and set their URLs. See [template-mcp-server](https://github.com/redhat-data-and-ai/template-mcp-server) for a compatible local MCP server.
 
 
 6. **Run the application**

--- a/deployment/openshift/configmap.yaml
+++ b/deployment/openshift/configmap.yaml
@@ -9,8 +9,7 @@ data:
   PYTHON_LOG_LEVEL: "INFO"
   USE_INMEMORY_SAVER: "false"
   LANGFUSE_TRACING_ENVIRONMENT: "production"
-  MCP_SERVER_NAME: "template-mcp-server"
-  MCP_SERVER_URL: "https://template-mcp-server.ns.svc:8443/mcp/"
-  MCP_TRANSPORT_PROTOCOL: "streamable_http"
+  # MCP servers are defined in agent_config/mcp_servers.json (baked into the image).
+  # Override the config file path with MCP_SERVERS_CONFIG if needed.
+  # MCP_SERVERS_CONFIG: "/app/mcp_servers.json"
   MCP_CONNECTION_TIMEOUT: "30"
-  MCP_SSL_VERIFY: "false"

--- a/deployment/openshift/deployment.yaml
+++ b/deployment/openshift/deployment.yaml
@@ -45,21 +45,11 @@ spec:
                 configMapKeyRef:
                   name: template-agent-config
                   key: LANGFUSE_TRACING_ENVIRONMENT
-            - name: MCP_SERVER_NAME
+            - name: MCP_CONNECTION_TIMEOUT
               valueFrom:
                 configMapKeyRef:
                   name: template-agent-config
-                  key: MCP_SERVER_NAME
-            - name: MCP_SERVER_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: template-agent-config
-                  key: MCP_SERVER_URL
-            - name: MCP_TRANSPORT_PROTOCOL
-              valueFrom:
-                configMapKeyRef:
-                  name: template-agent-config
-                  key: MCP_TRANSPORT_PROTOCOL
+                  key: MCP_CONNECTION_TIMEOUT
             - name: POSTGRES_HOST
               valueFrom:
                 secretKeyRef:

--- a/template_agent/agent_config/mcp_servers.json
+++ b/template_agent/agent_config/mcp_servers.json
@@ -1,0 +1,18 @@
+{
+  "mcpServers": {
+    "template-mcp-server": {
+      "enabled": false,
+      "url": "http://localhost:5001/mcp/",
+      "transport": "streamable_http",
+      "ssl_verify": false,
+      "description": "Local template MCP server"
+    },
+    "remote-mcp-server": {
+      "enabled": false,
+      "url": "https://mcp.example.com/mcp/",
+      "transport": "streamable_http",
+      "ssl_verify": true,
+      "description": "Remote MCP server (replace URL with your deployment)"
+    }
+  }
+}

--- a/template_agent/src/core/agent.py
+++ b/template_agent/src/core/agent.py
@@ -4,9 +4,11 @@ This module provides the core agent functionality for the template agent,
 including initialization, configuration, and agent creation utilities.
 """
 
+import asyncio
 from contextlib import asynccontextmanager
 from typing import Optional
 
+import httpx
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
@@ -79,86 +81,97 @@ async def get_template_agent(
         Exception: If there are issues with database connections or agent setup.
     """
     # Initialize MCP client and get tools
-    tools = []
+    tools: list = []
 
-    # Log MCP connection details for debugging
-    logger.info(f"Attempting to connect to MCP server at {settings.MCP_SERVER_URL}")
-    logger.info(f"MCP server name: {settings.MCP_SERVER_NAME}")
-    logger.info(f"MCP transport protocol: {settings.MCP_TRANSPORT_PROTOCOL}")
-    logger.info(f"MCP connection timeout: {settings.MCP_CONNECTION_TIMEOUT}s")
-    logger.info(f"SSO authentication: {'Yes' if sso_token else 'No'}")
+    mcp_defs = settings.mcp_servers
+    logger.info(
+        f"MCP connection timeout: {settings.MCP_CONNECTION_TIMEOUT}s | "
+        f"SSO authentication: {'Yes' if sso_token else 'No'} | "
+        f"Enabled servers: {list(mcp_defs.keys()) or '(none)'}"
+    )
 
-    try:
-        import asyncio
+    def _build_server_config(
+        url: str,
+        transport: str,
+        ssl_verify: bool,
+        token: str | None,
+    ) -> dict:
+        config: dict = {
+            "url": url,
+            "transport": transport,
+            "headers": {"Authorization": f"Bearer {token}"} if token else {},
+        }
+        if not ssl_verify:
+            logger.warning(f"SSL verification disabled for MCP server at {url}")
+            config["httpx_client_factory"] = (
+                lambda **kwargs: httpx.AsyncClient(verify=False, **kwargs)  # nosec B501
+            )
+        return config
 
-        # Add timeout wrapper for MCP connection
-        async def connect_with_timeout():
-            # Configure MCP client with SSL verification setting
-            server_config = {
-                "url": settings.MCP_SERVER_URL,
-                "transport": settings.MCP_TRANSPORT_PROTOCOL,
-                "headers": {"Authorization": f"Bearer {sso_token}"}
-                if sso_token
-                else {},
-            }
-
-            # Add SSL verification setting (verify=False disables cert verification)
-            if not settings.MCP_SSL_VERIFY:
-                server_config["verify"] = False
-                logger.warning(
-                    "SSL certificate verification disabled for MCP connection"
-                )
-
-            client = MultiServerMCPClient({settings.MCP_SERVER_NAME: server_config})
-            return await client.get_tools()
-
-        tools = await asyncio.wait_for(
-            connect_with_timeout(), timeout=settings.MCP_CONNECTION_TIMEOUT
+    server_configs: dict[str, dict] = {}
+    for name, defn in mcp_defs.items():
+        server_configs[name] = _build_server_config(
+            url=defn["url"],
+            transport=defn.get("transport", "streamable_http"),
+            ssl_verify=defn.get("ssl_verify", True),
+            token=sso_token,
         )
         logger.info(
-            f"Successfully connected to MCP server and loaded {len(tools)} tools"
+            f"MCP server '{name}' configured: {defn['url']} "
+            f"(transport={defn.get('transport', 'streamable_http')}, "
+            f"ssl_verify={defn.get('ssl_verify', True)})"
         )
-    except asyncio.TimeoutError:
-        # Handle timeout specifically
+
+    if server_configs:
+        async def _try_single_server(
+            srv_name: str, srv_cfg: dict
+        ) -> list:
+            """Connect to one MCP server; return tools or empty on failure."""
+            try:
+                client = MultiServerMCPClient({srv_name: srv_cfg})
+                srv_tools = await asyncio.wait_for(
+                    client.get_tools(),
+                    timeout=settings.MCP_CONNECTION_TIMEOUT,
+                )
+                logger.info(
+                    f"MCP server '{srv_name}': loaded {len(srv_tools)} tools"
+                )
+                return srv_tools
+            except asyncio.TimeoutError:
+                logger.error(
+                    f"MCP server '{srv_name}': timeout after "
+                    f"{settings.MCP_CONNECTION_TIMEOUT}s"
+                )
+            except Exception as exc:
+                logger.error(
+                    f"MCP server '{srv_name}': {type(exc).__name__}: {exc}",
+                    exc_info=True,
+                )
+            return []
+
+        results = await asyncio.gather(
+            *[
+                _try_single_server(name, cfg)
+                for name, cfg in server_configs.items()
+            ]
+        )
+        for server_tools in results:
+            tools.extend(server_tools)
+
+        logger.info(f"Total MCP tools loaded across all servers: {len(tools)}")
+    else:
+        logger.warning("No MCP servers enabled — agent will run without MCP tools")
+
+    if not tools and not settings.USE_INMEMORY_SAVER:
         error_msg = (
-            f"Timeout connecting to MCP server at {settings.MCP_SERVER_URL} "
-            f"after {settings.MCP_CONNECTION_TIMEOUT}s. "
-            f"Server may be down or unreachable."
+            "No MCP tools loaded and in-memory saver is disabled. "
+            "At least one MCP server must be reachable in production."
         )
-        logger.error(error_msg)
-
-        if settings.USE_INMEMORY_SAVER:
-            logger.warning("Running in local development mode without MCP tools")
-            tools = []
-        else:
-            logger.critical(error_msg)
-            raise AppException(
-                error_msg,
-                AppExceptionCode.PRODUCTION_MCP_CONNECTION_ERROR,
-            )
-    except Exception as e:
-        # Log detailed error information for other exceptions
-        logger.error(
-            f"Failed to connect to MCP server at {settings.MCP_SERVER_URL}",
-            exc_info=True,
+        logger.critical(error_msg)
+        raise AppException(
+            error_msg,
+            AppExceptionCode.PRODUCTION_MCP_CONNECTION_ERROR,
         )
-        logger.error(f"MCP connection error type: {type(e).__name__}")
-        logger.error(f"MCP connection error details: {str(e)}")
-
-        if settings.USE_INMEMORY_SAVER:
-            logger.warning("Running in local development mode without MCP tools")
-            tools = []  # No tools for local development
-        else:
-            # In production, MCP is required
-            error_msg = (
-                f"Failed to connect to required MCP server at {settings.MCP_SERVER_URL}. "
-                f"Error: {type(e).__name__}: {str(e)}"
-            )
-            logger.critical(error_msg)
-            raise AppException(
-                error_msg,
-                AppExceptionCode.PRODUCTION_MCP_CONNECTION_ERROR,
-            )
 
     # Initialize the language model
     model = ChatGoogleGenerativeAI(model="gemini-2.5-flash", temperature=0.3)

--- a/template_agent/src/settings.py
+++ b/template_agent/src/settings.py
@@ -5,7 +5,9 @@ BaseSettings for environment variable loading, validation, and default
 value handling for the template agent service.
 """
 
-from typing import Optional
+import json
+from pathlib import Path
+from typing import Any, Optional
 
 from dotenv import load_dotenv
 from pydantic import Field
@@ -96,29 +98,21 @@ class Settings(BaseSettings):
         json_schema_extra={"env": "GOOGLE_APPLICATION_CREDENTIALS_CONTENT"},
     )
 
-    # MCP Server Configuration
-    MCP_SERVER_NAME: str = Field(
-        default="template-mcp-server",
-        json_schema_extra={"env": "MCP_SERVER_NAME"},
-    )
-    MCP_SERVER_URL: str = Field(
-        default="http://localhost:5001/mcp/",
-        json_schema_extra={"env": "MCP_SERVER_URL"},
-    )
-    MCP_TRANSPORT_PROTOCOL: str = Field(
-        default="streamable_http",
-        json_schema_extra={"env": "MCP_TRANSPORT_PROTOCOL"},
+    # MCP Server Configuration (JSON-based — define N servers in one file)
+    MCP_SERVERS_CONFIG: str = Field(
+        default="",
+        json_schema_extra={
+            "env": "MCP_SERVERS_CONFIG",
+            "description": (
+                "Path to an mcp_servers.json file that declares all MCP "
+                "servers.  Falls back to agent_config/mcp_servers.json "
+                "when empty."
+            ),
+        },
     )
     MCP_CONNECTION_TIMEOUT: int = Field(
         default=30,
         json_schema_extra={"env": "MCP_CONNECTION_TIMEOUT"},
-    )
-    MCP_SSL_VERIFY: bool = Field(
-        default=False,
-        json_schema_extra={
-            "env": "MCP_SSL_VERIFY",
-            "description": "Enable SSL certificate verification for MCP connections",
-        },
     )
 
     # Request Logging Configuration
@@ -152,6 +146,50 @@ class Settings(BaseSettings):
     )
 
     @property
+    def mcp_servers(self) -> dict[str, dict[str, Any]]:
+        """Load MCP server definitions from the JSON config file.
+
+        Reads ``mcp_servers.json`` (path overridable via
+        ``MCP_SERVERS_CONFIG`` env var) and returns only the entries
+        where ``enabled`` is ``true``.
+
+        Returns:
+            A dict mapping server names to their config dicts.
+        """
+        config_path = (
+            Path(self.MCP_SERVERS_CONFIG) if self.MCP_SERVERS_CONFIG else None
+        )
+
+        if not config_path or not config_path.is_file():
+            config_path = (
+                Path(__file__).parent.parent / "agent_config" / "mcp_servers.json"
+            )
+
+        if not config_path.is_file():
+            logger.warning(f"MCP servers config not found at {config_path}")
+            return {}
+
+        try:
+            data = json.loads(config_path.read_text())
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.error(f"Failed to parse MCP config {config_path}: {exc}")
+            return {}
+
+        all_servers: dict[str, Any] = data.get("mcpServers", {})
+
+        enabled = {
+            name: cfg
+            for name, cfg in all_servers.items()
+            if cfg.get("enabled", True)
+        }
+
+        logger.info(
+            f"MCP config loaded: {len(enabled)}/{len(all_servers)} servers "
+            f"enabled from {config_path}"
+        )
+        return enabled
+
+    @property
     def database_uri(self) -> str:
         """Generate database URI from individual components.
 
@@ -170,7 +208,7 @@ def validate_config(settings: Settings) -> None:
 
     Performs comprehensive validation to ensure required settings are
     present and values are within acceptable ranges. This function
-    validates port ranges, log levels, and transport protocols.
+    validates port ranges and log levels.
 
     Args:
         settings: Settings instance to validate.

--- a/test_mcp.py
+++ b/test_mcp.py
@@ -1,0 +1,20 @@
+import asyncio
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
+
+async def main():
+    config = {
+        "example-mcp-server": {
+            "url": "http://localhost:5001/mcp/",
+            "transport": "streamable_http",
+        }
+    }
+
+    client = MultiServerMCPClient(config)
+    tools = await client.get_tools()
+    print("Available tools:")
+    for t in tools:
+        print(f"- {t.name}: {t.description}")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -82,5 +82,5 @@ class TestValidateConfig:
         assert "PYTHON_LOG_LEVEL must be one of" in exc_info.value.detail_message
         assert exc_info.value.error_code == "E_009"
 
-    # Note: MCP_PORT and MCP_TRANSPORT_PROTOCOL were removed from settings
-    # so these tests are no longer applicable
+    # MCP servers are now configured via agent_config/mcp_servers.json
+    # (see settings.mcp_servers property)


### PR DESCRIPTION
## Summary

- Replace hardcoded single MCP server env vars (`MCP_SERVER_NAME`, `MCP_SERVER_URL`, `MCP_TRANSPORT_PROTOCOL`, `MCP_SSL_VERIFY`) with a JSON config file (`agent_config/mcp_servers.json`) supporting N servers with per-server `enabled`, `url`, `transport`, and `ssl_verify` fields.
- Refactor `settings.py` to expose a `mcp_servers` property that reads the JSON config, filters to enabled servers, and falls back to the bundled default when `MCP_SERVERS_CONFIG` env var is unset.
- Refactor `agent.py` to iterate over all enabled servers, connect in parallel via `asyncio.gather`, and tolerate individual server failures without blocking the others.
- Update `.env.example`, OpenShift deployment manifests (`configmap.yaml`, `deployment.yaml`), `README.md` quickstart, and example `test_mcp.py` to align with the new config approach.

## Test plan

- [ ] Verify `mcp_servers.json` is loaded correctly with default fallback path
- [ ] Verify `MCP_SERVERS_CONFIG` env var overrides the config path
- [ ] Verify only `enabled: true` servers are connected
- [ ] Verify parallel connection with `asyncio.gather` — one failing server does not block others
- [ ] Verify SSL verification can be toggled per server via `ssl_verify`
- [ ] Verify agent starts without MCP tools when no servers are enabled and `USE_INMEMORY_SAVER=true`
- [ ] Verify production guard raises when no tools loaded and `USE_INMEMORY_SAVER=false`
- [ ] Verify existing unit tests still pass (`pytest`)