### PR TITLE
fix: fall back to DEFAULT_MODEL when subagent and orchestrator both omit model

### DIFF
--- a/deep_agent/src/infrastructure/subagents.py
+++ b/deep_agent/src/infrastructure/subagents.py
@@ -97,7 +97,8 @@ def _inherit_from_orchestrator(
     """Fill in missing model/mcps from the parent orchestrator config.
 
     Mutates *agent_cfg* in place. Only inherits fields the subagent did not
-    explicitly set.
+    explicitly set. Falls back to settings.DEFAULT_MODEL when neither the
+    subagent nor the orchestrator provides a model.
     """
     if not agent_cfg.get("model"):
         parent_model = orchestrator_cfg.get("model", "")
@@ -108,6 +109,14 @@ def _inherit_from_orchestrator(
                 parent_model,
             )
             agent_cfg["model"] = parent_model
+        else:
+            logger.warning(
+                "Subagent '%s' has no model and orchestrator has no model — "
+                "falling back to DEFAULT_MODEL: %s",
+                name,
+                settings.DEFAULT_MODEL,
+            )
+            agent_cfg["model"] = settings.DEFAULT_MODEL
 
     if not agent_cfg.get("mcps"):
         parent_mcps = orchestrator_cfg.get("mcps", [])

--- a/deep_agent/src/settings.py
+++ b/deep_agent/src/settings.py
@@ -57,6 +57,7 @@ class Settings(BaseSettings):
     REQUEST_LOG_BODY_MAX_SIZE: int = Field(default=10240)
 
     # ── Model ─────────────────────────────────────────────────────────
+    DEFAULT_MODEL: str = Field(default="gemini-2.5-pro")
     MAX_OUTPUT_TOKENS: int = Field(default=8192)
 
     # ── Database (PostgreSQL) ─────────────────────────────────────────

--- a/tests/unit/infrastructure/test_subagents.py
+++ b/tests/unit/infrastructure/test_subagents.py
@@ -28,22 +28,82 @@ class TestLoadSubagents:
 
             assert result is None
 
-    def test_load_subagents_raises_error_when_model_missing(self):
-        """Test that load_subagents raises ValueError when model is missing."""
-        with patch(
-            "deep_agent.src.infrastructure.subagents.agent_config.get_all_subagent_configs"
-        ) as mock_get_configs:
+    def test_load_subagents_falls_back_to_default_model(self):
+        """Test that subagent with no model inherits DEFAULT_MODEL when orchestrator also lacks one."""
+        mock_model = MagicMock()
+        mock_subagent = MagicMock()
+
+        with (
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_all_subagent_configs"
+            ) as mock_get_configs,
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_orchestrator_config"
+            ) as mock_get_orch,
+            patch(
+                "deep_agent.src.infrastructure.subagents.get_or_create_model"
+            ) as mock_create_model,
+            patch("deep_agent.src.infrastructure.subagents.SubAgent") as mock_sa,
+            patch(
+                "deep_agent.src.infrastructure.subagents.settings"
+            ) as mock_settings,
+        ):
+            mock_settings.DEFAULT_MODEL = "gemini-2.5-pro"
+            mock_get_configs.return_value = {
+                "dataverseagent": {
+                    "name": "dataverseagent",
+                    "description": "Test agent",
+                    "body": "Test prompt",
+                }
+            }
+            mock_get_orch.return_value = {
+                "name": "orchestrator",
+                "body": "Orchestrator prompt",
+            }
+            mock_create_model.return_value = mock_model
+            mock_sa.return_value = mock_subagent
+
+            result = load_subagents(tools=[])
+
+            assert result == [mock_subagent]
+            mock_create_model.assert_called_once_with(model_name="gemini-2.5-pro")
+
+    def test_load_subagents_inherits_model_from_orchestrator(self):
+        """Test that subagent with no model inherits from orchestrator config."""
+        mock_model = MagicMock()
+        mock_subagent = MagicMock()
+
+        with (
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_all_subagent_configs"
+            ) as mock_get_configs,
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_orchestrator_config"
+            ) as mock_get_orch,
+            patch(
+                "deep_agent.src.infrastructure.subagents.get_or_create_model"
+            ) as mock_create_model,
+            patch("deep_agent.src.infrastructure.subagents.SubAgent") as mock_sa,
+        ):
             mock_get_configs.return_value = {
                 "analyst": {
                     "name": "analyst",
                     "description": "Test analyst",
                     "body": "Test prompt",
-                    # Missing 'model' field
                 }
             }
+            mock_get_orch.return_value = {
+                "name": "orchestrator",
+                "model": "gemini-2.5-flash",
+                "body": "Orchestrator prompt",
+            }
+            mock_create_model.return_value = mock_model
+            mock_sa.return_value = mock_subagent
 
-            with pytest.raises(SubAgentError, match="missing required 'model' field"):
-                load_subagents(tools=[])
+            result = load_subagents(tools=[])
+
+            assert result == [mock_subagent]
+            mock_create_model.assert_called_once_with(model_name="gemini-2.5-flash")
 
     def test_load_single_subagent_minimal(self):
         """Test loading a single subagent with minimal config."""


### PR DESCRIPTION
## Summary

- Adds `DEFAULT_MODEL` setting (`gemini-2.5-pro`) as a last-resort fallback when neither a subagent's frontmatter nor the orchestrator's PROMPT.md specifies a `model` field
- Updates `_inherit_from_orchestrator` to use the fallback with a warning log instead of letting `_build_default_subagent` crash with `SubAgentError`
- Fixes 500 errors in deployed agents (e.g. `dv-nirav-preprod`) where registry-published subagents omit the `model` field

## Root Cause

```
SubAgentError: Failed to build subagent 'dataverseagent': Subagent 'dataverseagent' is missing required 'model' field in frontmatter
```

The inheritance from orchestrator was added in #61, but it only helps when the orchestrator itself has a `model` field. When both are missing, the system hard-fails instead of degrading gracefully.

## Changes

| File | Change |
|------|--------|
| `deep_agent/src/settings.py` | Add `DEFAULT_MODEL` field |
| `deep_agent/src/infrastructure/subagents.py` | Fall back to `settings.DEFAULT_MODEL` in `_inherit_from_orchestrator` |
| `tests/unit/infrastructure/test_subagents.py` | Update tests for inheritance + fallback behavior |

## Test Plan

- [x] Unit test: subagent with no model + orchestrator with no model → uses DEFAULT_MODEL
- [x] Unit test: subagent with no model + orchestrator with model → inherits from orchestrator
- [ ] Deploy to preprod and verify `dv-nirav-preprod` no longer 500s on thread state