### PR TITLE
fix: skip aegra db_manager initialization in in-memory mode

### DIFF
--- a/deep_agent/aegra/feedback.py
+++ b/deep_agent/aegra/feedback.py
@@ -35,6 +35,40 @@ from deep_agent.utils.pylogger import (
 
 logger = get_python_logger()
 
+
+def _patch_aegra_persistence_if_inmemory() -> None:
+    """Disable aegra_api database initialization when running in-memory mode.
+
+    The aegra_api lifespan unconditionally calls db_manager.initialize() which
+    opens a PostgreSQL connection pool. When deploying without a database
+    (USE_INMEMORY_SAVER=true), this causes the pod to crash. This patch
+    replaces initialize() with a no-op so the lifespan completes cleanly.
+    """
+    import os
+
+    disable_persistence = os.environ.get("AEGRA_DISABLE_PERSISTENCE", "").lower() in (
+        "true",
+        "1",
+    )
+    use_inmemory = os.environ.get("USE_INMEMORY_SAVER", "").lower() in ("true", "1")
+
+    if not (disable_persistence or use_inmemory):
+        return
+
+    try:
+        from aegra_api.core.database import db_manager
+
+        async def _noop_initialize() -> None:
+            logger.info("aegra_db_initialize_skipped_inmemory_mode")
+
+        db_manager.initialize = _noop_initialize  # type: ignore[method-assign]
+        logger.info("aegra_persistence_patched_for_inmemory_mode")
+    except ImportError:
+        pass
+
+
+_patch_aegra_persistence_if_inmemory()
+
 app = FastAPI(title="template-agent-custom")
 
 


### PR DESCRIPTION
## Summary

- Monkey-patches `aegra_api.core.database.db_manager.initialize()` to a no-op when `AEGRA_DISABLE_PERSISTENCE=true` or `USE_INMEMORY_SAVER=true` env vars are set
- Prevents `CrashLoopBackOff` on in-memory agent deployments where no PostgreSQL is available
- Works in concert with the deployer fix (MR !80) that injects these env vars

## Context

The `aegra_api` lifespan unconditionally calls `db_manager.initialize()` which opens an `AsyncConnectionPool` to PostgreSQL. When agents deploy in in-memory mode (no database provisioned), this causes the pod to crash immediately on startup.

## Test plan

- [ ] Deploy an agent with `AGENT_ENGINE_USE_INMEMORY_SAVER=true` — backend pod should start cleanly
- [ ] Verify chat functionality works with in-memory state
- [ ] Deploy an agent with a real database — verify migrations and persistence still work normally