### PR TITLE
feat(skills): add overlay sync for PVC-based skill composition

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     name: Unit Tests

--- a/config/agent/runtime/agent.yaml
+++ b/config/agent/runtime/agent.yaml
@@ -113,7 +113,7 @@ middleware:
     #   - name: team-sops
     #     host: "https://gitlab.example.com"
     #     project: "org/skills-overlay"
-    #     ref: "main"
+    #     ref: "main"   # Ideally, this would be a tag
     #     path: "products/my-product"
     #     priority: 1
   # --- Production guardrails ---

--- a/config/agent/runtime/agent.yaml
+++ b/config/agent/runtime/agent.yaml
@@ -108,6 +108,14 @@ middleware:
     enabled: true
   skills:
     enabled: true
+    overlays: []
+    # overlays:
+    #   - name: team-sops
+    #     host: "https://gitlab.example.com"
+    #     project: "org/skills-overlay"
+    #     ref: "main"
+    #     path: "products/my-product"
+    #     priority: 1
   # --- Production guardrails ---
   model_call_limit:
     enabled: true

--- a/config/agent/skills/bmi-report/overlay/pediatrics/SKILL.md
+++ b/config/agent/skills/bmi-report/overlay/pediatrics/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: bmi-report
+description: >
+  Pediatrics overlay for bmi-report. Replaces adult BMI categories with
+  age-appropriate percentile-based assessment for children aged 2-18.
+  Use when generating a BMI report for a pediatric patient.
+metadata:
+  author: anonymous
+  version: "1.0"
+  overlay-source: pediatrics
+compatibility: Requires base bmi-report skill to be active.
+---
+
+# BMI Report - Pediatrics Override
+
+For children aged 2-18, BMI interpretation uses age-and-sex percentile charts, not fixed adult categories.
+
+## Pediatric BMI Categories (Percentile-Based)
+
+| Percentile Range | Category       |
+|-----------------|----------------|
+| < 5th           | Underweight    |
+| 5th - 84th      | Healthy weight |
+| 85th - 94th     | Overweight     |
+| >= 95th         | Obese          |
+
+These replace the adult BMI ranges (18.5, 25, 30 cutoffs) from the base skill.
+
+## Adjusted Workflow
+
+1. Calculate BMI normally using height (cm) and weight (kg)
+2. Do NOT apply adult categories to the result
+3. Note that pediatric BMI requires percentile lookup by age and sex
+4. Report the raw BMI value with pediatric context
+
+## Output Format
+
+```
+## BMI Analysis (Pediatric)
+
+- **Age:** [age]
+- **Height:** [height] cm
+- **Weight:** [weight] kg
+- **BMI:** [calculated value]
+
+### Interpretation
+
+For a [age]-year-old [boy/girl], this BMI value needs to be plotted on
+CDC/WHO growth charts to determine the percentile. Standard adult BMI
+categories do not apply to children.
+
+**Approximate guidance:**
+- This BMI appears [below/within/above] the typical range for this age group.
+
+### Disclaimer
+
+This is not medical advice. Pediatric BMI interpretation requires clinical
+growth charts and should be confirmed by a pediatrician.
+```
+
+## Key Differences from Adult Reports
+
+- Never use adult category labels (Normal, Overweight, etc.) for children
+- Always mention that percentile charts are needed for accurate classification
+- Always recommend pediatrician confirmation
+- Health tips should focus on active play and balanced nutrition, not weight management
+- Tone: supportive, growth-focused, never alarming

--- a/config/agent/skills/client-intake/overlay/pediatrics/SKILL.md
+++ b/config/agent/skills/client-intake/overlay/pediatrics/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: client-intake
+description: >
+  Pediatrics overlay for client-intake. Narrows validation ranges for children
+  aged 0-18 and requires age collection for growth chart context. Use when
+  processing measurements for pediatric patients.
+metadata:
+  author: anonymous
+  version: "1.0"
+  overlay-source: pediatrics
+compatibility: Requires base client-intake skill to be active.
+---
+
+# Client Intake - Pediatrics Override
+
+This overlay adjusts the base client-intake skill for pediatric patients.
+
+## Adjusted Validation Ranges
+
+| Measurement | Base (Adult)  | Overlay (Pediatric) |
+|-------------|---------------|---------------------|
+| Height      | 50-272 cm     | 30-200 cm           |
+| Weight      | 20-300 kg     | 2-150 kg            |
+
+These replace the adult ranges from the base skill.
+
+## Additional Required Field
+
+Always collect patient age before processing measurements.
+
+- For children under 2: ask age in months
+- For children 2+: ask age in years
+- If age is not provided, prompt: "What is the patient's age?"
+
+## Output Format
+
+Return measurements with age included:
+
+```
+- **Age:** <value> years (or months for infants)
+- **Height:** <value> cm
+- **Weight:** <value> kg
+```
+
+## Pediatrics-Specific Rules
+
+- For infants under 2 years, measurement is recumbent length (lying down), not standing height
+- Ask "Was this measured lying down or standing?" if age < 2 and not specified
+- Flag any measurement below 1st or above 99th percentile for age as unusual
+- Use WHO growth standards for children under 5, CDC charts for 5-18

--- a/deep_agent/src/agent/config/loader.py
+++ b/deep_agent/src/agent/config/loader.py
@@ -272,10 +272,12 @@ class AgentConfig:
             return {}
 
         skills = {}
-        for skill_path in skills_dir.iterdir():
-            if skill_path.is_dir() and not skill_path.name.startswith("."):
-                skills[skill_path.name] = skill_path
-                logger.debug(f"Found skill: {skill_path.name}")
+        for skill_md in skills_dir.rglob("SKILL.md"):
+            skill_dir = skill_md.parent
+            if "overlay" in skill_dir.parts:
+                continue
+            skills[skill_dir.name] = skill_dir
+            logger.debug(f"Found skill: {skill_dir.name}")
 
         logger.info(f"Scanned {len(skills)} available skill(s)")
         return skills

--- a/deep_agent/src/agent/config/resolver.py
+++ b/deep_agent/src/agent/config/resolver.py
@@ -46,6 +46,14 @@ def resolve_skill_paths(
             skill_path = available_skills[skill_name]
             skill_paths.append(str(skill_path))
             logger.debug(f"Agent '{agent_name}' resolved skill: {skill_name}")
+            overlay_dir = skill_path / "overlay"
+            if overlay_dir.is_dir():
+                for source_dir in sorted(overlay_dir.iterdir()):
+                    if source_dir.is_dir() and (source_dir / "SKILL.md").is_file():
+                        skill_paths.append(str(source_dir))
+                        logger.info(
+                            f"Agent '{agent_name}' overlay: {source_dir.name}/{skill_name}"
+                        )
         else:
             missing.append(skill_name)
 

--- a/deep_agent/src/infrastructure/overlay.py
+++ b/deep_agent/src/infrastructure/overlay.py
@@ -1,0 +1,176 @@
+"""Overlay sync — fetch skill overlays from GitLab into the config PVC.
+
+Reads overlay sources from runtime/agent.yaml and fetches each into
+the corresponding skill's overlay/<source_name>/ directory.
+
+Runnable as CLI for init containers:
+    python -m deep_agent.src.infrastructure.overlay --sync-all
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+
+def _load_overlay_config(config_dir: Path) -> list[dict]:
+    """Load overlays list from agent.yaml."""
+    agent_yaml = config_dir / "runtime" / "agent.yaml"
+    if not agent_yaml.is_file():
+        return []
+    raw = yaml.safe_load(agent_yaml.read_text()) or {}
+    middleware: dict = raw.get("middleware", {})
+    skills: dict = middleware.get("skills", {})
+    overlays: list[dict] = skills.get("overlays", [])
+    return overlays
+
+
+def _fetch_archive(source: dict, dest: Path, config_dir: Path) -> bool:
+    """Fetch overlay via GitLab archive API. Returns True on success."""
+    host = source.get("host", "")
+    project = source.get("project", "")
+    ref = source.get("ref", "main")
+    path = source.get("path", "")
+    token = os.environ.get("GITLAB_TOKEN", "")
+
+    enc_project = urllib.parse.quote(project, safe="")
+    url = f"{host}/api/v4/projects/{enc_project}/repository/archive.tar.gz?sha={ref}"
+    if path:
+        url += f"&path={urllib.parse.quote(path, safe='')}"
+
+    req = urllib.request.Request(url)
+    if token:
+        req.add_header("PRIVATE-TOKEN", token)
+
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            if resp.status != 200:
+                return False
+            with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp:
+                shutil.copyfileobj(resp, tmp)
+                tmp_path = tmp.name
+    except Exception:
+        return False
+
+    try:
+        with tempfile.TemporaryDirectory() as extract_dir:
+            with tarfile.open(tmp_path, "r:gz") as tar:
+                tar.extractall(extract_dir, filter="data")
+            _distribute(Path(extract_dir), dest, config_dir)
+    finally:
+        os.unlink(tmp_path)
+    return True
+
+
+def _fetch_sparse_clone(source: dict, dest: Path, config_dir: Path) -> bool:
+    """Fallback: sparse clone from GitLab."""
+    host = source.get("host", "")
+    project = source.get("project", "")
+    ref = source.get("ref", "main")
+    path = source.get("path", "")
+    token = os.environ.get("GITLAB_TOKEN", "")
+
+    host_only = host.replace("https://", "").replace("http://", "")
+    if token:
+        clone_url = f"https://oauth2:{token}@{host_only}/{project}.git"
+    else:
+        clone_url = f"https://{host_only}/{project}.git"
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        try:
+            env = {**os.environ, "GIT_TERMINAL_PROMPT": "0"}
+            subprocess.run(
+                [
+                    "git",
+                    "clone",
+                    "--depth",
+                    "1",
+                    "--filter=blob:none",
+                    "--sparse",
+                    "--branch",
+                    ref,
+                    clone_url,
+                    tmp_dir + "/repo",
+                ],
+                check=True,
+                capture_output=True,
+                env=env,
+            )
+            if path:
+                subprocess.run(
+                    ["git", "-C", tmp_dir + "/repo", "sparse-checkout", "set", path],
+                    check=True,
+                    capture_output=True,
+                    env=env,
+                )
+            src = Path(tmp_dir) / "repo" / path if path else Path(tmp_dir) / "repo"
+            _distribute(src, dest, config_dir)
+            return True
+        except subprocess.CalledProcessError:
+            return False
+
+
+def _distribute(extracted: Path, source_dest: Path, config_dir: Path) -> None:
+    """Distribute fetched overlay files into skill/overlay/<source>/ dirs."""
+    skills_dir = config_dir / "skills"
+    for skill_md in extracted.rglob("SKILL.md"):
+        skill_dir_name = skill_md.parent.name
+        target_skill = _find_skill_dir(skills_dir, skill_dir_name)
+        if target_skill:
+            overlay_dest = target_skill / "overlay" / source_dest.name
+            overlay_dest.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(skill_md.parent, overlay_dest, dirs_exist_ok=True)
+
+
+def _find_skill_dir(skills_dir: Path, skill_name: str) -> Path | None:
+    """Find a base skill directory by name (recursive)."""
+    for candidate in skills_dir.rglob("SKILL.md"):
+        if "overlay" not in candidate.parts and candidate.parent.name == skill_name:
+            return candidate.parent
+    return None
+
+
+def sync_all(config_dir: Path | None = None) -> None:
+    """Sync all configured overlay sources."""
+    if config_dir is None:
+        config_dir = Path(__file__).parent.parent.parent.parent / "config" / "agent"
+
+    overlays = _load_overlay_config(config_dir)
+    if not overlays:
+        print("No overlays configured — nothing to sync")
+        return
+
+    for source in sorted(overlays, key=lambda s: s.get("priority", 99)):
+        name = source.get("name", "unnamed")
+        dest = Path(name)
+        print(f"Syncing overlay '{name}' (priority={source.get('priority', 99)})...")
+
+        if _fetch_archive(source, dest, config_dir):
+            print(f"  ✓ '{name}' synced via archive API")
+        elif _fetch_sparse_clone(source, dest, config_dir):
+            print(f"  ✓ '{name}' synced via sparse clone fallback")
+        else:
+            print(
+                f"  ✗ '{name}' FAILED — check GITLAB_TOKEN and network", file=sys.stderr
+            )
+
+
+if __name__ == "__main__":
+    if "--sync-all" in sys.argv:
+        config_path = None
+        if "--config-dir" in sys.argv:
+            idx = sys.argv.index("--config-dir")
+            config_path = Path(sys.argv[idx + 1])
+        sync_all(config_path)
+    else:
+        print("Usage: python -m deep_agent.src.infrastructure.overlay --sync-all")
+        sys.exit(1)

--- a/deployment/base/agent-config-pvc.yaml
+++ b/deployment/base/agent-config-pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: agent-config
+  labels:
+    app: agent
+    component: config
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi

--- a/deployment/base/kustomization.yaml
+++ b/deployment/base/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - redis-deployment.yaml
   - redis-pvc.yaml
   - redis-service.yaml
+  - agent-config-pvc.yaml
   - configmap.yaml
   - secret.yaml
 

--- a/deployment/overlays/openshift/deployment.yaml
+++ b/deployment/overlays/openshift/deployment.yaml
@@ -24,6 +24,30 @@ spec:
     spec:
       serviceAccountName: agent
       terminationGracePeriodSeconds: 60
+      volumes:
+        - name: agent-config
+          persistentVolumeClaim:
+            claimName: agent-config
+      initContainers:
+        - name: overlay-sync
+          image: agent:latest
+          command: ["python", "-m", "deep_agent.src.infrastructure.overlay", "--sync-all"]
+          volumeMounts:
+            - name: agent-config
+              mountPath: "/app/config/agent"
+          env:
+            - name: GITLAB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: agent-secrets
+                  key: GITLAB_TOKEN
+                  optional: true
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
       containers:
         - name: agent
           image: agent:latest
@@ -174,6 +198,9 @@ spec:
                 configMapKeyRef:
                   name: agent-config
                   key: REQUEST_LOG_BODY_MAX_SIZE
+          volumeMounts:
+            - name: agent-config
+              mountPath: "/app/config/agent"
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## What

Adds the ability for template-agent to pull skill overlays from a remote GitLab repo at pod startup. Overlays get layered on top of base skills so teams can ship product-specific extensions without forking the agent.

## Why

Right now if you want to customize a skill per product/team, you either fork the agent or maintain a separate config branch. This lets you point at a remote repo and have the agent pull just the overlay files it needs. Think of it like Kustomize but for skills.

## How it works

1. You define overlay sources in `agent.yaml` (host, project, path, priority)
2. An init container fetches each overlay into `<skill>/overlay/<source_name>/`
3. At runtime the resolver reads overlays in priority order after the base skill
4. The agent sees layered context: base > overlay 1 > overlay 2

## Changes

- New `overlay.py` that fetches overlays via GitLab archive API (falls back to sparse clone)
- Modified `resolver.py` to append overlay paths after base skill
- Modified `loader.py` for recursive skill scan, skips `overlay/` dirs
- Updated `agent.yaml` with `overlays:` config under `middleware.skills`
- New PVC (`ReadWriteMany`) + init container in deployment manifests

## Testing

Still needs:
- Unit tests for config parsing and file distribution
- Integration test with init container on OpenShift
- Verify priority ordering works as expected