### PR TITLE
fix: per-call MCP token refresh to prevent 401 errors

### DIFF
--- a/deep_agent/aegra/graph.py
+++ b/deep_agent/aegra/graph.py
@@ -98,7 +98,7 @@ async def agent(runtime: ServerRuntime) -> Any:
 
     from deepagents import create_deep_agent
 
-    from deep_agent.aegra.mcp import get_mcp_tools, refresh_access_token
+    from deep_agent.aegra.mcp import get_mcp_tools, refresh_access_token, set_mcp_auth_context
     from deep_agent.src.agent.config import agent_config
     from deep_agent.src.infrastructure.async_tasks import build_async_middleware
     from deep_agent.src.infrastructure.backend import get_configured_backend
@@ -114,6 +114,8 @@ async def agent(runtime: ServerRuntime) -> Any:
 
     if sso_token:
         sso_token = await refresh_access_token(sso_token, refresh_token)
+
+    set_mcp_auth_context(sso_token, refresh_token)
 
     orchestrator_cfg = agent_config.get_orchestrator_config()
     agent_name = orchestrator_cfg.get("name", "orchestrator")

--- a/deep_agent/aegra/mcp.py
+++ b/deep_agent/aegra/mcp.py
@@ -9,6 +9,13 @@ Why this exists:
     that agents can use. This module bridges the gap between our agent system
     and external MCP-compatible services.
 
+Architecture (auth-at-call-time):
+    Tool discovery happens once (cached for MCP_TOOL_CACHE_TTL seconds) and
+    returns lightweight wrapper tools. When the LLM actually invokes a tool,
+    the wrapper refreshes the SSO token and opens a fresh authenticated session
+    to the MCP server. This prevents 401 errors from expired tokens that were
+    baked in at discovery time.
+
 Functions:
     refresh_access_token: Exchange a refresh token for a fresh access token
     get_mcp_tools: Connect to all MCP servers and retrieve their tools
@@ -16,12 +23,14 @@ Functions:
 
 import asyncio
 import base64
+import contextvars
 import json
 import os
 import time
 from typing import Any
 
 import httpx
+from langchain_core.tools import StructuredTool
 from langchain_mcp_adapters.client import MultiServerMCPClient
 
 from deep_agent.src.agent.config import agent_config
@@ -38,6 +47,13 @@ _mcp_breaker: CircuitBreaker | None = None
 _MCP_TOOL_CACHE_TTL: float = float(agent_config.get_cache_config().mcp.ttl)
 _cached_tools: list[Any] = []
 _cached_tools_ts: float = 0.0
+
+_current_access_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "_current_access_token", default=None
+)
+_current_refresh_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "_current_refresh_token", default=None
+)
 
 
 def _get_mcp_breaker() -> CircuitBreaker:
@@ -247,6 +263,86 @@ def _is_connection_error(exc: BaseException) -> bool:
     return False
 
 
+def set_mcp_auth_context(
+    access_token: str | None,
+    refresh_token: str | None,
+) -> None:
+    """Store the current request's tokens in context vars for tool-call-time auth.
+
+    Must be called at the start of each request (e.g. in the graph factory)
+    BEFORE the LLM may invoke any MCP tools.  The wrapper tools read these
+    context vars at invocation time to obtain a fresh bearer token.
+
+    Args:
+        access_token: The user's current JWT access token.
+        refresh_token: The user's OIDC refresh token.
+    """
+    _current_access_token.set(access_token)
+    _current_refresh_token.set(refresh_token)
+
+
+def _make_auth_refreshing_tool(
+    original_tool: Any,
+    server_name: str,
+    server_entry: dict[str, Any],
+) -> StructuredTool:
+    """Wrap an MCP tool so it injects a fresh token at each invocation.
+
+    The returned tool preserves the original's name, description, and
+    args_schema but replaces the execution logic: on each call it reads
+    the current request's tokens from context vars, refreshes if needed,
+    opens a fresh authenticated session to the MCP server, and executes
+    the tool call with valid credentials.
+
+    Args:
+        original_tool: The tool object returned by MultiServerMCPClient.
+        server_name: Name of the MCP server this tool belongs to.
+        server_entry: Raw server config entry (url, auth, transport, etc).
+
+    Returns:
+        A StructuredTool with identical schema but fresh-auth execution.
+    """
+
+    async def _invoke_with_fresh_auth(**kwargs: Any) -> Any:
+        access = _current_access_token.get()
+        refresh = _current_refresh_token.get()
+
+        if access:
+            access = await refresh_access_token(access, refresh)
+            _current_access_token.set(access)
+
+        config = _build_server_config(server_entry, access)
+        timeout = server_entry.get("timeout", 30)
+
+        try:
+            async with asyncio.timeout(timeout):
+                client = MultiServerMCPClient({server_name: config})
+                tools = await client.get_tools()
+        except Exception as exc:
+            logger.error(
+                "[%s] tool '%s' failed to reconnect: %s",
+                server_name,
+                original_tool.name,
+                exc,
+            )
+            raise
+
+        target = next((t for t in tools if t.name == original_tool.name), None)
+        if target is None:
+            raise RuntimeError(
+                f"Tool '{original_tool.name}' not found on server '{server_name}' "
+                "after reconnection"
+            )
+        return await target.ainvoke(kwargs)
+
+    return StructuredTool.from_function(
+        coroutine=_invoke_with_fresh_auth,
+        name=original_tool.name,
+        description=original_tool.description or "",
+        args_schema=getattr(original_tool, "args_schema", None),
+    )
+
+
 def _filter_by_names(
     enabled: dict[str, dict[str, Any]],
     server_names: list[str] | None,
@@ -271,8 +367,10 @@ async def get_mcp_tools(
     """Connect to MCP server(s) and retrieve available tools.
 
     Results are cached for ``MCP_TOOL_CACHE_TTL`` seconds (default 300).
-    Subsequent calls within the TTL window return the cached tool list
-    without reconnecting, eliminating ~3-4s of overhead per request.
+    Cached tool objects are auth-refreshing wrappers: they do NOT embed
+    a static token.  At invocation time each wrapper reads the current
+    request's tokens from context vars (set via ``set_mcp_auth_context``)
+    and opens a fresh authenticated session.
 
     Loads server definitions from ``config/mcp.json``, connects to
     each enabled server in parallel, and returns a deduplicated flat list.
@@ -281,14 +379,13 @@ async def get_mcp_tools(
     are connected to, preventing unintended tool exposure from globally
     enabled servers that the agent did not declare.
 
-    The ``sso_token`` should already be **refreshed** by the caller via
-    ``refresh_access_token()`` before calling this function.
-
     Connection failures are logged but do not raise exceptions, ensuring
     the application continues with an empty tool list.
 
     Args:
-        sso_token: Optional SSO token for authentication (pre-refreshed).
+        sso_token: Optional SSO token for initial discovery handshake.
+            This token is used ONLY for the discovery connection, not
+            baked into the returned tool wrappers.
         server_names: Optional list of MCP server names to connect to.
             When provided, only these servers are used (must also be
             enabled in mcp.json). When ``None``, all enabled servers
@@ -336,13 +433,18 @@ async def get_mcp_tools(
         ]
     )
 
+    server_tool_map: dict[str, list[Any]] = {}
+    for (name, _entry), tool_list in zip(enabled.items(), results):
+        server_tool_map[name] = tool_list
+
     seen: set[str] = set()
     tools: list[Any] = []
-    for tool_list in results:
-        for tool in tool_list:
+    for name, entry in enabled.items():
+        for tool in server_tool_map.get(name, []):
             if tool.name not in seen:
                 seen.add(tool.name)
-                tools.append(tool)
+                wrapped = _make_auth_refreshing_tool(tool, name, entry)
+                tools.append(wrapped)
             else:
                 logger.warning(f"Duplicate tool '{tool.name}' skipped")
 

--- a/tests/unit/infrastructure/test_mcp.py
+++ b/tests/unit/infrastructure/test_mcp.py
@@ -9,6 +9,7 @@ from deep_agent.aegra.mcp import (
     _connect_single_server,
     _get_server_configs,
     get_mcp_tools,
+    set_mcp_auth_context,
 )
 
 
@@ -225,6 +226,8 @@ class TestGetMCPTools:
 
         mock_tool = MagicMock()
         mock_tool.name = "tool1"
+        mock_tool.description = "A test tool"
+        mock_tool.args_schema = None
 
         with (
             patch(
@@ -264,13 +267,21 @@ class TestGetMCPTools:
 
         tool_a1 = MagicMock()
         tool_a1.name = "shared_tool"
+        tool_a1.description = "from server a"
+        tool_a1.args_schema = None
         tool_a2 = MagicMock()
         tool_a2.name = "unique_a"
+        tool_a2.description = "unique to a"
+        tool_a2.args_schema = None
 
         tool_b1 = MagicMock()
         tool_b1.name = "shared_tool"
+        tool_b1.description = "from server b"
+        tool_b1.args_schema = None
         tool_b2 = MagicMock()
         tool_b2.name = "unique_b"
+        tool_b2.description = "unique to b"
+        tool_b2.args_schema = None
 
         with (
             patch(
@@ -285,12 +296,11 @@ class TestGetMCPTools:
 
             tools = await get_mcp_tools()
 
-            # Should have 3 tools: shared_tool (from server-a), unique_a, unique_b
             assert len(tools) == 3
             tool_names = {t.name for t in tools}
             assert tool_names == {"shared_tool", "unique_a", "unique_b"}
-            # First occurrence of shared_tool wins
-            assert tools[0] is tool_a1
+            assert tools[0].name == "shared_tool"
+            assert tools[0].description == "from server a"
 
     @pytest.mark.asyncio
     async def test_no_enabled_servers_returns_empty_list(self):
@@ -372,6 +382,8 @@ class TestGetMCPTools:
 
         mock_tool = MagicMock()
         mock_tool.name = "tool1"
+        mock_tool.description = "test"
+        mock_tool.args_schema = None
 
         with (
             patch(
@@ -407,10 +419,16 @@ class TestGetMCPTools:
 
         tool1 = MagicMock()
         tool1.name = "tool1"
+        tool1.description = "t1"
+        tool1.args_schema = None
         tool2 = MagicMock()
         tool2.name = "tool2"
+        tool2.description = "t2"
+        tool2.args_schema = None
         tool3 = MagicMock()
         tool3.name = "tool3"
+        tool3.description = "t3"
+        tool3.args_schema = None
 
         with (
             patch(
@@ -425,7 +443,6 @@ class TestGetMCPTools:
 
             tools = await get_mcp_tools()
 
-            # All three servers should be connected
             assert mock_connect.call_count == 3
             assert len(tools) == 3
 
@@ -440,6 +457,8 @@ class TestGetMCPTools:
 
         tool_w = MagicMock()
         tool_w.name = "wanted_tool"
+        tool_w.description = "wanted"
+        tool_w.args_schema = None
 
         with (
             patch(
@@ -457,3 +476,95 @@ class TestGetMCPTools:
             mock_connect.assert_called_once()
             assert len(tools) == 1
             assert tools[0].name == "wanted_tool"
+
+
+class TestSetMcpAuthContext:
+    """Tests for set_mcp_auth_context and context-var-based auth."""
+
+    def test_sets_and_reads_access_token(self):
+        """Test that set_mcp_auth_context populates access token context var."""
+        from deep_agent.aegra.mcp import (
+            _current_access_token,
+            _current_refresh_token,
+            set_mcp_auth_context,
+        )
+
+        set_mcp_auth_context("access_123", "refresh_456")
+
+        assert _current_access_token.get() == "access_123"
+        assert _current_refresh_token.get() == "refresh_456"
+
+    def test_handles_none_tokens(self):
+        """Test that None tokens are stored without error."""
+        from deep_agent.aegra.mcp import (
+            _current_access_token,
+            _current_refresh_token,
+            set_mcp_auth_context,
+        )
+
+        set_mcp_auth_context(None, None)
+
+        assert _current_access_token.get() is None
+        assert _current_refresh_token.get() is None
+
+
+class TestMakeAuthRefreshingTool:
+    """Tests for _make_auth_refreshing_tool wrapper."""
+
+    def test_preserves_tool_name_and_description(self):
+        """Test that wrapped tool preserves original name and description."""
+        from deep_agent.aegra.mcp import _make_auth_refreshing_tool
+
+        original = MagicMock()
+        original.name = "web_search"
+        original.description = "Search the web"
+        original.args_schema = None
+
+        server_entry = {"url": "http://mcp/", "auth": True, "timeout": 10}
+        wrapped = _make_auth_refreshing_tool(original, "search-server", server_entry)
+
+        assert wrapped.name == "web_search"
+        assert wrapped.description == "Search the web"
+
+    @pytest.mark.asyncio
+    async def test_invocation_refreshes_token_and_reconnects(self):
+        """Test that tool invocation triggers token refresh and reconnection."""
+        from deep_agent.aegra.mcp import (
+            _make_auth_refreshing_tool,
+            set_mcp_auth_context,
+        )
+
+        original = MagicMock()
+        original.name = "web_search"
+        original.description = "Search the web"
+        original.args_schema = None
+
+        server_entry = {"url": "http://mcp/", "auth": True, "timeout": 10}
+        wrapped = _make_auth_refreshing_tool(original, "search-server", server_entry)
+
+        set_mcp_auth_context("stale_token", "refresh_tok")
+
+        fresh_tool = MagicMock()
+        fresh_tool.name = "web_search"
+        fresh_tool.ainvoke = AsyncMock(return_value="search result")
+
+        mock_client = MagicMock()
+        mock_client.get_tools = AsyncMock(return_value=[fresh_tool])
+
+        with (
+            patch(
+                "deep_agent.aegra.mcp.refresh_access_token",
+                new_callable=AsyncMock,
+                return_value="fresh_token",
+            ) as mock_refresh,
+            patch(
+                "deep_agent.aegra.mcp.MultiServerMCPClient",
+                return_value=mock_client,
+            ) as mock_mcp_client,
+        ):
+            result = await wrapped.ainvoke({"query": "test"})
+
+            mock_refresh.assert_called_once_with("stale_token", "refresh_tok")
+            mock_mcp_client.assert_called_once()
+            fresh_tool.ainvoke.assert_called_once_with({"query": "test"})
+            assert result == "search result"


### PR DESCRIPTION
## Summary

MCP tools were caching stale SSO tokens at discovery time, causing `401 Unauthorized` errors when the token expired mid-session (typically after 5 minutes). This change introduces an **auth-at-call-time** architecture that eliminates token expiration issues entirely.

### Changes

- **`deep_agent/aegra/mcp.py`**: 
  - Added `contextvars` (`_current_access_token`, `_current_refresh_token`) to hold per-request tokens
  - Added `set_mcp_auth_context()` to inject tokens at the start of each request
  - Added `_make_auth_refreshing_tool()` wrapper that refreshes the token and opens a fresh authenticated session on each tool invocation
  - Modified `get_mcp_tools()` to return wrapped tools instead of raw token-bound tools
  - Cached tool objects are now lightweight wrappers — the cache remains valid regardless of token expiry

- **`deep_agent/aegra/graph.py`**: 
  - Calls `set_mcp_auth_context(sso_token, refresh_token)` after token refresh, before agent execution

- **`tests/unit/infrastructure/test_mcp.py`**: 
  - Added tests for `set_mcp_auth_context` and `_make_auth_refreshing_tool` behavior

### Architecture

```
Before: discover → cache tools with baked-in token → token expires → 401
After:  discover → cache wrapper tools → on invocation: read fresh token from contextvar → refresh if needed → connect → execute
```

## Test plan

- [x] Unit tests for context variable injection
- [x] Unit tests for auth-refreshing wrapper tool
- [ ] Deploy to preprod and verify MCP tools work across sessions > 5 minutes
- [ ] Verify tool caching still reduces overhead (no re-discovery per call)