### PR TITLE
feat: add graceful SIGTERM shutdown with drain and resource cleanup

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -20,9 +20,11 @@ COPY --chown=65532:root aegra.json /app/aegra.json
 ENV PYTHONPATH=/app
 ENV AGENT_HOST=0.0.0.0
 ENV AGENT_PORT=5002
+ENV AEGRA_CONFIG=/app/aegra.json
 
 EXPOSE 5002
-# Run uvicorn directly as PID 1 so logs go to container stdout
-# and SIGTERM triggers graceful shutdown. The aegra serve wrapper
-# uses subprocess.run() which swallows child output and signals.
+# Run uvicorn directly as PID 1 so container logs capture all output
+# and SIGTERM triggers graceful shutdown. The aegra serve wrapper uses
+# subprocess.run() which swallows child stdout and signals.
+# AEGRA_CONFIG is set above to replicate what aegra serve does.
 CMD ["/bin/sh", "-c", "exec /app/.venv/bin/python -m uvicorn aegra_api.main:app --host ${AGENT_HOST} --port ${AGENT_PORT}"]

--- a/Containerfile
+++ b/Containerfile
@@ -22,4 +22,7 @@ ENV AGENT_HOST=0.0.0.0
 ENV AGENT_PORT=5002
 
 EXPOSE 5002
-CMD ["/bin/sh", "-c", "/app/.venv/bin/aegra serve --host ${AGENT_HOST} --port ${AGENT_PORT}"]
+# Run uvicorn directly as PID 1 so logs go to container stdout
+# and SIGTERM triggers graceful shutdown. The aegra serve wrapper
+# uses subprocess.run() which swallows child output and signals.
+CMD ["/bin/sh", "-c", "exec /app/.venv/bin/python -m uvicorn aegra_api.main:app --host ${AGENT_HOST} --port ${AGENT_PORT}"]

--- a/deep_agent/aegra/__init__.py
+++ b/deep_agent/aegra/__init__.py
@@ -14,6 +14,7 @@ Modules:
     middleware: Authentication middleware (API key, JWT)
     telemetry: Langfuse integration
     redis: Redis caching layer
+    shutdown: Graceful SIGTERM shutdown orchestrator
 """
 
 __version__ = "0.1.0"

--- a/deep_agent/aegra/feedback.py
+++ b/deep_agent/aegra/feedback.py
@@ -14,7 +14,6 @@ persisted to Postgres for cross-session history.
 from __future__ import annotations
 
 import json
-from contextlib import asynccontextmanager
 from typing import Any, Literal
 from uuid import uuid4
 
@@ -70,16 +69,11 @@ def _patch_aegra_persistence_if_inmemory() -> None:
 
 _patch_aegra_persistence_if_inmemory()
 
+from deep_agent.aegra.shutdown import register_atexit
 
-@asynccontextmanager
-async def _lifespan(app: FastAPI):  # noqa: ARG001
-    yield
-    from deep_agent.aegra.shutdown import run_shutdown
+register_atexit()
 
-    await run_shutdown()
-
-
-app = FastAPI(title="template-agent-custom", lifespan=_lifespan)
+app = FastAPI(title="template-agent-custom")
 
 
 class TraceIDMiddleware(BaseHTTPMiddleware):
@@ -90,7 +84,6 @@ class TraceIDMiddleware(BaseHTTPMiddleware):
     """
 
     async def dispatch(self, request: Request, call_next: Any) -> Any:
-        """Extract X-Trace-ID from request, bind to context, forward to response."""
         trace_id = request.headers.get("x-trace-id") or uuid4().hex
         bind_request_context(trace_id=trace_id)
         response = await call_next(request)

--- a/deep_agent/aegra/feedback.py
+++ b/deep_agent/aegra/feedback.py
@@ -14,6 +14,7 @@ persisted to Postgres for cross-session history.
 from __future__ import annotations
 
 import json
+from contextlib import asynccontextmanager
 from typing import Any, Literal
 from uuid import uuid4
 
@@ -69,7 +70,16 @@ def _patch_aegra_persistence_if_inmemory() -> None:
 
 _patch_aegra_persistence_if_inmemory()
 
-app = FastAPI(title="template-agent-custom")
+
+@asynccontextmanager
+async def _lifespan(app: FastAPI):  # noqa: ARG001
+    yield
+    from deep_agent.aegra.shutdown import run_shutdown
+
+    await run_shutdown()
+
+
+app = FastAPI(title="template-agent-custom", lifespan=_lifespan)
 
 
 class TraceIDMiddleware(BaseHTTPMiddleware):

--- a/deep_agent/aegra/health.py
+++ b/deep_agent/aegra/health.py
@@ -21,6 +21,7 @@ The health module can be used standalone (imported and called)
 or wired as ASGI middleware for ``aegra serve``.
 """
 
+import asyncio
 import time
 from typing import Any
 
@@ -61,7 +62,7 @@ async def check_redis() -> dict[str, Any]:
             return {"status": "skipped", "reason": "redis not configured"}
 
         t0 = time.monotonic()
-        pong = await client.ping()
+        pong = await asyncio.to_thread(client.ping)
         latency_ms = (time.monotonic() - t0) * 1000
 
         return {
@@ -129,6 +130,15 @@ async def get_health_status() -> dict[str, Any]:
 
 async def health_response() -> tuple[int, dict[str, Any]]:
     """Return (status_code, body) for the health endpoint."""
+    from deep_agent.aegra.shutdown import is_shutting_down
+
+    if is_shutting_down():
+        return 503, {
+            "status": "shutting_down",
+            "version": "0.1.0",
+            "uptime_seconds": round(time.monotonic() - _start_time, 1),
+        }
+
     result = await get_health_status()
     code = 200 if result["status"] in ("healthy", "degraded") else 503
     return code, result

--- a/deep_agent/aegra/redis.py
+++ b/deep_agent/aegra/redis.py
@@ -74,6 +74,20 @@ def get_redis_client() -> Any:
         return None
 
 
+def close_redis_client() -> None:
+    """Close the Redis client connection if open. Idempotent."""
+    global _client  # noqa: PLW0603
+    if _client is None:
+        return
+    try:
+        _client.close()
+        logger.info("Redis client closed")
+    except Exception:
+        logger.debug("Redis close error", exc_info=True)
+    finally:
+        _client = None
+
+
 def cache_get(key: str) -> str | None:
     """Read a value from Redis cache. Returns None on miss or error."""
     client = get_redis_client()

--- a/deep_agent/aegra/shutdown.py
+++ b/deep_agent/aegra/shutdown.py
@@ -43,6 +43,7 @@ logger = get_python_logger()
 
 _shutting_down = False
 _shutdown_complete = False
+_atexit_registered = False
 
 SHUTDOWN_DRAIN_SECONDS = int(os.environ.get("SHUTDOWN_DRAIN_SECONDS", "15"))
 SHUTDOWN_LANGFUSE_TIMEOUT_SECONDS = int(
@@ -51,6 +52,27 @@ SHUTDOWN_LANGFUSE_TIMEOUT_SECONDS = int(
 SHUTDOWN_SCHEDULER_TIMEOUT_SECONDS = int(
     os.environ.get("SHUTDOWN_SCHEDULER_TIMEOUT_SECONDS", "10")
 )
+SHUTDOWN_GRACE_PERIOD_SECONDS = int(
+    os.environ.get("SHUTDOWN_GRACE_PERIOD_SECONDS", "60")
+)
+
+_TOTAL_BUDGET = (
+    SHUTDOWN_DRAIN_SECONDS
+    + SHUTDOWN_LANGFUSE_TIMEOUT_SECONDS
+    + SHUTDOWN_SCHEDULER_TIMEOUT_SECONDS
+)
+_HEADROOM = SHUTDOWN_GRACE_PERIOD_SECONDS - _TOTAL_BUDGET
+if _HEADROOM < 5:
+    logger.warning(
+        "Shutdown budget (%ds drain + %ds langfuse + %ds scheduler = %ds) "
+        "leaves only %ds before SIGKILL at %ds. Risk of incomplete cleanup.",
+        SHUTDOWN_DRAIN_SECONDS,
+        SHUTDOWN_LANGFUSE_TIMEOUT_SECONDS,
+        SHUTDOWN_SCHEDULER_TIMEOUT_SECONDS,
+        _TOTAL_BUDGET,
+        _HEADROOM,
+        SHUTDOWN_GRACE_PERIOD_SECONDS,
+    )
 
 
 def is_shutting_down() -> bool:
@@ -65,8 +87,14 @@ def register_atexit() -> None:
     """Register the sync shutdown as an atexit callback.
 
     Called at import time from ``feedback.py``. Unlike signal handlers,
-    atexit callbacks are not overwritten by uvicorn.
+    atexit callbacks are not overwritten by uvicorn. Idempotent — safe
+    to call multiple times (tests, reloads).
     """
+    global _atexit_registered  # noqa: PLW0603
+    if _atexit_registered:
+        return
+    _atexit_registered = True
+
     import atexit
 
     atexit.register(run_shutdown_sync)

--- a/deep_agent/aegra/shutdown.py
+++ b/deep_agent/aegra/shutdown.py
@@ -3,28 +3,37 @@
 Mirrors ``startup.py``: idempotent orchestrator, individual step
 functions, structured logging, defensive error handling.
 
-Three independent paths trigger shutdown (belt-and-suspenders for
-uncertain Aegra lifespan behavior):
+Two independent paths trigger shutdown:
 
-1. FastAPI lifespan exit (feedback.py)
-2. SIGTERM/SIGINT signal handler (registered at startup)
-3. atexit callback (fallback for normal process exit)
+1. ``atexit`` callback (registered at import time from ``feedback.py``)
+   — fires reliably when uvicorn handles SIGTERM and exits normally.
+   Runs a synchronous cleanup (Langfuse flush, Redis close, graph
+   cache clear). No event loop needed.
 
-All three call ``run_shutdown()`` which is idempotent — the second
-call returns immediately.
+2. ``loop.add_signal_handler`` (registered on first graph request via
+   ``startup.py``) — overrides uvicorn's handler, runs the full async
+   shutdown with drain period. Only active after the first graph
+   request, but that's when there's actually work to drain.
+
+Aegra strips our custom app's lifespan and middleware, so neither
+ASGI lifespan nor middleware-based registration works. The atexit
+path is guaranteed because Aegra always imports ``feedback.py``.
+
+Both paths call idempotent cleanup — the second call is a no-op.
 
 Shutdown sequence (within ``terminationGracePeriodSeconds: 60``):
 
     1. Set ``_shutting_down`` flag → health probes return 503
-    2. Drain period — in-flight requests finish
+    2. Drain period — in-flight requests finish (async path only)
     3. Flush and stop Langfuse
-    4. Stop memory scheduler
+    4. Stop memory scheduler (async path only)
     5. Clear graph cache
     6. Close Redis
 """
 
 import asyncio
 import os
+import signal
 import time
 from typing import Any
 
@@ -49,22 +58,109 @@ def is_shutting_down() -> bool:
     return _shutting_down
 
 
-async def run_shutdown() -> dict[str, str]:
-    """Execute the shutdown sequence. Returns a status dict.
+# -- Primary path: atexit (sync) ---------------------------------------------
 
-    Safe to call multiple times — subsequent calls are no-ops.
+
+def register_atexit() -> None:
+    """Register the sync shutdown as an atexit callback.
+
+    Called at import time from ``feedback.py``. Unlike signal handlers,
+    atexit callbacks are not overwritten by uvicorn.
+    """
+    import atexit
+
+    atexit.register(run_shutdown_sync)
+    logger.info("Shutdown atexit handler registered")
+
+
+def run_shutdown_sync() -> None:
+    """Synchronous shutdown — runs at process exit via atexit.
+
+    Handles cleanup that doesn't need an event loop: Langfuse flush,
+    Redis close, graph cache clear. Skips drain and async scheduler
+    stop (those only run in the async path).
     """
     global _shutting_down, _shutdown_complete  # noqa: PLW0603
 
+    if _shutdown_complete:
+        return
     if _shutting_down:
-        logger.debug("Shutdown already initiated — skipping")
-        return {"status": "already_complete"}
+        logger.debug("Async shutdown already ran — sync cleanup skipped")
+        _shutdown_complete = True
+        return
 
     _shutting_down = True
     t0 = time.monotonic()
     results: dict[str, str] = {}
 
-    logger.info("Shutdown initiated")
+    logger.info("Sync shutdown initiated (atexit)")
+
+    for key, step in [
+        ("langfuse", _shutdown_langfuse_sync),
+        ("graph_cache", _clear_graph_cache),
+        ("redis", _close_redis),
+    ]:
+        try:
+            results[key] = step()
+        except Exception as exc:
+            logger.warning("Shutdown step '%s' failed: %s", key, exc)
+            results[key] = f"error: {exc}"
+
+    _shutdown_complete = True
+    elapsed = round((time.monotonic() - t0) * 1000, 1)
+    logger.info("Sync shutdown complete in %.1fms: %s", elapsed, results)
+
+
+# -- Secondary path: signal handler (async) ----------------------------------
+
+
+def register_signal_handlers() -> None:
+    """Install loop-aware SIGTERM/SIGINT handlers.
+
+    Uses ``loop.add_signal_handler`` which overrides uvicorn's handler.
+    Must be called from inside a running event loop. Called from
+    ``startup.py`` after the first graph request.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        logger.warning("No running event loop — signal handlers not registered")
+        return
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, _handle_signal, sig, loop)
+
+    logger.info("Shutdown signal handlers registered (SIGTERM, SIGINT)")
+
+
+def _handle_signal(signum: int, loop: asyncio.AbstractEventLoop) -> None:
+    global _shutting_down  # noqa: PLW0603
+    _shutting_down = True
+    logger.info("Signal %d received — scheduling async shutdown", signum)
+    loop.create_task(run_shutdown())
+
+
+_async_shutdown_started = False
+
+
+async def run_shutdown() -> dict[str, str]:
+    """Full async shutdown with drain period.
+
+    Only runs when signal handlers were registered (after first graph
+    request). Safe to call multiple times — subsequent calls are no-ops.
+    """
+    global _shutting_down, _shutdown_complete, _async_shutdown_started  # noqa: PLW0603
+
+    if _shutdown_complete or _async_shutdown_started:
+        return {"status": "already_complete"}
+
+    _async_shutdown_started = True
+    _shutting_down = True
+
+    t0 = time.monotonic()
+    results: dict[str, str] = {}
+
+    logger.info("Async shutdown initiated")
 
     for key, step in [
         ("drain", _drain),
@@ -85,53 +181,8 @@ async def run_shutdown() -> dict[str, str]:
     _shutdown_complete = True
     elapsed = round((time.monotonic() - t0) * 1000, 1)
 
-    logger.info("Shutdown complete in %.1fms: %s", elapsed, results)
+    logger.info("Async shutdown complete in %.1fms: %s", elapsed, results)
     return results
-
-
-def run_shutdown_sync() -> None:
-    """Synchronous fallback for atexit. Bootstraps a loop if needed."""
-    if _shutdown_complete or _shutting_down:
-        return
-    try:
-        loop = asyncio.get_event_loop()
-        if loop.is_running():
-            loop.create_task(run_shutdown())
-            return
-        loop.run_until_complete(run_shutdown())
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
-        try:
-            loop.run_until_complete(run_shutdown())
-        finally:
-            loop.close()
-
-
-def register_signal_handlers() -> None:
-    """Install SIGTERM/SIGINT handlers on the running event loop.
-
-    Must be called from the main thread while a loop is running.
-    Uses ``loop.add_signal_handler`` (Unix-only — fine for OpenShift).
-    """
-    import signal
-
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        logger.warning("No running event loop — signal handlers not registered")
-        return
-
-    for sig in (signal.SIGTERM, signal.SIGINT):
-        loop.add_signal_handler(sig, _handle_signal, sig, loop)
-
-    logger.info("Shutdown signal handlers registered (SIGTERM, SIGINT)")
-
-
-def _handle_signal(signum: int, loop: asyncio.AbstractEventLoop) -> None:
-    global _shutting_down  # noqa: PLW0603
-    _shutting_down = True
-    logger.info("Signal %d received — scheduling shutdown", signum)
-    loop.create_task(run_shutdown())
 
 
 # -- Individual shutdown steps -----------------------------------------------
@@ -168,8 +219,23 @@ async def _shutdown_langfuse() -> str:
         return f"error: {exc}"
 
 
+def _shutdown_langfuse_sync() -> str:
+    """Sync Langfuse flush for atexit path."""
+    try:
+        from deep_agent.aegra.telemetry import get_langfuse_client
+
+        client = get_langfuse_client()
+        if client is None:
+            return "skipped: not configured"
+        _langfuse_shutdown_blocking(client)
+        return "ok"
+    except Exception as exc:
+        logger.warning("Langfuse shutdown failed: %s", exc)
+        return f"error: {exc}"
+
+
 def _langfuse_shutdown_blocking(client: Any) -> None:
-    """Run the sync Langfuse shutdown in a thread."""
+    """Run the sync Langfuse shutdown."""
     if hasattr(client, "shutdown"):
         client.shutdown()
     elif hasattr(client, "flush"):

--- a/deep_agent/aegra/shutdown.py
+++ b/deep_agent/aegra/shutdown.py
@@ -93,6 +93,9 @@ def run_shutdown_sync() -> None:
     t0 = time.monotonic()
     results: dict[str, str] = {}
 
+    import sys
+
+    print("[shutdown] Graceful shutdown started", file=sys.stderr, flush=True)
     logger.info("Sync shutdown initiated (atexit)")
 
     for key, step in [
@@ -108,7 +111,11 @@ def run_shutdown_sync() -> None:
 
     _shutdown_complete = True
     elapsed = round((time.monotonic() - t0) * 1000, 1)
-    logger.info("Sync shutdown complete in %.1fms: %s", elapsed, results)
+    print(
+        f"[shutdown] Graceful shutdown complete in {elapsed}ms: {results}",
+        file=sys.stderr,
+        flush=True,
+    )
 
 
 # -- Secondary path: signal handler (async) ----------------------------------
@@ -220,18 +227,25 @@ async def _shutdown_langfuse() -> str:
 
 
 def _shutdown_langfuse_sync() -> str:
-    """Sync Langfuse flush for atexit path."""
-    try:
-        from deep_agent.aegra.telemetry import get_langfuse_client
+    """Sync Langfuse flush for atexit path.
 
-        client = get_langfuse_client()
-        if client is None:
+    Only flushes if a client was already initialized — avoids creating
+    a new client during interpreter shutdown (which triggers
+    ``RuntimeError: cannot schedule new futures``).
+    """
+    try:
+        from deep_agent.aegra.telemetry import _langfuse_configured
+
+        if not _langfuse_configured():
             return "skipped: not configured"
+
+        from langfuse import get_client
+
+        client = get_client()
         _langfuse_shutdown_blocking(client)
         return "ok"
     except Exception as exc:
-        logger.warning("Langfuse shutdown failed: %s", exc)
-        return f"error: {exc}"
+        return f"skipped: {exc}"
 
 
 def _langfuse_shutdown_blocking(client: Any) -> None:

--- a/deep_agent/aegra/shutdown.py
+++ b/deep_agent/aegra/shutdown.py
@@ -1,0 +1,221 @@
+"""Shutdown orchestrator — coordinated teardown on SIGTERM.
+
+Mirrors ``startup.py``: idempotent orchestrator, individual step
+functions, structured logging, defensive error handling.
+
+Three independent paths trigger shutdown (belt-and-suspenders for
+uncertain Aegra lifespan behavior):
+
+1. FastAPI lifespan exit (feedback.py)
+2. SIGTERM/SIGINT signal handler (registered at startup)
+3. atexit callback (fallback for normal process exit)
+
+All three call ``run_shutdown()`` which is idempotent — the second
+call returns immediately.
+
+Shutdown sequence (within ``terminationGracePeriodSeconds: 60``):
+
+    1. Set ``_shutting_down`` flag → health probes return 503
+    2. Drain period — in-flight requests finish
+    3. Flush and stop Langfuse
+    4. Stop memory scheduler
+    5. Clear graph cache
+    6. Close Redis
+"""
+
+import asyncio
+import os
+import time
+from typing import Any
+
+from deep_agent.utils.pylogger import get_python_logger
+
+logger = get_python_logger()
+
+_shutting_down = False
+_shutdown_complete = False
+
+SHUTDOWN_DRAIN_SECONDS = int(os.environ.get("SHUTDOWN_DRAIN_SECONDS", "15"))
+SHUTDOWN_LANGFUSE_TIMEOUT_SECONDS = int(
+    os.environ.get("SHUTDOWN_LANGFUSE_TIMEOUT_SECONDS", "5")
+)
+SHUTDOWN_SCHEDULER_TIMEOUT_SECONDS = int(
+    os.environ.get("SHUTDOWN_SCHEDULER_TIMEOUT_SECONDS", "10")
+)
+
+
+def is_shutting_down() -> bool:
+    """Return True once shutdown has been initiated."""
+    return _shutting_down
+
+
+async def run_shutdown() -> dict[str, str]:
+    """Execute the shutdown sequence. Returns a status dict.
+
+    Safe to call multiple times — subsequent calls are no-ops.
+    """
+    global _shutting_down, _shutdown_complete  # noqa: PLW0603
+
+    if _shutting_down:
+        logger.debug("Shutdown already initiated — skipping")
+        return {"status": "already_complete"}
+
+    _shutting_down = True
+    t0 = time.monotonic()
+    results: dict[str, str] = {}
+
+    logger.info("Shutdown initiated")
+
+    for key, step in [
+        ("drain", _drain),
+        ("langfuse", _shutdown_langfuse),
+        ("scheduler", _stop_scheduler),
+        ("graph_cache", _clear_graph_cache),
+        ("redis", _close_redis),
+    ]:
+        try:
+            result = step()
+            if asyncio.iscoroutine(result):
+                result = await result
+            results[key] = result
+        except Exception as exc:
+            logger.warning("Shutdown step '%s' failed: %s", key, exc)
+            results[key] = f"error: {exc}"
+
+    _shutdown_complete = True
+    elapsed = round((time.monotonic() - t0) * 1000, 1)
+
+    logger.info("Shutdown complete in %.1fms: %s", elapsed, results)
+    return results
+
+
+def run_shutdown_sync() -> None:
+    """Synchronous fallback for atexit. Bootstraps a loop if needed."""
+    if _shutdown_complete or _shutting_down:
+        return
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            loop.create_task(run_shutdown())
+            return
+        loop.run_until_complete(run_shutdown())
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(run_shutdown())
+        finally:
+            loop.close()
+
+
+def register_signal_handlers() -> None:
+    """Install SIGTERM/SIGINT handlers on the running event loop.
+
+    Must be called from the main thread while a loop is running.
+    Uses ``loop.add_signal_handler`` (Unix-only — fine for OpenShift).
+    """
+    import signal
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        logger.warning("No running event loop — signal handlers not registered")
+        return
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, _handle_signal, sig, loop)
+
+    logger.info("Shutdown signal handlers registered (SIGTERM, SIGINT)")
+
+
+def _handle_signal(signum: int, loop: asyncio.AbstractEventLoop) -> None:
+    global _shutting_down  # noqa: PLW0603
+    _shutting_down = True
+    logger.info("Signal %d received — scheduling shutdown", signum)
+    loop.create_task(run_shutdown())
+
+
+# -- Individual shutdown steps -----------------------------------------------
+
+
+async def _drain() -> str:
+    if SHUTDOWN_DRAIN_SECONDS <= 0:
+        return "skipped: drain disabled"
+    logger.info("Draining for %ds", SHUTDOWN_DRAIN_SECONDS)
+    await asyncio.sleep(SHUTDOWN_DRAIN_SECONDS)
+    return "ok"
+
+
+async def _shutdown_langfuse() -> str:
+    try:
+        from deep_agent.aegra.telemetry import get_langfuse_client
+
+        client = get_langfuse_client()
+        if client is None:
+            return "skipped: not configured"
+
+        await asyncio.wait_for(
+            asyncio.to_thread(_langfuse_shutdown_blocking, client),
+            timeout=SHUTDOWN_LANGFUSE_TIMEOUT_SECONDS,
+        )
+        return "ok"
+    except asyncio.TimeoutError:
+        logger.warning(
+            "Langfuse shutdown timed out after %ds", SHUTDOWN_LANGFUSE_TIMEOUT_SECONDS
+        )
+        return "timeout"
+    except Exception as exc:
+        logger.warning("Langfuse shutdown failed: %s", exc)
+        return f"error: {exc}"
+
+
+def _langfuse_shutdown_blocking(client: Any) -> None:
+    """Run the sync Langfuse shutdown in a thread."""
+    if hasattr(client, "shutdown"):
+        client.shutdown()
+    elif hasattr(client, "flush"):
+        client.flush()
+
+
+async def _stop_scheduler() -> str:
+    try:
+        from deep_agent.src.memory.scheduler import stop_scheduler
+
+        await asyncio.wait_for(
+            stop_scheduler(),
+            timeout=SHUTDOWN_SCHEDULER_TIMEOUT_SECONDS,
+        )
+        return "ok"
+    except asyncio.TimeoutError:
+        logger.warning(
+            "Scheduler stop timed out after %ds", SHUTDOWN_SCHEDULER_TIMEOUT_SECONDS
+        )
+        return "timeout"
+    except Exception as exc:
+        logger.warning("Scheduler stop failed: %s", exc)
+        return f"error: {exc}"
+
+
+def _clear_graph_cache() -> str:
+    try:
+        from deep_agent.aegra.graph import _graph_cache, _graph_cache_ts
+
+        count = len(_graph_cache)
+        _graph_cache.clear()
+        _graph_cache_ts.clear()
+        if count > 0:
+            logger.info("Cleared %d cached graph(s)", count)
+        return "ok"
+    except Exception as exc:
+        logger.warning("Graph cache clear failed: %s", exc)
+        return f"error: {exc}"
+
+
+def _close_redis() -> str:
+    try:
+        from deep_agent.aegra.redis import close_redis_client
+
+        close_redis_client()
+        return "ok"
+    except Exception as exc:
+        logger.warning("Redis close failed: %s", exc)
+        return f"error: {exc}"

--- a/deep_agent/aegra/startup.py
+++ b/deep_agent/aegra/startup.py
@@ -48,6 +48,8 @@ async def run_startup() -> dict[str, str]:
     elapsed = round((time.monotonic() - t0) * 1000, 1)
     _startup_complete = True
 
+    _register_shutdown_handlers()
+
     logger.info(
         "Startup complete in %.1fms: %s",
         elapsed,
@@ -135,6 +137,24 @@ def _setup_telemetry() -> str:
     except Exception as exc:
         logger.warning("Telemetry setup failed: %s", exc)
         return f"warning: {exc}"
+
+
+def _register_shutdown_handlers() -> None:
+    """Register signal and atexit shutdown handlers."""
+    import atexit
+
+    try:
+        from deep_agent.aegra.shutdown import register_signal_handlers, run_shutdown_sync
+
+        try:
+            register_signal_handlers()
+        except Exception:
+            logger.warning("Failed to register signal handlers", exc_info=True)
+
+        atexit.register(run_shutdown_sync)
+        logger.info("Shutdown handlers registered")
+    except Exception:
+        logger.warning("Failed to register shutdown handlers", exc_info=True)
 
 
 def is_ready() -> bool:

--- a/deep_agent/aegra/startup.py
+++ b/deep_agent/aegra/startup.py
@@ -45,10 +45,10 @@ async def run_startup() -> dict[str, str]:
     results["scheduler"] = await _start_scheduler()
     results["telemetry"] = _setup_telemetry()
 
+    _upgrade_signal_handlers()
+
     elapsed = round((time.monotonic() - t0) * 1000, 1)
     _startup_complete = True
-
-    _register_shutdown_handlers()
 
     logger.info(
         "Startup complete in %.1fms: %s",
@@ -56,6 +56,16 @@ async def run_startup() -> dict[str, str]:
         results,
     )
     return results
+
+
+def _upgrade_signal_handlers() -> None:
+    """Upgrade to loop-aware signal handlers for async drain."""
+    try:
+        from deep_agent.aegra.shutdown import register_signal_handlers
+
+        register_signal_handlers()
+    except Exception:
+        logger.warning("Failed to register signal handlers", exc_info=True)
 
 
 async def _validate_config() -> str:
@@ -137,24 +147,6 @@ def _setup_telemetry() -> str:
     except Exception as exc:
         logger.warning("Telemetry setup failed: %s", exc)
         return f"warning: {exc}"
-
-
-def _register_shutdown_handlers() -> None:
-    """Register signal and atexit shutdown handlers."""
-    import atexit
-
-    try:
-        from deep_agent.aegra.shutdown import register_signal_handlers, run_shutdown_sync
-
-        try:
-            register_signal_handlers()
-        except Exception:
-            logger.warning("Failed to register signal handlers", exc_info=True)
-
-        atexit.register(run_shutdown_sync)
-        logger.info("Shutdown handlers registered")
-    except Exception:
-        logger.warning("Failed to register shutdown handlers", exc_info=True)
 
 
 def is_ready() -> bool:

--- a/tests/integration/aegra/test_graceful_shutdown.py
+++ b/tests/integration/aegra/test_graceful_shutdown.py
@@ -1,0 +1,185 @@
+"""Integration tests for graceful shutdown under concurrent load.
+
+Proves the shutdown sequence completes cleanly while simulated
+graph runs are active, and that all subsystems are torn down
+within the configured timeout budget.
+"""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import deep_agent.aegra.shutdown as shutdown_mod
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(autouse=True)
+def _reset_shutdown_state():
+    shutdown_mod._shutting_down = False
+    shutdown_mod._shutdown_complete = False
+    yield
+    shutdown_mod._shutting_down = False
+    shutdown_mod._shutdown_complete = False
+
+
+def _mock_all_subsystems(drain_seconds=0):
+    """Context manager that mocks all external subsystems for shutdown."""
+    mock_langfuse = MagicMock()
+    mock_langfuse.shutdown = MagicMock()
+
+    return (
+        patch.object(shutdown_mod, "SHUTDOWN_DRAIN_SECONDS", drain_seconds),
+        patch(
+            "deep_agent.aegra.telemetry.get_langfuse_client",
+            return_value=mock_langfuse,
+        ),
+        patch(
+            "deep_agent.src.memory.scheduler.stop_scheduler",
+            new_callable=AsyncMock,
+        ),
+        patch("deep_agent.aegra.redis.close_redis_client"),
+    )
+
+
+class TestShutdownUnderConcurrentActivity:
+    async def test_shutdown_while_tasks_are_running(self):
+        """Simulate concurrent graph runs during shutdown.
+
+        Active tasks should be able to continue during the drain
+        period. After drain, cleanup runs and completes.
+        """
+        completed_tasks = []
+
+        async def simulate_graph_run(task_id: int, duration: float):
+            await asyncio.sleep(duration)
+            completed_tasks.append(task_id)
+
+        tasks = [
+            asyncio.create_task(simulate_graph_run(i, i * 0.05))
+            for i in range(5)
+        ]
+
+        patches = _mock_all_subsystems(drain_seconds=0.3)
+        with patches[0], patches[1], patches[2], patches[3]:
+            t0 = time.monotonic()
+            result = await shutdown_mod.run_shutdown()
+            elapsed = time.monotonic() - t0
+
+        assert result["drain"] == "ok"
+        assert result["langfuse"] == "ok"
+        assert result["scheduler"] == "ok"
+        assert result["redis"] == "ok"
+        assert shutdown_mod._shutdown_complete is True
+        assert elapsed < 2.0
+
+        await asyncio.gather(*tasks, return_exceptions=True)
+        assert len(completed_tasks) == 5
+
+    async def test_resources_cleaned_up_after_drain(self):
+        """After drain period, all subsystems are torn down."""
+        mock_langfuse = MagicMock()
+        mock_langfuse.shutdown = MagicMock()
+        mock_stop = AsyncMock()
+        mock_close = MagicMock()
+
+        with (
+            patch.object(shutdown_mod, "SHUTDOWN_DRAIN_SECONDS", 0),
+            patch(
+                "deep_agent.aegra.telemetry.get_langfuse_client",
+                return_value=mock_langfuse,
+            ),
+            patch(
+                "deep_agent.src.memory.scheduler.stop_scheduler",
+                mock_stop,
+            ),
+            patch("deep_agent.aegra.redis.close_redis_client", mock_close),
+        ):
+            await shutdown_mod.run_shutdown()
+
+        mock_langfuse.shutdown.assert_called_once()
+        mock_stop.assert_awaited_once()
+        mock_close.assert_called_once()
+
+
+class TestHealthDuringShutdown:
+    async def test_health_returns_503_during_shutdown(self):
+        from deep_agent.aegra.health import health_response
+
+        with patch(
+            "deep_agent.aegra.health.get_health_status",
+            new_callable=AsyncMock,
+            return_value={"status": "healthy"},
+        ):
+            code_before, _ = await health_response()
+        assert code_before == 200
+
+        shutdown_mod._shutting_down = True
+
+        code_after, body = await health_response()
+        assert code_after == 503
+        assert body["status"] == "shutting_down"
+
+
+class TestLangfuseTimeoutResilience:
+    async def test_slow_langfuse_does_not_block_shutdown(self):
+        """A hanging Langfuse server must not prevent Redis/scheduler cleanup."""
+
+        def slow_shutdown():
+            time.sleep(30)
+
+        mock_langfuse = MagicMock()
+        mock_langfuse.shutdown = slow_shutdown
+        mock_close = MagicMock()
+        mock_stop = AsyncMock()
+
+        with (
+            patch.object(shutdown_mod, "SHUTDOWN_DRAIN_SECONDS", 0),
+            patch.object(shutdown_mod, "SHUTDOWN_LANGFUSE_TIMEOUT_SECONDS", 0.2),
+            patch(
+                "deep_agent.aegra.telemetry.get_langfuse_client",
+                return_value=mock_langfuse,
+            ),
+            patch(
+                "deep_agent.src.memory.scheduler.stop_scheduler",
+                mock_stop,
+            ),
+            patch("deep_agent.aegra.redis.close_redis_client", mock_close),
+        ):
+            t0 = time.monotonic()
+            result = await shutdown_mod.run_shutdown()
+            elapsed = time.monotonic() - t0
+
+        assert result["langfuse"] == "timeout"
+        assert result["scheduler"] == "ok"
+        assert result["redis"] == "ok"
+        mock_stop.assert_awaited_once()
+        mock_close.assert_called_once()
+        assert elapsed < 3.0
+
+
+class TestIdempotentConcurrentShutdown:
+    async def test_concurrent_calls_execute_once(self):
+        """Two concurrent run_shutdown() calls should only execute steps once."""
+        call_count = 0
+
+        async def counting_drain():
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.05)
+            return "ok"
+
+        patches = _mock_all_subsystems(drain_seconds=0)
+        with patches[0], patches[1], patches[2], patches[3]:
+            with patch.object(shutdown_mod, "_drain", side_effect=counting_drain):
+                results = await asyncio.gather(
+                    shutdown_mod.run_shutdown(),
+                    shutdown_mod.run_shutdown(),
+                )
+
+        real_runs = [r for r in results if "drain" in r]
+        skipped = [r for r in results if r.get("status") == "already_complete"]
+        assert len(real_runs) == 1
+        assert len(skipped) == 1

--- a/tests/integration/aegra/test_graceful_shutdown.py
+++ b/tests/integration/aegra/test_graceful_shutdown.py
@@ -20,9 +20,11 @@ pytestmark = pytest.mark.integration
 def _reset_shutdown_state():
     shutdown_mod._shutting_down = False
     shutdown_mod._shutdown_complete = False
+    shutdown_mod._async_shutdown_started = False
     yield
     shutdown_mod._shutting_down = False
     shutdown_mod._shutdown_complete = False
+    shutdown_mod._async_shutdown_started = False
 
 
 def _mock_all_subsystems(drain_seconds=0):

--- a/tests/unit/aegra/test_shutdown.py
+++ b/tests/unit/aegra/test_shutdown.py
@@ -12,8 +12,10 @@ from deep_agent.aegra.shutdown import (
     _close_redis,
     _drain,
     _shutdown_langfuse,
+    _shutdown_langfuse_sync,
     _stop_scheduler,
     is_shutting_down,
+    register_atexit,
     register_signal_handlers,
     run_shutdown,
     run_shutdown_sync,
@@ -25,9 +27,11 @@ def _reset_shutdown_state():
     """Reset module-level flags before each test."""
     shutdown_mod._shutting_down = False
     shutdown_mod._shutdown_complete = False
+    shutdown_mod._async_shutdown_started = False
     yield
     shutdown_mod._shutting_down = False
     shutdown_mod._shutdown_complete = False
+    shutdown_mod._async_shutdown_started = False
 
 
 class TestIsShuttingDown:
@@ -72,6 +76,7 @@ class TestRunShutdown:
 
     async def test_idempotent(self):
         shutdown_mod._shutting_down = True
+        shutdown_mod._shutdown_complete = True
         result = await run_shutdown()
         assert result["status"] == "already_complete"
 
@@ -286,9 +291,29 @@ class TestRunShutdownSync:
         shutdown_mod._shutdown_complete = True
         run_shutdown_sync()
 
-    def test_noop_when_shutting_down(self):
+    def test_skips_when_async_already_ran(self):
         shutdown_mod._shutting_down = True
         run_shutdown_sync()
+        assert shutdown_mod._shutdown_complete is True
+
+    def test_runs_sync_cleanup(self):
+        with (
+            patch.object(shutdown_mod, "_shutdown_langfuse_sync", return_value="ok"),
+            patch.object(shutdown_mod, "_clear_graph_cache", return_value="ok"),
+            patch.object(shutdown_mod, "_close_redis", return_value="ok"),
+        ):
+            run_shutdown_sync()
+        assert shutdown_mod._shutting_down is True
+        assert shutdown_mod._shutdown_complete is True
+
+
+class TestRegisterAtexit:
+    def test_registers_callback(self):
+        import atexit
+
+        with patch.object(atexit, "register") as mock_register:
+            register_atexit()
+            mock_register.assert_called_once_with(run_shutdown_sync)
 
 
 class TestRegisterSignalHandlers:

--- a/tests/unit/aegra/test_shutdown.py
+++ b/tests/unit/aegra/test_shutdown.py
@@ -28,10 +28,12 @@ def _reset_shutdown_state():
     shutdown_mod._shutting_down = False
     shutdown_mod._shutdown_complete = False
     shutdown_mod._async_shutdown_started = False
+    shutdown_mod._atexit_registered = False
     yield
     shutdown_mod._shutting_down = False
     shutdown_mod._shutdown_complete = False
     shutdown_mod._async_shutdown_started = False
+    shutdown_mod._atexit_registered = False
 
 
 class TestIsShuttingDown:
@@ -314,6 +316,14 @@ class TestRegisterAtexit:
         with patch.object(atexit, "register") as mock_register:
             register_atexit()
             mock_register.assert_called_once_with(run_shutdown_sync)
+
+    def test_idempotent(self):
+        import atexit
+
+        with patch.object(atexit, "register") as mock_register:
+            register_atexit()
+            register_atexit()
+            mock_register.assert_called_once()
 
 
 class TestRegisterSignalHandlers:

--- a/tests/unit/aegra/test_shutdown.py
+++ b/tests/unit/aegra/test_shutdown.py
@@ -1,0 +1,302 @@
+"""Unit tests for shutdown orchestrator."""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import deep_agent.aegra.shutdown as shutdown_mod
+from deep_agent.aegra.shutdown import (
+    _clear_graph_cache,
+    _close_redis,
+    _drain,
+    _shutdown_langfuse,
+    _stop_scheduler,
+    is_shutting_down,
+    register_signal_handlers,
+    run_shutdown,
+    run_shutdown_sync,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_shutdown_state():
+    """Reset module-level flags before each test."""
+    shutdown_mod._shutting_down = False
+    shutdown_mod._shutdown_complete = False
+    yield
+    shutdown_mod._shutting_down = False
+    shutdown_mod._shutdown_complete = False
+
+
+class TestIsShuttingDown:
+    def test_false_initially(self):
+        assert is_shutting_down() is False
+
+    def test_true_after_flag_set(self):
+        shutdown_mod._shutting_down = True
+        assert is_shutting_down() is True
+
+
+class TestRunShutdown:
+    async def test_runs_all_steps(self):
+        with (
+            patch.object(
+                shutdown_mod, "_drain", new_callable=AsyncMock, return_value="ok"
+            ),
+            patch.object(
+                shutdown_mod,
+                "_shutdown_langfuse",
+                new_callable=AsyncMock,
+                return_value="ok",
+            ),
+            patch.object(
+                shutdown_mod,
+                "_stop_scheduler",
+                new_callable=AsyncMock,
+                return_value="ok",
+            ),
+            patch.object(shutdown_mod, "_clear_graph_cache", return_value="ok"),
+            patch.object(shutdown_mod, "_close_redis", return_value="ok"),
+        ):
+            result = await run_shutdown()
+
+        assert result["drain"] == "ok"
+        assert result["langfuse"] == "ok"
+        assert result["scheduler"] == "ok"
+        assert result["graph_cache"] == "ok"
+        assert result["redis"] == "ok"
+        assert is_shutting_down() is True
+        assert shutdown_mod._shutdown_complete is True
+
+    async def test_idempotent(self):
+        shutdown_mod._shutting_down = True
+        result = await run_shutdown()
+        assert result["status"] == "already_complete"
+
+    async def test_sets_flag_immediately(self):
+        flag_during_drain = None
+
+        async def capture_flag():
+            nonlocal flag_during_drain
+            flag_during_drain = is_shutting_down()
+            return "ok"
+
+        with (
+            patch.object(shutdown_mod, "_drain", side_effect=capture_flag),
+            patch.object(
+                shutdown_mod,
+                "_shutdown_langfuse",
+                new_callable=AsyncMock,
+                return_value="ok",
+            ),
+            patch.object(
+                shutdown_mod,
+                "_stop_scheduler",
+                new_callable=AsyncMock,
+                return_value="ok",
+            ),
+            patch.object(shutdown_mod, "_clear_graph_cache", return_value="ok"),
+            patch.object(shutdown_mod, "_close_redis", return_value="ok"),
+        ):
+            await run_shutdown()
+
+        assert flag_during_drain is True
+
+    async def test_continues_after_step_failure(self):
+        with (
+            patch.object(
+                shutdown_mod, "_drain", new_callable=AsyncMock, return_value="ok"
+            ),
+            patch.object(
+                shutdown_mod,
+                "_shutdown_langfuse",
+                new_callable=AsyncMock,
+                side_effect=Exception("langfuse boom"),
+            ),
+            patch.object(
+                shutdown_mod,
+                "_stop_scheduler",
+                new_callable=AsyncMock,
+                return_value="ok",
+            ) as mock_sched,
+            patch.object(shutdown_mod, "_clear_graph_cache", return_value="ok"),
+            patch.object(
+                shutdown_mod, "_close_redis", return_value="ok"
+            ) as mock_redis,
+        ):
+            result = await run_shutdown()
+
+        mock_sched.assert_awaited_once()
+        mock_redis.assert_called_once()
+        assert shutdown_mod._shutdown_complete is True
+
+
+class TestDrain:
+    async def test_skips_when_zero(self):
+        with patch.object(shutdown_mod, "SHUTDOWN_DRAIN_SECONDS", 0):
+            result = await _drain()
+        assert "skipped" in result
+
+    async def test_sleeps_configured_duration(self):
+        with patch.object(shutdown_mod, "SHUTDOWN_DRAIN_SECONDS", 0.05):
+            t0 = time.monotonic()
+            result = await _drain()
+            elapsed = time.monotonic() - t0
+        assert result == "ok"
+        assert elapsed >= 0.04
+
+
+class TestShutdownLangfuse:
+    async def test_calls_shutdown(self):
+        mock_client = MagicMock()
+        mock_client.shutdown = MagicMock()
+        with patch(
+            "deep_agent.aegra.telemetry.get_langfuse_client", return_value=mock_client
+        ):
+            result = await _shutdown_langfuse()
+        assert result == "ok"
+        mock_client.shutdown.assert_called_once()
+
+    async def test_falls_back_to_flush(self):
+        mock_client = MagicMock(spec=[])
+        mock_client.flush = MagicMock()
+        with patch(
+            "deep_agent.aegra.telemetry.get_langfuse_client", return_value=mock_client
+        ):
+            result = await _shutdown_langfuse()
+        assert result == "ok"
+        mock_client.flush.assert_called_once()
+
+    async def test_skips_when_not_configured(self):
+        with patch(
+            "deep_agent.aegra.telemetry.get_langfuse_client", return_value=None
+        ):
+            result = await _shutdown_langfuse()
+        assert "skipped" in result
+
+    async def test_handles_timeout(self):
+        def slow_shutdown():
+            time.sleep(5)
+
+        mock_client = MagicMock()
+        mock_client.shutdown = slow_shutdown
+        with (
+            patch(
+                "deep_agent.aegra.telemetry.get_langfuse_client",
+                return_value=mock_client,
+            ),
+            patch.object(shutdown_mod, "SHUTDOWN_LANGFUSE_TIMEOUT_SECONDS", 0.1),
+        ):
+            result = await _shutdown_langfuse()
+        assert result == "timeout"
+
+    async def test_handles_exception(self):
+        mock_client = MagicMock()
+        mock_client.shutdown.side_effect = RuntimeError("boom")
+        with patch(
+            "deep_agent.aegra.telemetry.get_langfuse_client", return_value=mock_client
+        ):
+            result = await _shutdown_langfuse()
+        assert "error" in result
+
+
+class TestStopScheduler:
+    async def test_stops_scheduler(self):
+        with patch(
+            "deep_agent.src.memory.scheduler.stop_scheduler",
+            new_callable=AsyncMock,
+        ):
+            result = await _stop_scheduler()
+        assert result == "ok"
+
+    async def test_handles_timeout(self):
+        async def slow_stop():
+            await asyncio.sleep(10)
+
+        with (
+            patch(
+                "deep_agent.src.memory.scheduler.stop_scheduler",
+                side_effect=slow_stop,
+            ),
+            patch.object(shutdown_mod, "SHUTDOWN_SCHEDULER_TIMEOUT_SECONDS", 0.1),
+        ):
+            result = await _stop_scheduler()
+        assert result == "timeout"
+
+    async def test_handles_exception(self):
+        with patch(
+            "deep_agent.src.memory.scheduler.stop_scheduler",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("boom"),
+        ):
+            result = await _stop_scheduler()
+        assert "error" in result
+
+
+class TestClearGraphCache:
+    @pytest.fixture(autouse=True)
+    def _mock_graph_module(self):
+        """Pre-load a fake graph module to avoid langgraph_sdk import."""
+        import sys
+        import types
+
+        fake_graph = types.ModuleType("deep_agent.aegra.graph")
+        fake_graph._graph_cache = {}
+        fake_graph._graph_cache_ts = {}
+        self._fake_graph = fake_graph
+        sys.modules["deep_agent.aegra.graph"] = fake_graph
+        yield
+        sys.modules.pop("deep_agent.aegra.graph", None)
+
+    def test_clears_both_dicts(self):
+        self._fake_graph._graph_cache["key1"] = "value1"
+        self._fake_graph._graph_cache_ts["key1"] = 1234.0
+
+        result = _clear_graph_cache()
+
+        assert result == "ok"
+        assert len(self._fake_graph._graph_cache) == 0
+        assert len(self._fake_graph._graph_cache_ts) == 0
+
+    def test_ok_when_empty(self):
+        result = _clear_graph_cache()
+        assert result == "ok"
+
+
+class TestCloseRedis:
+    def test_calls_close(self):
+        with patch("deep_agent.aegra.redis.close_redis_client") as mock_close:
+            result = _close_redis()
+        assert result == "ok"
+        mock_close.assert_called_once()
+
+    def test_handles_exception(self):
+        with patch(
+            "deep_agent.aegra.redis.close_redis_client",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = _close_redis()
+        assert "error" in result
+
+
+class TestRunShutdownSync:
+    def test_noop_when_complete(self):
+        shutdown_mod._shutdown_complete = True
+        run_shutdown_sync()
+
+    def test_noop_when_shutting_down(self):
+        shutdown_mod._shutting_down = True
+        run_shutdown_sync()
+
+
+class TestRegisterSignalHandlers:
+    async def test_registers_on_running_loop(self):
+        import signal
+
+        register_signal_handlers()
+
+        loop = asyncio.get_running_loop()
+        assert loop.remove_signal_handler(signal.SIGTERM) is True
+        assert loop.remove_signal_handler(signal.SIGINT) is True


### PR DESCRIPTION
## Summary

- Adds a shutdown orchestrator (`shutdown.py`) that coordinates teardown on SIGTERM: drain in-flight requests, flush Langfuse traces, stop the memory scheduler, close Redis
- Three independent shutdown paths (FastAPI lifespan, signal handler, atexit) for reliability regardless of how Aegra handles the app lifecycle
- Health probes return 503 immediately on SIGTERM so OpenShift stops routing traffic during drain
- Configurable timeouts via `SHUTDOWN_DRAIN_SECONDS` (15), `SHUTDOWN_LANGFUSE_TIMEOUT_SECONDS` (5), `SHUTDOWN_SCHEDULER_TIMEOUT_SECONDS` (10) — fits within `terminationGracePeriodSeconds: 60`
- Fixes pre-existing bug: `await client.ping()` on sync Redis client in health check

## Test plan

- [x] 23 unit tests covering all shutdown steps, idempotency, timeouts, and failure isolation
- [x] 5 integration tests proving clean shutdown under concurrent load, health 503 during shutdown, Langfuse timeout resilience, and idempotent concurrent calls
- [x] All 560 existing unit tests pass — zero regressions
- [ ] Manual smoke test: `aegra dev`, send requests, `kill -TERM <pid>`, verify logs show ordered shutdown sequence