### PR TITLE
fix(agent): expose MCP tools when servers are declared without explicit tool list

### DIFF
--- a/deep_agent/aegra/graph.py
+++ b/deep_agent/aegra/graph.py
@@ -181,12 +181,16 @@ async def agent(runtime: ServerRuntime) -> Any:
     register_profiles_from_config(providers_config)
     model = resolve_model_from_config(model_name, providers_config)
 
-    mcp_tools = await get_mcp_tools(sso_token=sso_token)
+    mcp_tools = await get_mcp_tools(
+        sso_token=sso_token,
+        server_names=mcp_server_names or None,
+    )
     tools = agent_config.resolve_tools(tool_names, mcp_tools, agent_name=agent_name)
     if not tools and not tool_names and mcp_server_names and mcp_tools:
         logger.info(
-            "Agent '%s' declared MCP servers but no explicit tools; exposing all %d MCP tool(s)",
+            "Agent '%s' declared MCP servers %s but no explicit tools; exposing all %d MCP tool(s)",
             agent_name,
+            mcp_server_names,
             len(mcp_tools),
         )
         tools = mcp_tools

--- a/deep_agent/aegra/graph.py
+++ b/deep_agent/aegra/graph.py
@@ -121,6 +121,7 @@ async def agent(runtime: ServerRuntime) -> Any:
     system_prompt = orchestrator_cfg.get("body", "")
     skill_paths = orchestrator_cfg.get("skill_paths", [])
     tool_names = orchestrator_cfg.get("tools", [])
+    mcp_server_names = orchestrator_cfg.get("mcps", [])
 
     user_identity = getattr(user, "identity", None) if user else None
     if user_identity:
@@ -182,6 +183,13 @@ async def agent(runtime: ServerRuntime) -> Any:
 
     mcp_tools = await get_mcp_tools(sso_token=sso_token)
     tools = agent_config.resolve_tools(tool_names, mcp_tools, agent_name=agent_name)
+    if not tools and mcp_server_names and mcp_tools:
+        logger.info(
+            "Agent '%s' declared MCP servers but no explicit tools; exposing all %d MCP tool(s)",
+            agent_name,
+            len(mcp_tools),
+        )
+        tools = mcp_tools
 
     cache_key = _graph_fingerprint(
         model_name,

--- a/deep_agent/aegra/graph.py
+++ b/deep_agent/aegra/graph.py
@@ -183,7 +183,7 @@ async def agent(runtime: ServerRuntime) -> Any:
 
     mcp_tools = await get_mcp_tools(sso_token=sso_token)
     tools = agent_config.resolve_tools(tool_names, mcp_tools, agent_name=agent_name)
-    if not tools and mcp_server_names and mcp_tools:
+    if not tools and not tool_names and mcp_server_names and mcp_tools:
         logger.info(
             "Agent '%s' declared MCP servers but no explicit tools; exposing all %d MCP tool(s)",
             agent_name,

--- a/deep_agent/aegra/mcp.py
+++ b/deep_agent/aegra/mcp.py
@@ -247,8 +247,26 @@ def _is_connection_error(exc: BaseException) -> bool:
     return False
 
 
+def _filter_by_names(
+    enabled: dict[str, dict[str, Any]],
+    server_names: list[str] | None,
+) -> dict[str, dict[str, Any]]:
+    """Restrict *enabled* servers to only those declared in *server_names*."""
+    if not server_names:
+        return enabled
+    requested = set(server_names)
+    missing = requested - set(enabled)
+    if missing:
+        logger.warning(
+            "Declared MCP server(s) not found or not enabled: %s",
+            ", ".join(sorted(missing)),
+        )
+    return {k: v for k, v in enabled.items() if k in requested}
+
+
 async def get_mcp_tools(
     sso_token: str | None = None,
+    server_names: list[str] | None = None,
 ) -> list[Any]:
     """Connect to MCP server(s) and retrieve available tools.
 
@@ -259,6 +277,10 @@ async def get_mcp_tools(
     Loads server definitions from ``config/mcp.json``, connects to
     each enabled server in parallel, and returns a deduplicated flat list.
 
+    When ``server_names`` is provided, only the servers whose names match
+    are connected to, preventing unintended tool exposure from globally
+    enabled servers that the agent did not declare.
+
     The ``sso_token`` should already be **refreshed** by the caller via
     ``refresh_access_token()`` before calling this function.
 
@@ -267,13 +289,20 @@ async def get_mcp_tools(
 
     Args:
         sso_token: Optional SSO token for authentication (pre-refreshed).
+        server_names: Optional list of MCP server names to connect to.
+            When provided, only these servers are used (must also be
+            enabled in mcp.json). When ``None``, all enabled servers
+            are connected.
 
     Returns:
         List of available MCP tools (empty list if all connections fail).
     """
     global _cached_tools, _cached_tools_ts  # noqa: PLW0603
 
-    if _cached_tools and (time.time() - _cached_tools_ts) < _MCP_TOOL_CACHE_TTL:
+    if (
+        _cached_tools
+        and (time.time() - _cached_tools_ts) < _MCP_TOOL_CACHE_TTL
+    ):
         logger.info(
             "MCP tool cache hit (%d tools, %.0fs old)",
             len(_cached_tools),
@@ -285,6 +314,8 @@ async def get_mcp_tools(
     enabled: dict[str, dict[str, Any]] = {
         k: v for k, v in servers.items() if v.get("enabled", False)
     }
+
+    enabled = _filter_by_names(enabled, server_names)
 
     if not enabled:
         logger.warning("No MCP servers enabled")

--- a/deep_agent/src/agent/config/loader.py
+++ b/deep_agent/src/agent/config/loader.py
@@ -170,6 +170,25 @@ class AgentConfig:
         """Get the config base directory path."""
         return self._base_dir
 
+    @staticmethod
+    def _validate_mcps_field(mcps: Any, agent_name: str) -> None:
+        """Validate the ``mcps`` frontmatter field is a list of strings.
+
+        Args:
+            mcps: The raw value from frontmatter.
+            agent_name: Agent name for error messages.
+
+        Raises:
+            AppException: If ``mcps`` is not a list of strings.
+        """
+        if not isinstance(mcps, list) or not all(
+            isinstance(s, str) for s in mcps
+        ):
+            raise AppException(
+                f"Agent '{agent_name}': 'mcps' must be a list of strings",
+                ErrorCodes.CONFIGURATION_VALIDATION_ERROR,
+            )
+
     def _load_orchestrator(self) -> dict[str, Any]:
         """Load orchestrator configuration at initialization.
 
@@ -184,6 +203,11 @@ class AgentConfig:
             config = parse_frontmatter(orchestrator_path)
             if "body" in config:
                 config["body"] = inject_runtime_values(config["body"])
+
+            if "mcps" in config:
+                self._validate_mcps_field(
+                    config["mcps"], config.get("name", "orchestrator")
+                )
 
             # Resolve skill names to paths eagerly
             skill_names = config.get("skills", [])
@@ -225,6 +249,9 @@ class AgentConfig:
                     config["body"] = inject_runtime_values(config["body"])
 
                 name = config.get("name", agent_file.stem)
+
+                if "mcps" in config:
+                    self._validate_mcps_field(config["mcps"], name)
 
                 # Resolve skill names to paths eagerly
                 skill_names = config.get("skills", [])

--- a/tests/unit/aegra/test_graph.py
+++ b/tests/unit/aegra/test_graph.py
@@ -10,6 +10,13 @@ if "langgraph_sdk.runtime" not in sys.modules:
     sys.modules["langgraph_sdk.runtime"] = _runtime_mock
 
 
+def _reset_graph_state() -> None:
+    from deep_agent.aegra import graph
+
+    graph._graph_cache.clear()
+    graph._graph_cache_ts.clear()
+
+
 class TestAgentFactory:
     """Tests for the agent() graph factory function.
 
@@ -29,21 +36,30 @@ class TestAgentFactory:
             "tools": [],
         }
         mock_config.resolve_tools.return_value = []
+        mock_config.resolve_agent_middleware.return_value = MagicMock(
+            skills_enabled=True
+        )
 
         mock_runtime = MagicMock()
         mock_runtime.user = None
 
+        _reset_graph_state()
+
         with (
             patch(
-                "deep_agent.src.agent.config.loader.agent_config",
+                "deep_agent.src.agent.config.agent_config",
                 mock_config,
             ),
             patch(
-                "deep_agent.src.agent.llm.create_model",
+                "deep_agent.src.infrastructure.providers.register_profiles_from_config",
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.src.infrastructure.providers.resolve_model_from_config",
                 return_value=MagicMock(),
             ),
             patch(
-                "deep_agent.src.infrastructure.mcp.get_mcp_tools",
+                "deep_agent.aegra.mcp.get_mcp_tools",
                 new_callable=AsyncMock,
                 return_value=[],
             ),
@@ -52,9 +68,22 @@ class TestAgentFactory:
                 return_value=None,
             ),
             patch(
-                "deep_agent.src.infrastructure.backend.get_backend",
+                "deep_agent.src.infrastructure.backend.get_configured_backend",
                 return_value=MagicMock(),
             ),
+            patch(
+                "deep_agent.src.infrastructure.async_tasks.build_async_middleware",
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.src.infrastructure.middleware.build_middleware_list",
+                return_value=[],
+            ),
+            patch(
+                "deep_agent.src.infrastructure.middleware.resolve_memory_param",
+                return_value=None,
+            ),
+            patch("deep_agent.aegra.graph._ensure_startup", new_callable=AsyncMock),
             patch("deepagents.create_deep_agent", return_value=mock_compiled),
         ):
             from deep_agent.aegra.graph import agent
@@ -74,6 +103,9 @@ class TestAgentFactory:
             "tools": [],
         }
         mock_config.resolve_tools.return_value = []
+        mock_config.resolve_agent_middleware.return_value = MagicMock(
+            skills_enabled=True
+        )
 
         mock_user = MagicMock()
         mock_user.access_token = "test_access_token"
@@ -83,22 +115,28 @@ class TestAgentFactory:
         mock_runtime = MagicMock()
         mock_runtime.user = mock_user
 
+        _reset_graph_state()
+
         with (
             patch(
-                "deep_agent.src.agent.config.loader.agent_config",
+                "deep_agent.src.agent.config.agent_config",
                 mock_config,
             ),
             patch(
-                "deep_agent.src.agent.llm.create_model",
+                "deep_agent.src.infrastructure.providers.register_profiles_from_config",
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.src.infrastructure.providers.resolve_model_from_config",
                 return_value=MagicMock(),
             ),
             patch(
-                "deep_agent.src.infrastructure.mcp.get_mcp_tools",
+                "deep_agent.aegra.mcp.get_mcp_tools",
                 new_callable=AsyncMock,
                 return_value=[],
             ),
             patch(
-                "deep_agent.src.infrastructure.mcp.refresh_access_token",
+                "deep_agent.aegra.mcp.refresh_access_token",
                 new_callable=AsyncMock,
                 return_value="refreshed_token",
             ) as mock_refresh,
@@ -107,9 +145,22 @@ class TestAgentFactory:
                 return_value=None,
             ),
             patch(
-                "deep_agent.src.infrastructure.backend.get_backend",
+                "deep_agent.src.infrastructure.backend.get_configured_backend",
                 return_value=MagicMock(),
             ),
+            patch(
+                "deep_agent.src.infrastructure.async_tasks.build_async_middleware",
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.src.infrastructure.middleware.build_middleware_list",
+                return_value=[],
+            ),
+            patch(
+                "deep_agent.src.infrastructure.middleware.resolve_memory_param",
+                return_value=None,
+            ),
+            patch("deep_agent.aegra.graph._ensure_startup", new_callable=AsyncMock),
             patch("deepagents.create_deep_agent", return_value=mock_compiled),
         ):
             from deep_agent.aegra.graph import agent
@@ -119,3 +170,76 @@ class TestAgentFactory:
             mock_refresh.assert_awaited_once_with(
                 "test_access_token", "test_refresh_token"
             )
+
+    @pytest.mark.asyncio
+    async def test_exposes_all_mcp_tools_when_mcps_declared_without_tool_list(self):
+        mock_compiled = MagicMock()
+        mock_config = MagicMock()
+        mock_config.get_orchestrator_config.return_value = {
+            "name": "orchestrator",
+            "model": "gemini-2.5-flash",
+            "body": "test prompt",
+            "skill_paths": [],
+            "tools": [],
+            "mcps": ["dataverse-mcp-prod1"],
+        }
+        mock_config.resolve_tools.return_value = []
+        mock_config.resolve_agent_middleware.return_value = MagicMock(
+            skills_enabled=True
+        )
+
+        mock_tool = MagicMock()
+        mock_tool.name = "identify_dataproducts"
+
+        mock_runtime = MagicMock()
+        mock_runtime.user = None
+
+        _reset_graph_state()
+
+        with (
+            patch(
+                "deep_agent.src.agent.config.agent_config",
+                mock_config,
+            ),
+            patch(
+                "deep_agent.src.infrastructure.providers.register_profiles_from_config",
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.src.infrastructure.providers.resolve_model_from_config",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.aegra.mcp.get_mcp_tools",
+                new_callable=AsyncMock,
+                return_value=[mock_tool],
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.load_subagents",
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.src.infrastructure.backend.get_configured_backend",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.async_tasks.build_async_middleware",
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.src.infrastructure.middleware.build_middleware_list",
+                return_value=[],
+            ),
+            patch(
+                "deep_agent.src.infrastructure.middleware.resolve_memory_param",
+                return_value=None,
+            ),
+            patch("deep_agent.aegra.graph._ensure_startup", new_callable=AsyncMock),
+            patch("deepagents.create_deep_agent", return_value=mock_compiled) as mock_create,
+        ):
+            from deep_agent.aegra.graph import agent
+
+            result = await agent(mock_runtime)
+
+        assert result is mock_compiled
+        assert mock_create.call_args.kwargs["tools"] == [mock_tool]

--- a/tests/unit/aegra/test_graph.py
+++ b/tests/unit/aegra/test_graph.py
@@ -213,7 +213,7 @@ class TestAgentFactory:
                 "deep_agent.aegra.mcp.get_mcp_tools",
                 new_callable=AsyncMock,
                 return_value=[mock_tool],
-            ),
+            ) as mock_get_mcp,
             patch(
                 "deep_agent.src.infrastructure.subagents.load_subagents",
                 return_value=None,
@@ -243,3 +243,6 @@ class TestAgentFactory:
 
         assert result is mock_compiled
         assert mock_create.call_args.kwargs["tools"] == [mock_tool]
+        mock_get_mcp.assert_awaited_once_with(
+            sso_token=None, server_names=["dataverse-mcp-prod1"]
+        )

--- a/tests/unit/agent/config/test_config.py
+++ b/tests/unit/agent/config/test_config.py
@@ -1,6 +1,9 @@
 """Unit tests for agent_config skill path resolution."""
 
+import pytest
+
 from deep_agent.src.agent.config import AgentConfig
+from deep_agent.src.exceptions import AppException
 
 
 class TestAgentConfigSkillResolution:
@@ -102,3 +105,77 @@ Test orchestrator prompt.
         assert len(skill_paths) == 0
 
         assert "unknown skills" in caplog.text.lower()
+
+
+class TestMcpsValidation:
+    """Test mcps field validation for orchestrator and subagents."""
+
+    def setup_method(self):
+        AgentConfig._instance = None
+
+    def test_orchestrator_valid_mcps(self, tmp_path):
+        """Valid mcps list of strings loads without error."""
+        config_dir = tmp_path / "agent_config"
+        config_dir.mkdir()
+        (config_dir / "skills").mkdir()
+
+        (config_dir / "PROMPT.md").write_text("""---
+name: orch
+model: gemini-2.5-flash
+mcps:
+  - web-search
+  - dataverse-mcp
+---
+Orchestrator.
+""")
+
+        cfg = AgentConfig(config_dir)
+        orch = cfg.get_orchestrator_config()
+        assert orch["mcps"] == ["web-search", "dataverse-mcp"]
+
+    def test_orchestrator_invalid_mcps_raises(self, tmp_path):
+        """Non-list mcps raises AppException."""
+        config_dir = tmp_path / "agent_config"
+        config_dir.mkdir()
+        (config_dir / "skills").mkdir()
+
+        (config_dir / "PROMPT.md").write_text("""---
+name: orch
+model: gemini-2.5-flash
+mcps: "not-a-list"
+---
+Orchestrator.
+""")
+
+        with pytest.raises(AppException, match="must be a list of strings"):
+            cfg = AgentConfig(config_dir)
+            cfg.get_orchestrator_config()
+
+    def test_subagent_invalid_mcps_is_skipped(self, tmp_path, caplog):
+        """Subagent with non-string mcps entries is skipped and logged."""
+        config_dir = tmp_path / "agent_config"
+        config_dir.mkdir()
+        (config_dir / "skills").mkdir()
+
+        (config_dir / "PROMPT.md").write_text("""---
+name: orch
+model: gemini-2.5-flash
+---
+Orchestrator.
+""")
+
+        sub_dir = config_dir / "subagents"
+        sub_dir.mkdir()
+        (sub_dir / "bad.md").write_text("""---
+name: bad-agent
+model: gemini-2.5-flash
+mcps:
+  - 123
+---
+Bad agent.
+""")
+
+        cfg = AgentConfig(config_dir)
+        subs = cfg.get_all_subagent_configs()
+        assert "bad-agent" not in subs
+        assert "must be a list of strings" in caplog.text

--- a/tests/unit/infrastructure/test_mcp.py
+++ b/tests/unit/infrastructure/test_mcp.py
@@ -29,7 +29,7 @@ class TestGetServerConfigs:
         }
 
         with patch(
-            "deep_agent.src.infrastructure.mcp.agent_config.get_mcp_servers"
+            "deep_agent.aegra.mcp.agent_config.get_mcp_servers"
         ) as mock_get_servers:
             mock_get_servers.return_value = mock_servers
 
@@ -41,7 +41,7 @@ class TestGetServerConfigs:
     def test_returns_empty_dict_when_no_servers(self):
         """Test returns empty dict when no MCP servers configured."""
         with patch(
-            "deep_agent.src.infrastructure.mcp.agent_config.get_mcp_servers"
+            "deep_agent.aegra.mcp.agent_config.get_mcp_servers"
         ) as mock_get_servers:
             mock_get_servers.return_value = {}
 
@@ -136,7 +136,7 @@ class TestConnectSingleServer:
         config = {"url": "http://localhost:8000/mcp/", "transport": "http"}
 
         with patch(
-            "deep_agent.src.infrastructure.mcp.MultiServerMCPClient",
+            "deep_agent.aegra.mcp.MultiServerMCPClient",
             return_value=mock_client,
         ):
             tools = await _connect_single_server("test_server", config, timeout=5)
@@ -155,7 +155,7 @@ class TestConnectSingleServer:
         config = {"url": "http://localhost:8000/mcp/", "transport": "http"}
 
         with patch(
-            "deep_agent.src.infrastructure.mcp.MultiServerMCPClient",
+            "deep_agent.aegra.mcp.MultiServerMCPClient",
             return_value=mock_client,
         ):
             tools = await _connect_single_server("slow_server", config, timeout=1)
@@ -173,7 +173,7 @@ class TestConnectSingleServer:
         config = {"url": "http://unreachable:8000/mcp/", "transport": "http"}
 
         with patch(
-            "deep_agent.src.infrastructure.mcp.MultiServerMCPClient",
+            "deep_agent.aegra.mcp.MultiServerMCPClient",
             return_value=mock_client,
         ):
             tools = await _connect_single_server("broken_server", config, timeout=5)
@@ -189,12 +189,20 @@ class TestConnectSingleServer:
         config = {"url": "http://localhost:8000/mcp/", "transport": "http"}
 
         with patch(
-            "deep_agent.src.infrastructure.mcp.MultiServerMCPClient",
+            "deep_agent.aegra.mcp.MultiServerMCPClient",
             return_value=mock_client,
         ):
             tools = await _connect_single_server("faulty_server", config, timeout=5)
 
             assert tools == []
+
+
+def _reset_mcp_cache() -> None:
+    """Clear MCP tool cache between tests."""
+    from deep_agent.aegra import mcp
+
+    mcp._cached_tools = []
+    mcp._cached_tools_ts = 0.0
 
 
 class TestGetMCPTools:
@@ -203,6 +211,7 @@ class TestGetMCPTools:
     @pytest.mark.asyncio
     async def test_successful_connection_with_tools(self):
         """Test successful MCP connection with tools."""
+        _reset_mcp_cache()
         mock_servers = {
             "test_server": {
                 "url": "http://localhost:8000/mcp/",
@@ -219,10 +228,10 @@ class TestGetMCPTools:
 
         with (
             patch(
-                "deep_agent.src.infrastructure.mcp._get_server_configs"
+                "deep_agent.aegra.mcp._get_server_configs"
             ) as mock_get_configs,
             patch(
-                "deep_agent.src.infrastructure.mcp._connect_single_server"
+                "deep_agent.aegra.mcp._connect_single_server"
             ) as mock_connect,
         ):
             mock_get_configs.return_value = mock_servers
@@ -237,6 +246,7 @@ class TestGetMCPTools:
     @pytest.mark.asyncio
     async def test_deduplicates_tools_from_multiple_servers(self):
         """Test that duplicate tool names are deduplicated (first wins)."""
+        _reset_mcp_cache()
         mock_servers = {
             "server-a": {
                 "url": "http://a/mcp/",
@@ -264,10 +274,10 @@ class TestGetMCPTools:
 
         with (
             patch(
-                "deep_agent.src.infrastructure.mcp._get_server_configs"
+                "deep_agent.aegra.mcp._get_server_configs"
             ) as mock_get_configs,
             patch(
-                "deep_agent.src.infrastructure.mcp._connect_single_server"
+                "deep_agent.aegra.mcp._connect_single_server"
             ) as mock_connect,
         ):
             mock_get_configs.return_value = mock_servers
@@ -285,6 +295,7 @@ class TestGetMCPTools:
     @pytest.mark.asyncio
     async def test_no_enabled_servers_returns_empty_list(self):
         """Test that no enabled servers returns empty list."""
+        _reset_mcp_cache()
         mock_servers = {
             "disabled": {
                 "url": "http://localhost/mcp/",
@@ -293,7 +304,7 @@ class TestGetMCPTools:
         }
 
         with patch(
-            "deep_agent.src.infrastructure.mcp._get_server_configs"
+            "deep_agent.aegra.mcp._get_server_configs"
         ) as mock_get_configs:
             mock_get_configs.return_value = mock_servers
 
@@ -304,8 +315,9 @@ class TestGetMCPTools:
     @pytest.mark.asyncio
     async def test_no_servers_configured_returns_empty_list(self):
         """Test that no MCP servers configured returns empty list."""
+        _reset_mcp_cache()
         with patch(
-            "deep_agent.src.infrastructure.mcp._get_server_configs"
+            "deep_agent.aegra.mcp._get_server_configs"
         ) as mock_get_configs:
             mock_get_configs.return_value = {}
 
@@ -316,6 +328,7 @@ class TestGetMCPTools:
     @pytest.mark.asyncio
     async def test_all_connections_fail_returns_empty_list(self):
         """Test that all connection failures return empty list gracefully."""
+        _reset_mcp_cache()
         mock_servers = {
             "server-a": {
                 "url": "http://a/mcp/",
@@ -331,10 +344,10 @@ class TestGetMCPTools:
 
         with (
             patch(
-                "deep_agent.src.infrastructure.mcp._get_server_configs"
+                "deep_agent.aegra.mcp._get_server_configs"
             ) as mock_get_configs,
             patch(
-                "deep_agent.src.infrastructure.mcp._connect_single_server"
+                "deep_agent.aegra.mcp._connect_single_server"
             ) as mock_connect,
         ):
             mock_get_configs.return_value = mock_servers
@@ -347,6 +360,7 @@ class TestGetMCPTools:
     @pytest.mark.asyncio
     async def test_sso_token_passed_to_build_config(self):
         """Test that SSO token is passed through to _build_server_config."""
+        _reset_mcp_cache()
         mock_servers = {
             "test": {
                 "url": "http://localhost/mcp/",
@@ -361,13 +375,13 @@ class TestGetMCPTools:
 
         with (
             patch(
-                "deep_agent.src.infrastructure.mcp._get_server_configs"
+                "deep_agent.aegra.mcp._get_server_configs"
             ) as mock_get_configs,
             patch(
-                "deep_agent.src.infrastructure.mcp._build_server_config"
+                "deep_agent.aegra.mcp._build_server_config"
             ) as mock_build_config,
             patch(
-                "deep_agent.src.infrastructure.mcp._connect_single_server"
+                "deep_agent.aegra.mcp._connect_single_server"
             ) as mock_connect,
         ):
             mock_get_configs.return_value = mock_servers
@@ -384,6 +398,7 @@ class TestGetMCPTools:
     @pytest.mark.asyncio
     async def test_parallel_connection_to_multiple_servers(self):
         """Test that multiple servers are connected in parallel."""
+        _reset_mcp_cache()
         mock_servers = {
             "server-1": {"url": "http://1/mcp/", "enabled": True, "timeout": 5},
             "server-2": {"url": "http://2/mcp/", "enabled": True, "timeout": 5},
@@ -399,10 +414,10 @@ class TestGetMCPTools:
 
         with (
             patch(
-                "deep_agent.src.infrastructure.mcp._get_server_configs"
+                "deep_agent.aegra.mcp._get_server_configs"
             ) as mock_get_configs,
             patch(
-                "deep_agent.src.infrastructure.mcp._connect_single_server"
+                "deep_agent.aegra.mcp._connect_single_server"
             ) as mock_connect,
         ):
             mock_get_configs.return_value = mock_servers
@@ -413,3 +428,32 @@ class TestGetMCPTools:
             # All three servers should be connected
             assert mock_connect.call_count == 3
             assert len(tools) == 3
+
+    @pytest.mark.asyncio
+    async def test_server_names_filters_enabled_servers(self):
+        """Test that server_names restricts which servers are connected."""
+        _reset_mcp_cache()
+        mock_servers = {
+            "wanted": {"url": "http://w/mcp/", "enabled": True, "timeout": 5},
+            "unwanted": {"url": "http://u/mcp/", "enabled": True, "timeout": 5},
+        }
+
+        tool_w = MagicMock()
+        tool_w.name = "wanted_tool"
+
+        with (
+            patch(
+                "deep_agent.aegra.mcp._get_server_configs"
+            ) as mock_get_configs,
+            patch(
+                "deep_agent.aegra.mcp._connect_single_server"
+            ) as mock_connect,
+        ):
+            mock_get_configs.return_value = mock_servers
+            mock_connect.return_value = [tool_w]
+
+            tools = await get_mcp_tools(server_names=["wanted"])
+
+            mock_connect.assert_called_once()
+            assert len(tools) == 1
+            assert tools[0].name == "wanted_tool"


### PR DESCRIPTION
## Summary

- When an agent bundle declares MCP servers but no explicit orchestrator tools, register all loaded MCP tools with the agent graph.
- Ensures DataVerse-style agents (MCP-only, no hardcoded tool names) expose runtime tools as expected.
- Add unit tests for the MCP fallback behavior in `graph.py`.

## Test plan

- [ ] Deploy agent with MCP servers in bundle and empty `tools` list — agent logs show MCP tools loaded and available to the model.
- [ ] Deploy agent with explicit `tools` list — only listed tools are exposed (unchanged behavior).
- [ ] Deploy agent with no MCP and no tools — no regression.
- [ ] `pytest tests/unit/aegra/test_graph.py -q` passes.