### PR TITLE
feat: Adds per-thread and per-user daily LLM token tracking with MongoDB persistence and OTEL metrics export

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,22 @@ REDIS_URL=redis://redis:6379/0
 REDIS_BROKER_ENABLED=true
 
 # MongoDB (platform token usage rollup — optional, set by deploy components)
-# MONGODB_URI=
+#
+# SECURITY: MONGODB_URI may contain credentials in the URI itself:
+#   mongodb://user:password@host:27017/tokenusage?authSource=tokenusage
+#
+# - NEVER commit a URI with credentials to version control.
+# - NEVER log or expose this value in error messages or debug output.
+# - In production, inject via secrets management:
+#     Kubernetes : mount as a Secret, reference via envFrom or env.valueFrom.secretKeyRef
+#     AWS        : use Secrets Manager or SSM Parameter Store with an operator/init container
+#     GCP        : use Secret Manager with Workload Identity
+#     Vault      : use the Vault Agent injector or ESO (External Secrets Operator)
+# - Scope the MongoDB user to read/write on the tokenusage DB only — no admin privileges.
+# - Rotate credentials without redeploying by updating the secret and triggering a rollout.
+#
+# Local dev (unauthenticated, never in production):
+# MONGODB_URI=mongodb://localhost:27017
 # MONGODB_DB=tokenusage
 
 # --- Observability ---

--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,10 @@ POSTGRES_PASSWORD=postgres
 REDIS_URL=redis://redis:6379/0
 REDIS_BROKER_ENABLED=true
 
+# MongoDB (platform token usage rollup — optional, set by deploy components)
+# MONGODB_URI=
+# MONGODB_DB=tokenusage
+
 # --- Observability ---
 
 # Langfuse (v4 SDK — auto-read by client and CallbackHandler)
@@ -44,6 +48,16 @@ LANGFUSE_PUBLIC_KEY=pk-lf-...
 LANGFUSE_SECRET_KEY=sk-lf-...
 LANGFUSE_BASE_URL=https://cloud.langfuse.com
 LANGFUSE_TRACING_ENVIRONMENT=development
+
+# OpenTelemetry (metrics → otel-gateway; traces → Jaeger)
+# For dev-loop integration: use compose.devloop.yaml which sets these automatically
+# ENABLE_OTEL_METRICS=false
+# OTEL_EXPORTER_OTLP_ENDPOINT=
+# ENABLE_OTEL_TRACES=false
+# OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4317
+# OTEL_SERVICE_NAME=template-agent
+# OTEL_AUTH_TOKEN=
+# OTEL_METRIC_EXPORT_INTERVAL_MILLIS=10000
 
 # --- Model Provider Credentials ---
 

--- a/config/agent/runtime/agent.yaml
+++ b/config/agent/runtime/agent.yaml
@@ -234,6 +234,12 @@ memory:
     interval_hours: 6
   max_inject: 20
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Token Budget                                                   [YAML-loaded]
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Tracks cumulative LLM tokens per conversation thread_id in MongoDB.
+token_budget:
+  enabled: true
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Observability                                                      [env-var]
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Langfuse auto-activates when secrets are provided. No additional config needed.

--- a/deep_agent/aegra/feedback.py
+++ b/deep_agent/aegra/feedback.py
@@ -17,7 +17,9 @@ import json
 from typing import Any, Literal
 from uuid import uuid4
 
-from fastapi import FastAPI, Request
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -73,7 +75,19 @@ from deep_agent.aegra.shutdown import register_atexit
 
 register_atexit()
 
-app = FastAPI(title="template-agent-custom")
+
+@asynccontextmanager
+async def _lifespan(_app: FastAPI):
+    from deep_agent.aegra.startup import run_startup
+    from deep_agent.src.observability.otel_setup import setup_otel_metrics, setup_otel_traces
+
+    await run_startup()
+    setup_otel_metrics(settings, logger)
+    setup_otel_traces(_app, settings, logger)
+    yield
+
+
+app = FastAPI(title="template-agent-custom", lifespan=_lifespan)
 
 
 class TraceIDMiddleware(BaseHTTPMiddleware):
@@ -286,6 +300,33 @@ async def get_thread_feedback(
     repo = FeedbackRepository(settings.database_uri)
     items = await repo.list_feedback(thread_id, user_id)
     return {"feedback": items}
+
+
+@app.get("/threads/{thread_id}/token-usage")
+async def get_thread_token_usage_endpoint(thread_id: str) -> dict[str, Any]:
+    """Return cumulative token usage for a thread."""
+    from dataclasses import asdict
+
+    from deep_agent.src.token_budget.service import (
+        TokenUsageNotFoundError,
+        TokenUsageUnavailableError,
+        get_thread_token_usage,
+    )
+
+    try:
+        usage = await get_thread_token_usage(thread_id)
+    except TokenUsageNotFoundError:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No token usage for thread {thread_id}",
+        ) from None
+    except TokenUsageUnavailableError:
+        raise HTTPException(
+            status_code=503,
+            detail="Token usage storage unavailable",
+        ) from None
+
+    return asdict(usage)
 
 
 @app.get("/info")

--- a/deep_agent/aegra/feedback.py
+++ b/deep_agent/aegra/feedback.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import json
 from typing import Any, Literal
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from contextlib import asynccontextmanager
 
@@ -290,11 +290,22 @@ async def feedback_handler(request: Request) -> JSONResponse:
     )
 
 
+def _validate_thread_id(thread_id: str) -> str:
+    """Validate that thread_id is a well-formed UUID."""
+    try:
+        return str(UUID(thread_id))
+    except ValueError:
+        raise HTTPException(
+            status_code=400, detail="Invalid thread_id format (expected UUID)"
+        ) from None
+
+
 @app.get("/feedback/{thread_id}")
 async def get_thread_feedback(
     thread_id: str, user_id: str = "anonymous"
 ) -> dict[str, Any]:
     """Return all feedback for a thread."""
+    thread_id = _validate_thread_id(thread_id)
     if not settings.database_uri:
         return {"feedback": []}
     repo = FeedbackRepository(settings.database_uri)
@@ -305,6 +316,7 @@ async def get_thread_feedback(
 @app.get("/threads/{thread_id}/token-usage")
 async def get_thread_token_usage_endpoint(thread_id: str) -> dict[str, Any]:
     """Return cumulative token usage for a thread."""
+    thread_id = _validate_thread_id(thread_id)
     from dataclasses import asdict
 
     from deep_agent.src.token_budget.service import (

--- a/deep_agent/aegra/startup.py
+++ b/deep_agent/aegra/startup.py
@@ -16,6 +16,7 @@ This module is idempotent — calling ``run_startup()`` multiple
 times is safe (each step guards against double-init).
 """
 
+import asyncio
 import time
 
 from deep_agent.utils.pylogger import get_python_logger
@@ -81,7 +82,7 @@ async def _validate_config() -> str:
 
 
 async def _ensure_database() -> str:
-    """Create personalization and feedback tables if they don't exist."""
+    """Create personalization, feedback, and token budget tables if they don't exist."""
     try:
         from deep_agent.src.feedback.repository import FeedbackRepository
         from deep_agent.src.personalization.repository import (
@@ -89,13 +90,29 @@ async def _ensure_database() -> str:
         )
         from deep_agent.src.settings import settings
 
-        if not settings.database_uri:
-            return "skipped: no database_uri"
+        setup_tasks = []
 
-        repo = PersonalizationRepository(settings.database_uri)
-        await repo.ensure_tables()
-        feedback_repo = FeedbackRepository(settings.database_uri)
-        await feedback_repo.ensure_table()
+        if settings.database_uri:
+            personalization_repo = PersonalizationRepository(settings.database_uri)
+            feedback_repo = FeedbackRepository(settings.database_uri)
+            setup_tasks.append(personalization_repo.ensure_tables())
+            setup_tasks.append(feedback_repo.ensure_table())
+
+        if settings.MONGODB_URI:
+            from deep_agent.src.token_budget.mongo_repository import (
+                TokenUsageMongoRepository,
+            )
+
+            mongo_repo = TokenUsageMongoRepository(
+                settings.MONGODB_URI,
+                db_name=settings.MONGODB_DB,
+            )
+            setup_tasks.append(mongo_repo.ensure_indexes())
+
+        if not setup_tasks:
+            return "skipped: no database configured"
+
+        await asyncio.gather(*setup_tasks)
         return "ok"
     except Exception as exc:
         logger.error("Database setup failed: %s", exc)
@@ -138,11 +155,15 @@ async def _start_scheduler() -> str:
 
 
 def _setup_telemetry() -> str:
-    """Register Langfuse tracing if credentials are configured."""
+    """Register Langfuse tracing and token budget tracking if configured."""
     try:
-        from deep_agent.aegra.telemetry import setup_langfuse_tracing
+        from deep_agent.aegra.telemetry import (
+            setup_langfuse_tracing,
+            setup_token_budget_tracking,
+        )
 
         setup_langfuse_tracing()
+        setup_token_budget_tracking()  # Callback-based tracking
         return "ok"
     except Exception as exc:
         logger.warning("Telemetry setup failed: %s", exc)

--- a/deep_agent/aegra/telemetry.py
+++ b/deep_agent/aegra/telemetry.py
@@ -1,8 +1,9 @@
-"""Langfuse integration for aegra deployment.
+"""Langfuse and token budget observability for aegra deployment.
 
 Provides:
 - Langfuse callback handler factory for LangChain tracing (v4 SDK)
 - Langfuse client accessor via ``get_langfuse_client()``
+- Token budget LangChain callback registration and metadata provider
 
 Environment variables (Langfuse — auto-read by v4 SDK):
     LANGFUSE_PUBLIC_KEY: Langfuse public key
@@ -11,6 +12,7 @@ Environment variables (Langfuse — auto-read by v4 SDK):
     LANGFUSE_TRACING_ENVIRONMENT: Environment tag (e.g. development, production)
 """
 
+import contextvars
 import os
 from typing import Any
 
@@ -24,6 +26,7 @@ logger = get_python_logger()
 # ---------------------------------------------------------------------------
 
 _langfuse_tracing_initialized = False
+_token_budget_tracing_initialized = False
 
 
 def _get_trace_name() -> str:
@@ -68,8 +71,6 @@ def setup_langfuse_tracing() -> None:
         return
 
     try:
-        import contextvars
-
         from langchain_core.tracers.context import register_configure_hook
         from langfuse.langchain import CallbackHandler
 
@@ -138,6 +139,96 @@ class LangfuseObservabilityProvider:
     def is_enabled(self) -> bool:
         """Return True if Langfuse credentials are configured."""
         return _langfuse_configured()
+
+
+# ---------------------------------------------------------------------------
+# Token budget callback integration
+# ---------------------------------------------------------------------------
+
+
+class TokenBudgetObservabilityProvider:
+    """Inject thread_id into RunnableConfig metadata for the token budget callback."""
+
+    def get_callbacks(self) -> list[Any]:
+        """Return empty list — callbacks are handled by register_configure_hook."""
+        return []
+
+    def get_metadata(
+        self, run_id: str, thread_id: str, user_identity: str | None = None
+    ) -> dict[str, Any]:
+        from deep_agent.src.token_budget.callback import (
+            THREAD_ID_METADATA_KEY,
+            USER_ID_METADATA_KEY,
+        )
+
+        metadata: dict[str, Any] = {}
+        if thread_id:
+            metadata[THREAD_ID_METADATA_KEY] = thread_id
+        if user_identity:
+            metadata[USER_ID_METADATA_KEY] = user_identity
+        return metadata
+
+    def is_enabled(self) -> bool:
+        try:
+            from deep_agent.src.agent.config import agent_config
+
+            return agent_config.get_token_budget_config().is_active
+        except Exception:
+            return False
+
+
+def setup_token_budget_tracking() -> None:
+    """Register token budget LangChain callback and Aegra metadata provider."""
+    global _token_budget_tracing_initialized
+    if _token_budget_tracing_initialized:
+        return
+    _token_budget_tracing_initialized = True
+
+    try:
+        from deep_agent.src.agent.config import agent_config
+
+        if not agent_config.get_token_budget_config().is_active:
+            logger.info("Token budget disabled — callback registration skipped")
+            return
+    except Exception:
+        logger.debug("Token budget config unavailable — skipping callback registration")
+        return
+
+    try:
+        from langchain_core.tracers.context import register_configure_hook
+
+        from deep_agent.src.token_budget.callback import TokenBudgetCallbackHandler
+
+        _token_budget_ctx_var: contextvars.ContextVar = contextvars.ContextVar(
+            "token_budget_handler", default=None
+        )
+        os.environ.setdefault("TOKEN_BUDGET_TRACKING", "1")
+        register_configure_hook(
+            _token_budget_ctx_var,
+            True,
+            TokenBudgetCallbackHandler,
+            env_var="TOKEN_BUDGET_TRACKING",
+        )
+        logger.info("Token budget callback registered for all LangChain runs")
+    except ImportError:
+        logger.warning("langchain_core not available — token budget callback disabled")
+        return
+    except Exception:
+        logger.warning("Failed to register token budget callback", exc_info=True)
+        return
+
+    try:
+        from aegra_api.observability.base import get_observability_manager
+
+        manager = get_observability_manager()
+        manager.register_provider(TokenBudgetObservabilityProvider())
+        logger.info("Token budget observability provider registered with Aegra")
+    except ImportError:
+        logger.debug("aegra_api not available — skipping token budget provider")
+    except Exception:
+        logger.warning(
+            "Failed to register token budget observability provider", exc_info=True
+        )
 
 
 def get_langfuse_client() -> Any:

--- a/deep_agent/src/agent/config/loader.py
+++ b/deep_agent/src/agent/config/loader.py
@@ -23,6 +23,7 @@ import yaml
 
 from deep_agent.src.exceptions import AppException, ErrorCodes
 from deep_agent.src.settings import settings
+from deep_agent.src.token_budget.config import TokenBudgetConfig
 from deep_agent.utils.pylogger import get_python_logger
 
 from .cache import CacheFileConfig
@@ -65,6 +66,7 @@ class AgentConfig:
     _filesystem_config: FilesystemFileConfig
     _providers_config: ProvidersFileConfig
     _cache_config: CacheFileConfig
+    _token_budget_config: TokenBudgetConfig
     _name: str
 
     def __new__(cls, base_dir: Path | None = None) -> "AgentConfig":
@@ -157,6 +159,11 @@ class AgentConfig:
 
         # Extract cache section
         self._cache_config = CacheFileConfig.model_validate(raw.get("cache", {}))
+
+        # Extract token budget section
+        self._token_budget_config = TokenBudgetConfig.model_validate(
+            raw.get("token_budget", {})
+        )
 
         # Extract top-level identity
         self._name = raw.get("name", "Agent")
@@ -387,6 +394,11 @@ class AgentConfig:
         """
         self._ensure_loaded()
         return self._cache_config
+
+    def get_token_budget_config(self) -> TokenBudgetConfig:
+        """Get the pre-loaded per-thread token budget configuration."""
+        self._ensure_loaded()
+        return self._token_budget_config
 
     def get_name(self) -> str:
         """Get the agent display name from config.

--- a/deep_agent/src/error_handling.py
+++ b/deep_agent/src/error_handling.py
@@ -88,6 +88,36 @@ subagent_retry = retry(
     reraise=True,
 )
 
+try:
+    from pymongo.errors import (
+        AutoReconnect,
+        ConnectionFailure,
+        NetworkTimeout,
+        NotPrimaryError,
+        ServerSelectionTimeoutError,
+    )
+
+    _MONGO_TRANSIENT_ERRORS: tuple[type[Exception], ...] = (
+        AutoReconnect,
+        ConnectionFailure,
+        NetworkTimeout,
+        NotPrimaryError,
+        ServerSelectionTimeoutError,
+        ConnectionError,
+        TimeoutError,
+        OSError,
+    )
+except ImportError:  # pragma: no cover - pymongo optional at import time
+    _MONGO_TRANSIENT_ERRORS = (ConnectionError, TimeoutError, OSError)
+
+mongo_retry = retry(
+    retry=retry_if_exception_type(_MONGO_TRANSIENT_ERRORS),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=0.2, min=0.1, max=2),
+    before_sleep=_log_retry,
+    reraise=True,
+)
+
 
 # ---------------------------------------------------------------------------
 # Circuit Breaker

--- a/deep_agent/src/infrastructure/subagents.py
+++ b/deep_agent/src/infrastructure/subagents.py
@@ -366,6 +366,7 @@ def _build_default_subagent(
 
     # Build fallback middleware if spec has fallback configured
     fallback_mw = _build_fallback_middleware(spec)
+    subagent_middleware = [*fallback_mw]
 
     subagent_params: dict[str, Any] = {
         "name": name,
@@ -378,8 +379,8 @@ def _build_default_subagent(
         subagent_params["tools"] = resolved_tools
     if skill_paths:
         subagent_params["skills"] = skill_paths
-    if fallback_mw:
-        subagent_params["middleware"] = fallback_mw
+    if subagent_middleware:
+        subagent_params["middleware"] = subagent_middleware
 
     return SubAgent(**subagent_params)
 
@@ -431,6 +432,7 @@ def _build_compiled_subagent(
 
     # Build fallback middleware if spec has fallback configured
     fallback_mw = _build_fallback_middleware(spec)
+    compiled_middleware = [*fallback_mw]
 
     create_kwargs = {
         "name": name,
@@ -441,8 +443,8 @@ def _build_compiled_subagent(
         "backend": get_configured_backend(),
     }
 
-    if fallback_mw:
-        create_kwargs["middleware"] = fallback_mw
+    if compiled_middleware:
+        create_kwargs["middleware"] = compiled_middleware
 
     compiled_graph = create_deep_agent(**create_kwargs)
 

--- a/deep_agent/src/observability/__init__.py
+++ b/deep_agent/src/observability/__init__.py
@@ -1,0 +1,1 @@
+"""Observability package."""

--- a/deep_agent/src/observability/otel_setup.py
+++ b/deep_agent/src/observability/otel_setup.py
@@ -1,0 +1,131 @@
+"""OTLP metrics (otel-gateway) and traces bootstrap."""
+
+from __future__ import annotations
+
+from typing import Any
+
+_fastapi_instrumented = False
+_metrics_initialized = False
+_traces_initialized = False
+_service_resource = None
+
+
+def _service_resource_for(settings: Any) -> Any:
+    """Return a shared OTEL resource for metrics and traces providers."""
+    global _service_resource  # noqa: PLW0603
+
+    if _service_resource is None:
+        from opentelemetry.sdk.resources import Resource
+
+        _service_resource = Resource.create(
+            {"service.name": settings.OTEL_SERVICE_NAME}
+        )
+    return _service_resource
+
+
+def _otlp_grpc_exporter_kwargs(endpoint: str, settings: Any) -> dict[str, Any]:
+    """Build OTLP/gRPC exporter kwargs from a config endpoint string."""
+    raw = endpoint.strip()
+    kwargs: dict[str, Any] = {}
+    lower = raw.lower()
+    if lower.startswith("https://"):
+        kwargs["endpoint"] = raw[len("https://") :]
+    elif lower.startswith("http://"):
+        kwargs["endpoint"] = raw[len("http://") :]
+        kwargs["insecure"] = True
+    else:
+        kwargs["endpoint"] = raw
+        kwargs["insecure"] = True
+    token = (getattr(settings, "OTEL_AUTH_TOKEN", None) or "").strip()
+    if token and not token.startswith("<"):
+        kwargs["headers"] = (("authorization", f"Bearer {token}"),)
+    return kwargs
+
+
+def _instrument_fastapi(app: Any, log: Any) -> None:
+    """HTTP server metrics + traces (needs MeterProvider and/or TracerProvider set first)."""
+    global _fastapi_instrumented  # noqa: PLW0603
+    if _fastapi_instrumented:
+        return
+    try:
+        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+        FastAPIInstrumentor.instrument_app(app)
+        _fastapi_instrumented = True
+    except Exception:
+        log.warning("template_agent_fastapi_instrument_failed", exc_info=True)
+
+
+def setup_otel_metrics(settings: Any, log: Any) -> None:
+    """Export OTLP metrics to OTEL_EXPORTER_OTLP_ENDPOINT when enabled."""
+    global _metrics_initialized  # noqa: PLW0603
+
+    if _metrics_initialized:
+        return
+    if not settings.ENABLE_OTEL_METRICS or not settings.OTEL_EXPORTER_OTLP_ENDPOINT:
+        return
+
+    try:
+        from opentelemetry import metrics
+        from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+            OTLPMetricExporter,
+        )
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+
+        resource = _service_resource_for(settings)
+        exporter = OTLPMetricExporter(
+            **_otlp_grpc_exporter_kwargs(
+                settings.OTEL_EXPORTER_OTLP_ENDPOINT, settings
+            )
+        )
+        reader = PeriodicExportingMetricReader(
+            exporter,
+            export_interval_millis=settings.OTEL_METRIC_EXPORT_INTERVAL_MILLIS,
+        )
+        provider = MeterProvider(resource=resource, metric_readers=[reader])
+        metrics.set_meter_provider(provider)
+        _metrics_initialized = True
+        log.info("template_agent_otel_metrics_export_enabled")
+    except Exception:
+        log.warning("template_agent_otel_metrics_export_failed", exc_info=True)
+
+
+def setup_otel_traces(app: Any, settings: Any, log: Any) -> None:
+    """Export OTLP traces when enabled; instrument FastAPI when metrics or traces on."""
+    global _traces_initialized  # noqa: PLW0603
+
+    traces_endpoint = settings.resolved_otel_traces_endpoint()
+    metrics_on = bool(
+        settings.ENABLE_OTEL_METRICS and settings.OTEL_EXPORTER_OTLP_ENDPOINT
+    )
+    traces_on = bool(settings.otel_traces_active() and traces_endpoint)
+
+    if not metrics_on and not traces_on:
+        return
+
+    if traces_on and not _traces_initialized:
+        try:
+            from opentelemetry import trace
+            from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+                OTLPSpanExporter,
+            )
+            from opentelemetry.sdk.trace import TracerProvider
+            from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+            resource = _service_resource_for(settings)
+            provider = TracerProvider(resource=resource)
+            processor = BatchSpanProcessor(
+                OTLPSpanExporter(
+                    **_otlp_grpc_exporter_kwargs(traces_endpoint, settings)
+                )
+            )
+            provider.add_span_processor(processor)
+            trace.set_tracer_provider(provider)
+            _traces_initialized = True
+            log.info("template_agent_otel_tracing_enabled")
+        except Exception:
+            log.warning("template_agent_otel_tracing_failed", exc_info=True)
+
+    if metrics_on or traces_on:
+        _instrument_fastapi(app, log)

--- a/deep_agent/src/settings.py
+++ b/deep_agent/src/settings.py
@@ -66,6 +66,10 @@ class Settings(BaseSettings):
     POSTGRES_USER: str = Field(default="postgres")
     POSTGRES_PASSWORD: str = Field(default="postgres")
 
+    # ── MongoDB ───────────────────────────────────────────────────────
+    MONGODB_URI: Optional[str] = Field(default=None)
+    MONGODB_DB: str = Field(default="tokenusage")
+
     # ── Redis ─────────────────────────────────────────────────────────
     REDIS_URL: str = Field(default="redis://redis:6379/0")
     REDIS_BROKER_ENABLED: bool = Field(default=True)
@@ -84,6 +88,29 @@ class Settings(BaseSettings):
     LANGFUSE_SECRET_KEY: Optional[str] = Field(default=None)
     LANGFUSE_BASE_URL: Optional[str] = Field(default=None)
     LANGFUSE_TRACING_ENVIRONMENT: str = Field(default="development")
+
+    # ── OpenTelemetry ─────────────────────────────────────────────────
+    ENABLE_OTEL_METRICS: bool = Field(default=False)
+    ENABLE_OTEL_TRACES: bool = Field(default=False)
+    OTEL_SERVICE_NAME: str = Field(default="template-agent")
+    OTEL_EXPORTER_OTLP_ENDPOINT: str = Field(
+        default="",
+        description="OTLP gRPC metrics endpoint (OpenShift: otel-gateway:4327)",
+    )
+    OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: str = Field(
+        default="",
+        description="OTLP gRPC traces endpoint (local/dev-loop: Jaeger :4317)",
+    )
+    OTEL_AUTH_TOKEN: str = Field(default="", repr=False)
+    OTEL_METRIC_EXPORT_INTERVAL_MILLIS: int = Field(default=10000)
+
+    def resolved_otel_traces_endpoint(self) -> str:
+        return self.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+
+    def otel_traces_active(self) -> bool:
+        return bool(
+            self.ENABLE_OTEL_TRACES and self.resolved_otel_traces_endpoint()
+        )
 
     # ── Google Cloud ──────────────────────────────────────────────────
     GOOGLE_APPLICATION_CREDENTIALS_CONTENT: Optional[str] = Field(default=None)

--- a/deep_agent/src/settings.py
+++ b/deep_agent/src/settings.py
@@ -67,7 +67,7 @@ class Settings(BaseSettings):
     POSTGRES_PASSWORD: str = Field(default="postgres")
 
     # ── MongoDB ───────────────────────────────────────────────────────
-    MONGODB_URI: Optional[str] = Field(default=None)
+    MONGODB_URI: Optional[str] = Field(default=None, repr=False)
     MONGODB_DB: str = Field(default="tokenusage")
 
     # ── Redis ─────────────────────────────────────────────────────────

--- a/deep_agent/src/token_budget/__init__.py
+++ b/deep_agent/src/token_budget/__init__.py
@@ -1,0 +1,1 @@
+"""Thread-level token budget tracking and threshold warnings."""

--- a/deep_agent/src/token_budget/callback.py
+++ b/deep_agent/src/token_budget/callback.py
@@ -1,0 +1,113 @@
+"""LangChain callback handler for per-thread token budget tracking."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.callbacks import AsyncCallbackHandler
+from langchain_core.outputs import ChatGeneration, LLMResult
+
+from deep_agent.src.token_budget.identity import resolve_thread_id, resolve_user_id
+from deep_agent.src.token_budget.service import (
+    check_and_record,
+    extract_tokens_from_llm_result,
+    extract_tokens_from_message,
+)
+from deep_agent.utils.pylogger import get_python_logger
+
+logger = get_python_logger()
+
+THREAD_ID_METADATA_KEY = "token_budget_thread_id"
+USER_ID_METADATA_KEY = "token_budget_user_id"
+
+
+def _extract_from_metadata(
+    metadata: dict[str, Any] | None,
+    key: str,
+    *,
+    fallback_keys: tuple[str, ...] = (),
+) -> str | None:
+    """Return the first non-empty metadata value for key or fallback keys."""
+    if not metadata:
+        return None
+    for metadata_key in (key, *fallback_keys):
+        value = metadata.get(metadata_key)
+        if value:
+            return str(value)
+    return None
+
+
+def thread_id_from_metadata(metadata: dict[str, Any] | None) -> str | None:
+    """Resolve thread_id from RunnableConfig metadata."""
+    return _extract_from_metadata(
+        metadata,
+        THREAD_ID_METADATA_KEY,
+        fallback_keys=("langfuse_session_id",),
+    )
+
+
+def user_id_from_metadata(metadata: dict[str, Any] | None) -> str | None:
+    """Resolve the chatting user's id from RunnableConfig metadata."""
+    return _extract_from_metadata(metadata, USER_ID_METADATA_KEY)
+
+
+class TokenBudgetCallbackHandler(AsyncCallbackHandler):
+    """Increment per-thread token usage after each LLM call."""
+
+    async def _record_tokens(
+        self,
+        response: LLMResult,
+        metadata: dict[str, Any] | None,
+        extraction_fn: Any,
+    ) -> None:
+        """Shared logic for recording token usage from LLM responses."""
+        thread_id = thread_id_from_metadata(metadata) or resolve_thread_id()
+        if not thread_id:
+            logger.debug("token_budget_callback_no_thread_id")
+            return
+
+        user_id = user_id_from_metadata(metadata) or resolve_user_id()
+
+        input_tokens, output_tokens = extraction_fn(response)
+        if input_tokens <= 0 and output_tokens <= 0:
+            input_tokens, output_tokens = _tokens_from_generations(response)
+
+        try:
+            await check_and_record(
+                thread_id,
+                input_tokens,
+                output_tokens,
+                user_id=user_id,
+            )
+        except Exception:
+            logger.warning(
+                "token_budget_callback_failed",
+                thread_id=thread_id,
+                exc_info=True,
+            )
+
+    async def on_llm_end(
+        self,
+        response: LLMResult,
+        *,
+        run_id: Any,
+        parent_run_id: Any | None = None,
+        tags: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        await self._record_tokens(response, metadata, extract_tokens_from_llm_result)
+
+
+def _tokens_from_generations(response: LLMResult) -> tuple[int, int]:
+    input_tokens = 0
+    output_tokens = 0
+    for generation_list in response.generations:
+        for generation in generation_list:
+            if not isinstance(generation, ChatGeneration):
+                continue
+            message = generation.message
+            in_t, out_t = extract_tokens_from_message(message)
+            input_tokens += in_t
+            output_tokens += out_t
+    return input_tokens, output_tokens

--- a/deep_agent/src/token_budget/callback.py
+++ b/deep_agent/src/token_budget/callback.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from typing import Any
 
 from langchain_core.callbacks import AsyncCallbackHandler
@@ -19,6 +20,35 @@ logger = get_python_logger()
 
 THREAD_ID_METADATA_KEY = "token_budget_thread_id"
 USER_ID_METADATA_KEY = "token_budget_user_id"
+
+# Emit an ERROR-level alert after this many consecutive failures so ops
+# teams can detect a persistently degraded token-tracking feature.
+_CONSECUTIVE_FAILURE_ALERT_THRESHOLD = 5
+
+_counter_lock = threading.Lock()
+_consecutive_failures = 0
+_total_failures = 0
+
+
+def _on_tracking_success() -> None:
+    global _consecutive_failures
+    with _counter_lock:
+        _consecutive_failures = 0
+
+
+def _on_tracking_failure() -> None:
+    global _consecutive_failures, _total_failures
+    with _counter_lock:
+        _consecutive_failures += 1
+        _total_failures += 1
+        consecutive = _consecutive_failures
+        total = _total_failures
+    if consecutive >= _CONSECUTIVE_FAILURE_ALERT_THRESHOLD:
+        logger.error(
+            "token_budget_tracking_degraded",
+            consecutive_failures=consecutive,
+            total_failures=total,
+        )
 
 
 def _extract_from_metadata(
@@ -79,12 +109,13 @@ class TokenBudgetCallbackHandler(AsyncCallbackHandler):
                 output_tokens,
                 user_id=user_id,
             )
+            _on_tracking_success()
         except Exception:
             logger.warning(
                 "token_budget_callback_failed",
-                thread_id=thread_id,
                 exc_info=True,
             )
+            _on_tracking_failure()
 
     async def on_llm_end(
         self,

--- a/deep_agent/src/token_budget/config.py
+++ b/deep_agent/src/token_budget/config.py
@@ -1,0 +1,16 @@
+"""Token budget configuration models."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class TokenBudgetConfig(BaseModel):
+    """Per-thread token usage tracking from agent.yaml ``token_budget:`` section."""
+
+    enabled: bool = False
+
+    @property
+    def is_active(self) -> bool:
+        """Return True when tracking should run."""
+        return self.enabled

--- a/deep_agent/src/token_budget/identity.py
+++ b/deep_agent/src/token_budget/identity.py
@@ -1,0 +1,51 @@
+"""Resolve thread and user identity from LangGraph RunnableConfig."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langgraph.runtime import Runtime
+
+
+def resolve_thread_id(runtime: Runtime[Any] | None = None) -> str | None:
+    """Resolve thread_id from LangGraph runtime or active RunnableConfig."""
+    if runtime is not None:
+        execution_info = getattr(runtime, "execution_info", None)
+        if execution_info is not None:
+            thread_id = getattr(execution_info, "thread_id", None)
+            if thread_id:
+                return str(thread_id)
+
+    try:
+        from langgraph.config import get_config
+
+        config = get_config()
+        configurable = config.get("configurable") or {}
+        thread_id = configurable.get("thread_id")
+        if thread_id:
+            return str(thread_id)
+    except Exception:
+        pass
+    return None
+
+
+def resolve_user_id(runtime: Runtime[Any] | None = None) -> str | None:
+    """Resolve chatting user_id from LangGraph runtime or active RunnableConfig."""
+    if runtime is not None:
+        execution_info = getattr(runtime, "execution_info", None)
+        if execution_info is not None:
+            user_id = getattr(execution_info, "user_id", None)
+            if user_id:
+                return str(user_id)
+
+    try:
+        from langgraph.config import get_config
+
+        config = get_config()
+        configurable = config.get("configurable") or {}
+        user_id = configurable.get("user_id")
+        if user_id:
+            return str(user_id)
+    except Exception:
+        pass
+    return None

--- a/deep_agent/src/token_budget/mongo_repository.py
+++ b/deep_agent/src/token_budget/mongo_repository.py
@@ -1,0 +1,141 @@
+"""MongoDB store for per-thread and per-user daily token usage."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from motor.motor_asyncio import AsyncIOMotorClient
+from pymongo import ReturnDocument
+
+from deep_agent.src.error_handling import mongo_retry
+from deep_agent.utils.pylogger import get_python_logger
+
+logger = get_python_logger()
+
+_INDEXES_ENSURED = False
+
+
+class TokenUsageMongoRepository:
+    """MongoDB token usage: per-thread counts and per-user daily rollup."""
+
+    def __init__(self, mongodb_uri: str, db_name: str) -> None:
+        self._uri = mongodb_uri
+        self._db_name = db_name
+        self._client: AsyncIOMotorClient | None = None
+
+    def _get_client(self) -> AsyncIOMotorClient:
+        if self._client is None:
+            self._client = AsyncIOMotorClient(self._uri)
+        return self._client
+
+    @property
+    def _db(self):
+        return self._get_client()[self._db_name]
+
+    @property
+    def _thread_collection(self):
+        return self._db["thread_token_usage"]
+
+    @property
+    def _daily_collection(self):
+        return self._db["user_daily_token_usage"]
+
+    @mongo_retry
+    async def ensure_indexes(self) -> None:
+        """Create indexes once per process (also invoked from startup)."""
+        global _INDEXES_ENSURED  # noqa: PLW0603
+        if _INDEXES_ENSURED:
+            return
+        await self._thread_collection.create_index("thread_id", unique=True)
+        await self._thread_collection.create_index("updated_at")
+        await self._daily_collection.create_index(
+            [("user_id", 1), ("date", 1)],
+            unique=True,
+        )
+        await self._daily_collection.create_index("date")
+        _INDEXES_ENSURED = True
+        logger.info("MongoDB token usage indexes ensured")
+
+    @mongo_retry
+    async def increment_usage(
+        self,
+        thread_id: str,
+        input_tokens: int,
+        output_tokens: int,
+        *,
+        agent_name: str | None = None,
+    ) -> dict[str, Any]:
+        """Atomically add tokens for a thread and return the updated document."""
+        input_tokens = max(input_tokens, 0)
+        output_tokens = max(output_tokens, 0)
+        total_delta = input_tokens + output_tokens
+        now = datetime.now(UTC)
+
+        update: dict[str, Any] = {
+            "$inc": {
+                "total_tokens": total_delta,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            },
+            "$set": {"updated_at": now},
+            "$setOnInsert": {"thread_id": thread_id},
+        }
+        if agent_name:
+            update["$set"]["agent_name"] = agent_name
+
+        result = await self._thread_collection.find_one_and_update(
+            {"thread_id": thread_id},
+            update,
+            upsert=True,
+            return_document=ReturnDocument.AFTER,
+        )
+        if result is None:
+            raise RuntimeError(f"Failed to increment Mongo token usage for {thread_id}")
+        return result
+
+    @mongo_retry
+    async def increment_daily_usage(
+        self,
+        user_id: str,
+        tokens: int,
+        *,
+        date: str | None = None,
+    ) -> dict[str, Any]:
+        """Increment a user's total token usage for a UTC calendar day."""
+        tokens = max(tokens, 0)
+        day = date or datetime.now(UTC).strftime("%Y-%m-%d")
+        now = datetime.now(UTC)
+
+        result = await self._daily_collection.find_one_and_update(
+            {"user_id": user_id, "date": day},
+            {
+                "$inc": {"total_tokens": tokens},
+                "$set": {"updated_at": now},
+                "$setOnInsert": {"user_id": user_id, "date": day},
+            },
+            upsert=True,
+            return_document=ReturnDocument.AFTER,
+        )
+        if result is None:
+            raise RuntimeError(f"Failed to increment daily usage for {user_id} on {day}")
+        return result
+
+    @mongo_retry
+    async def get_thread_usage(self, thread_id: str) -> dict[str, Any] | None:
+        return await self._thread_collection.find_one({"thread_id": thread_id})
+
+    @mongo_retry
+    async def get_daily_usage(
+        self,
+        user_id: str,
+        *,
+        date: str | None = None,
+    ) -> dict[str, Any] | None:
+        day = date or datetime.now(UTC).strftime("%Y-%m-%d")
+        return await self._daily_collection.find_one({"user_id": user_id, "date": day})
+
+    async def close(self) -> None:
+        if self._client is not None:
+            self._client.close()
+            self._client = None

--- a/deep_agent/src/token_budget/mongo_repository.py
+++ b/deep_agent/src/token_budget/mongo_repository.py
@@ -1,9 +1,31 @@
-"""MongoDB store for per-thread and per-user daily token usage."""
+"""MongoDB store for per-thread and per-user daily token usage.
+
+Security:
+    MONGODB_URI may contain credentials. It MUST NOT be logged, included in
+    error messages, or exposed via API responses. In production the URI should
+    authenticate as a user with read/write access to the tokenusage DB only
+    (principle of least privilege — no admin or cluster-wide access).
+"""
 
 from __future__ import annotations
 
+import re
 from datetime import UTC, datetime
 from typing import Any
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _validated_date(date: str | None) -> str:
+    """Return *date* unchanged if it matches YYYY-MM-DD, else raise ValueError.
+
+    When *date* is None the current UTC date is returned.
+    """
+    if date is None:
+        return datetime.now(UTC).strftime("%Y-%m-%d")
+    if not _DATE_RE.match(date):
+        raise ValueError(f"Invalid date format {date!r}, expected YYYY-MM-DD")
+    return date
 
 from motor.motor_asyncio import AsyncIOMotorClient
 from pymongo import ReturnDocument
@@ -24,6 +46,9 @@ class TokenUsageMongoRepository:
         self._db_name = db_name
         self._client: AsyncIOMotorClient | None = None
 
+    def __repr__(self) -> str:
+        return f"TokenUsageMongoRepository(db={self._db_name!r})"
+
     def _get_client(self) -> AsyncIOMotorClient:
         if self._client is None:
             self._client = AsyncIOMotorClient(self._uri)
@@ -43,7 +68,17 @@ class TokenUsageMongoRepository:
 
     @mongo_retry
     async def ensure_indexes(self) -> None:
-        """Create indexes once per process (also invoked from startup)."""
+        """Create indexes idempotently once per process.
+
+        MongoDB create_index is a no-op if the index already exists, so
+        concurrent calls from multiple replicas are safe (no data corruption).
+        The _INDEXES_ENSURED flag avoids redundant network calls within a
+        single process.
+
+        For large-scale deployments with many replicas starting simultaneously,
+        consider running index creation via a one-off migration job instead of
+        at application startup to avoid thundering-herd load on the DB.
+        """
         global _INDEXES_ENSURED  # noqa: PLW0603
         if _INDEXES_ENSURED:
             return
@@ -91,7 +126,7 @@ class TokenUsageMongoRepository:
             return_document=ReturnDocument.AFTER,
         )
         if result is None:
-            raise RuntimeError(f"Failed to increment Mongo token usage for {thread_id}")
+            raise RuntimeError("Failed to increment Mongo token usage")
         return result
 
     @mongo_retry
@@ -104,7 +139,7 @@ class TokenUsageMongoRepository:
     ) -> dict[str, Any]:
         """Increment a user's total token usage for a UTC calendar day."""
         tokens = max(tokens, 0)
-        day = date or datetime.now(UTC).strftime("%Y-%m-%d")
+        day = _validated_date(date)
         now = datetime.now(UTC)
 
         result = await self._daily_collection.find_one_and_update(
@@ -118,7 +153,7 @@ class TokenUsageMongoRepository:
             return_document=ReturnDocument.AFTER,
         )
         if result is None:
-            raise RuntimeError(f"Failed to increment daily usage for {user_id} on {day}")
+            raise RuntimeError("Failed to increment daily token usage")
         return result
 
     @mongo_retry
@@ -132,7 +167,7 @@ class TokenUsageMongoRepository:
         *,
         date: str | None = None,
     ) -> dict[str, Any] | None:
-        day = date or datetime.now(UTC).strftime("%Y-%m-%d")
+        day = _validated_date(date)
         return await self._daily_collection.find_one({"user_id": user_id, "date": day})
 
     async def close(self) -> None:

--- a/deep_agent/src/token_budget/otel_emit.py
+++ b/deep_agent/src/token_budget/otel_emit.py
@@ -1,0 +1,190 @@
+"""OTEL emission for per-call and daily token usage."""
+
+from __future__ import annotations
+
+import threading
+from datetime import UTC, datetime
+from typing import Any
+
+from deep_agent.src.settings import settings
+from deep_agent.utils.pylogger import get_python_logger
+
+logger = get_python_logger()
+
+_counters_initialized = False
+_token_counter: Any | None = None
+_thread_total_counter: Any | None = None
+_daily_total_counter: Any | None = None
+_counters_lock = threading.Lock()
+
+
+def token_budget_otel_enabled() -> bool:
+    """Return True when token usage metrics export is enabled."""
+    return bool(settings.ENABLE_OTEL_METRICS and settings.OTEL_EXPORTER_OTLP_ENDPOINT)
+
+
+def token_budget_traces_enabled() -> bool:
+    """Return True when token usage span events can be exported."""
+    return bool(
+        settings.otel_traces_active() and settings.resolved_otel_traces_endpoint()
+    )
+
+
+def _agent_name() -> str:
+    try:
+        from deep_agent.src.agent.config import agent_config
+
+        return agent_config.get_name()
+    except Exception:
+        return settings.OTEL_SERVICE_NAME
+
+
+def _format_timestamp(value: Any | None = None) -> str:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=UTC).isoformat()
+        return value.isoformat()
+    if isinstance(value, str) and value:
+        return value
+    return datetime.now(UTC).isoformat()
+
+
+def _ensure_counters() -> None:
+    global _counters_initialized, _token_counter, _thread_total_counter, _daily_total_counter  # noqa: PLW0603
+
+    if _counters_initialized or not token_budget_otel_enabled():
+        return
+
+    with _counters_lock:
+        if _counters_initialized or not token_budget_otel_enabled():
+            return
+        _counters_initialized = True
+
+        try:
+            from opentelemetry import metrics
+
+            meter = metrics.get_meter("template-agent.token-budget")
+            _token_counter = meter.create_counter(
+                "token_budget.tokens",
+                description="Billable LLM tokens recorded per call",
+            )
+            _thread_total_counter = meter.create_counter(
+                "token_budget.thread_total",
+                description="Cumulative thread token totals after each LLM call",
+            )
+            _daily_total_counter = meter.create_counter(
+                "token_budget.daily_total",
+                description="Cumulative per-user daily token totals after each LLM call",
+            )
+        except Exception:
+            logger.warning("token_budget_otel_counter_init_failed", exc_info=True)
+
+
+def emit_token_usage(
+    *,
+    thread_id: str,
+    user_id: str | None,
+    input_tokens: int,
+    output_tokens: int,
+    cumulative_total: int,
+    cumulative_input: int,
+    cumulative_output: int,
+    timestamp: Any | None = None,
+) -> None:
+    """Emit OTEL metrics and optional span events for a single LLM usage record."""
+    if not token_budget_otel_enabled():
+        return
+
+    _ensure_counters()
+
+    recorded_at = _format_timestamp(timestamp)
+    agent_name = _agent_name()
+    attributes = {
+        "thread_id": thread_id,
+        "agent.name": agent_name,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens,
+        "cumulative_total_tokens": cumulative_total,
+        "cumulative_input_tokens": cumulative_input,
+        "cumulative_output_tokens": cumulative_output,
+        "timestamp": recorded_at,
+    }
+    if user_id:
+        attributes["user_id"] = user_id
+
+    logger.info("token_budget_usage", **attributes)
+
+    if token_budget_traces_enabled():
+        try:
+            from opentelemetry import trace as otel_trace
+
+            span = otel_trace.get_current_span()
+            if span is not None and span.is_recording():
+                span.add_event("token_budget.usage", attributes=attributes)
+        except ImportError:
+            pass
+
+    metric_attrs = {
+        "agent.name": agent_name,
+        "thread_id": thread_id,
+    }
+    if user_id:
+        metric_attrs["user_id"] = user_id
+
+    if _token_counter is not None:
+        if input_tokens > 0:
+            _token_counter.add(input_tokens, {**metric_attrs, "token.type": "input"})
+        if output_tokens > 0:
+            _token_counter.add(output_tokens, {**metric_attrs, "token.type": "output"})
+
+    if _thread_total_counter is not None and cumulative_total > 0:
+        _thread_total_counter.add(
+            cumulative_total,
+            {**metric_attrs, "aggregation": "cumulative"},
+        )
+
+
+def emit_daily_token_usage(
+    *,
+    user_id: str,
+    total_tokens: int,
+    date: str,
+    timestamp: Any | None = None,
+) -> None:
+    """Emit OTEL metrics and optional span events for a user's daily token rollup."""
+    if not token_budget_otel_enabled():
+        return
+
+    _ensure_counters()
+
+    recorded_at = _format_timestamp(timestamp)
+    attributes = {
+        "user_id": user_id,
+        "total_tokens": total_tokens,
+        "date": date,
+        "timestamp": recorded_at,
+        "agent.name": _agent_name(),
+    }
+
+    logger.info("token_budget_daily_usage", **attributes)
+
+    if token_budget_traces_enabled():
+        try:
+            from opentelemetry import trace as otel_trace
+
+            span = otel_trace.get_current_span()
+            if span is not None and span.is_recording():
+                span.add_event("token_budget.daily_usage", attributes=attributes)
+        except ImportError:
+            pass
+
+    if _daily_total_counter is not None and total_tokens > 0:
+        _daily_total_counter.add(
+            total_tokens,
+            {
+                "agent.name": _agent_name(),
+                "user_id": user_id,
+                "date": date,
+            },
+        )

--- a/deep_agent/src/token_budget/service.py
+++ b/deep_agent/src/token_budget/service.py
@@ -170,6 +170,9 @@ def _mongo_repo():
     return _mongo_repo_instance
 
 
+_MAX_REASONABLE_TOKENS = 2_000_000
+
+
 async def check_and_record(
     thread_id: str,
     input_tokens: int,
@@ -184,9 +187,16 @@ async def check_and_record(
     if not thread_id or thread_id == "unknown":
         return
     if not settings.MONGODB_URI:
-        logger.debug("token_budget_skipped_no_mongodb_uri", thread_id=thread_id)
+        logger.debug("token_budget_skipped_no_mongodb_uri")
         return
     if input_tokens <= 0 and output_tokens <= 0:
+        return
+    if input_tokens > _MAX_REASONABLE_TOKENS or output_tokens > _MAX_REASONABLE_TOKENS:
+        logger.warning(
+            "token_budget_suspicious_count",
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )
         return
 
     try:
@@ -205,7 +215,6 @@ async def check_and_record(
     except Exception:
         logger.warning(
             "token_budget_mongo_write_failed",
-            thread_id=thread_id,
             exc_info=True,
         )
         return
@@ -244,7 +253,6 @@ async def get_thread_token_usage(thread_id: str) -> ThreadTokenUsage:
     except Exception as exc:
         logger.warning(
             "token_budget_mongo_read_failed",
-            thread_id=thread_id,
             exc_info=True,
         )
         raise TokenUsageUnavailableError("token usage storage unavailable") from exc

--- a/deep_agent/src/token_budget/service.py
+++ b/deep_agent/src/token_budget/service.py
@@ -1,0 +1,260 @@
+"""Token usage tracking and extraction."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Any
+
+from deep_agent.src.agent.config import agent_config
+from deep_agent.src.settings import settings
+from deep_agent.utils.pylogger import get_python_logger
+
+logger = get_python_logger()
+
+
+@dataclass(frozen=True)
+class ThreadTokenUsage:
+    """Thread token usage summary."""
+
+    thread_id: str
+    used: int
+    input_tokens: int
+    output_tokens: int
+
+
+class TokenUsageUnavailableError(Exception):
+    """Token usage storage is not configured or temporarily unreachable."""
+
+
+class TokenUsageNotFoundError(Exception):
+    """No token usage record exists for the requested thread."""
+
+    def __init__(self, thread_id: str) -> None:
+        self.thread_id = thread_id
+        super().__init__(thread_id)
+
+def _reasoning_tokens(usage: dict[str, Any]) -> int:
+    """Return reasoning tokens from provider output_token_details (Gemini)."""
+    details = usage.get("output_token_details")
+    if not isinstance(details, dict):
+        return 0
+    value = details.get("reasoning")
+    return int(value) if isinstance(value, int) else 0
+
+
+def _usage_dict_to_counts(usage: dict[str, Any] | None) -> tuple[int, int]:
+    """Map provider usage to billable input/output counts.
+
+    Matches Langfuse **Total usage** (input + visible output + reasoning).
+    Gemini often reports ``output_tokens`` as visible output only (e.g. 29) while
+    ``output_token_details.reasoning`` holds the rest (e.g. 141). Prefer
+    ``total_tokens - input_tokens`` when both are present.
+    """
+    if not usage:
+        return 0, 0
+    input_tokens = int(
+        usage.get("input_tokens")
+        or usage.get("input")
+        or usage.get("prompt_tokens")
+        or usage.get("prompt_token_count")
+        or 0
+    )
+    total_tokens = int(usage.get("total_tokens") or usage.get("total") or 0)
+    if total_tokens > 0 and total_tokens >= input_tokens:
+        return input_tokens, total_tokens - input_tokens
+
+    output_tokens = int(
+        usage.get("output_tokens")
+        or usage.get("output")
+        or usage.get("completion_tokens")
+        or usage.get("candidates_token_count")
+        or 0
+    )
+    reasoning = _reasoning_tokens(usage)
+    if reasoning:
+        output_tokens += reasoning
+
+    if input_tokens or output_tokens:
+        return input_tokens, output_tokens
+    if total_tokens:
+        return 0, total_tokens
+    return 0, 0
+
+
+def _usage_from_generation(generation: Any) -> tuple[int, int]:
+    """Extract billable tokens from a single LangChain generation."""
+    message = getattr(generation, "message", None)
+    if message is not None:
+        in_t, out_t = extract_tokens_from_message(message)
+        if in_t or out_t:
+            return in_t, out_t
+
+    gen_info = getattr(generation, "generation_info", None) or {}
+    if isinstance(gen_info, dict):
+        usage = gen_info.get("usage_metadata") or gen_info.get("token_usage") or {}
+        if isinstance(usage, dict):
+            return _usage_dict_to_counts(usage)
+
+    return 0, 0
+
+
+def extract_tokens_from_llm_result(response: Any) -> tuple[int, int]:
+    """Extract billable token counts from a LangChain LLMResult."""
+    input_tokens = 0
+    output_tokens = 0
+    generations = getattr(response, "generations", None) or []
+    for generation_list in generations:
+        for generation in generation_list:
+            in_t, out_t = _usage_from_generation(generation)
+            input_tokens += in_t
+            output_tokens += out_t
+
+    if input_tokens or output_tokens:
+        return input_tokens, output_tokens
+
+    llm_output = getattr(response, "llm_output", None) or {}
+    if isinstance(llm_output, dict):
+        token_usage = llm_output.get("token_usage") or llm_output.get("usage") or {}
+        if isinstance(token_usage, dict):
+            return _usage_dict_to_counts(token_usage)
+
+    return 0, 0
+
+
+def extract_tokens_from_chat_result(response: Any) -> tuple[int, int]:
+    """Alias for chat model results — Langfuse routes these through on_llm_end."""
+    return extract_tokens_from_llm_result(response)
+
+
+def extract_tokens_from_message(message: Any) -> tuple[int, int]:
+    """Extract billable token counts from a LangChain message object."""
+    usage = getattr(message, "usage_metadata", None) or {}
+    if isinstance(usage, dict) and usage:
+        return _usage_dict_to_counts(usage)
+
+    response_metadata = getattr(message, "response_metadata", None) or {}
+    if isinstance(response_metadata, dict):
+        nested_usage = (
+            response_metadata.get("usage_metadata")
+            or response_metadata.get("token_usage")
+            or {}
+        )
+        if isinstance(nested_usage, dict):
+            in_t, out_t = _usage_dict_to_counts(nested_usage)
+            if in_t or out_t:
+                return in_t, out_t
+
+    return 0, 0
+
+
+_mongo_repo_instance = None
+_mongo_repo_lock = threading.Lock()
+
+
+def _mongo_repo():
+    """Return a process-wide Mongo repository (reuses the Motor client pool)."""
+    global _mongo_repo_instance  # noqa: PLW0603
+
+    if _mongo_repo_instance is None:
+        with _mongo_repo_lock:
+            if _mongo_repo_instance is None:
+                from deep_agent.src.token_budget.mongo_repository import (
+                    TokenUsageMongoRepository,
+                )
+
+                _mongo_repo_instance = TokenUsageMongoRepository(
+                    settings.MONGODB_URI,
+                    db_name=settings.MONGODB_DB,
+                )
+    return _mongo_repo_instance
+
+
+async def check_and_record(
+    thread_id: str,
+    input_tokens: int,
+    output_tokens: int,
+    *,
+    user_id: str | None = None,
+) -> None:
+    """Increment thread usage, roll up daily user totals, and emit OTEL when enabled."""
+    config = agent_config.get_token_budget_config()
+    if not config.is_active:
+        return
+    if not thread_id or thread_id == "unknown":
+        return
+    if not settings.MONGODB_URI:
+        logger.debug("token_budget_skipped_no_mongodb_uri", thread_id=thread_id)
+        return
+    if input_tokens <= 0 and output_tokens <= 0:
+        return
+
+    try:
+        repo = _mongo_repo()
+        agent_name = agent_config.get_name()
+        row = await repo.increment_usage(
+            thread_id,
+            input_tokens,
+            output_tokens,
+            agent_name=agent_name,
+        )
+        total_delta = input_tokens + output_tokens
+        daily_row = None
+        if user_id and user_id != "unknown" and total_delta > 0:
+            daily_row = await repo.increment_daily_usage(user_id, total_delta)
+    except Exception:
+        logger.warning(
+            "token_budget_mongo_write_failed",
+            thread_id=thread_id,
+            exc_info=True,
+        )
+        return
+
+    from deep_agent.src.token_budget.otel_emit import emit_daily_token_usage, emit_token_usage
+
+    emit_token_usage(
+        thread_id=thread_id,
+        user_id=user_id,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cumulative_total=int(row["total_tokens"]),
+        cumulative_input=int(row["input_tokens"]),
+        cumulative_output=int(row["output_tokens"]),
+        timestamp=row.get("updated_at"),
+    )
+
+    if daily_row is not None:
+        emit_daily_token_usage(
+            user_id=str(daily_row["user_id"]),
+            total_tokens=int(daily_row["total_tokens"]),
+            date=str(daily_row["date"]),
+            timestamp=daily_row.get("updated_at"),
+        )
+
+
+async def get_thread_token_usage(thread_id: str) -> ThreadTokenUsage:
+    """Return cumulative token usage for a thread."""
+    config = agent_config.get_token_budget_config()
+    if not config.is_active or not settings.MONGODB_URI:
+        raise TokenUsageUnavailableError("token budget tracking is not configured")
+
+    try:
+        repo = _mongo_repo()
+        row = await repo.get_thread_usage(thread_id)
+    except Exception as exc:
+        logger.warning(
+            "token_budget_mongo_read_failed",
+            thread_id=thread_id,
+            exc_info=True,
+        )
+        raise TokenUsageUnavailableError("token usage storage unavailable") from exc
+
+    if row is None:
+        raise TokenUsageNotFoundError(thread_id)
+
+    return ThreadTokenUsage(
+        thread_id=thread_id,
+        used=int(row["total_tokens"]),
+        input_tokens=int(row["input_tokens"]),
+        output_tokens=int(row["output_tokens"]),
+    )

--- a/deep_agent/src/token_budget/service.py
+++ b/deep_agent/src/token_budget/service.py
@@ -170,7 +170,7 @@ def _mongo_repo():
     return _mongo_repo_instance
 
 
-_MAX_REASONABLE_TOKENS = 2_000_000
+_MAX_REASONABLE_TOKENS = 1_000_000
 
 
 async def check_and_record(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "aegra-cli",
     "psycopg[binary,pool]==3.3.3",
     "psycopg2-binary==2.9.11",
+    "motor==3.6.0",
     "structlog==25.5.0",
     "pyyaml==6.0.3",
     "PyJWT[crypto]>=2.8.0",
@@ -36,6 +37,10 @@ dependencies = [
     "redis>=5.0.0,<7",
     "cachetools>=5.5.0,<6",
     "apscheduler>=4.0.0a5",
+    "opentelemetry-api>=1.27.0",
+    "opentelemetry-sdk>=1.27.0",
+    "opentelemetry-exporter-otlp>=1.27.0",
+    "opentelemetry-instrumentation-fastapi>=0.48b0",
 ]
 
 [project.optional-dependencies]

--- a/test_otel_alert.py
+++ b/test_otel_alert.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Test script to emit sample OTEL token usage events."""
+
+import asyncio
+import os
+
+
+async def test_otel_usage() -> None:
+    os.environ["ENABLE_OTEL_METRICS"] = "true"
+    os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = os.environ.get(
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "localhost:4327",
+    )
+    os.environ["OTEL_SERVICE_NAME"] = "template-agent-test"
+
+    from deep_agent.src.observability.otel_setup import setup_otel_metrics
+    from deep_agent.src.settings import settings
+    from deep_agent.src.token_budget.otel_emit import emit_token_usage
+    from deep_agent.utils.pylogger import get_python_logger
+
+    log = get_python_logger()
+    setup_otel_metrics(settings, log)
+
+    samples = [
+        ("test-thread-1", "user-1", 1200, 340, 1200, 1200, 340),
+        ("test-thread-1", "user-1", 800, 210, 2000, 2000, 550),
+        ("test-thread-2", "user-2", 500, 90, 500, 500, 90),
+    ]
+
+    for i, (
+        thread_id,
+        user_id,
+        input_tokens,
+        output_tokens,
+        cumulative_total,
+        cumulative_input,
+        cumulative_output,
+    ) in enumerate(samples, 1):
+        print(
+            f"\n[{i}] Emitting usage for {thread_id}: "
+            f"+{input_tokens} in / +{output_tokens} out "
+            f"(cumulative {cumulative_total})"
+        )
+        emit_token_usage(
+            thread_id=thread_id,
+            user_id=user_id,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cumulative_total=cumulative_total,
+            cumulative_input=cumulative_input,
+            cumulative_output=cumulative_output,
+        )
+        await asyncio.sleep(1)
+
+    print("\nDone. Check your collector for token_budget.tokens metrics.")
+
+
+if __name__ == "__main__":
+    asyncio.run(test_otel_usage())

--- a/tests/unit/aegra/test_feedback.py
+++ b/tests/unit/aegra/test_feedback.py
@@ -187,3 +187,55 @@ class TestFeedbackHandler:
         assert res.status_code == 200
         assert res.json() == {"feedback": [{"message_id": "m1", "feedback": "up"}]}
         mock_repo.list_feedback.assert_awaited_once_with("thread-1", "u1")
+
+
+class TestTokenUsageEndpoint:
+    def test_get_thread_token_usage_success(self) -> None:
+        from deep_agent.src.token_budget.service import ThreadTokenUsage
+
+        client = TestClient(app)
+
+        with patch(
+            "deep_agent.src.token_budget.service.get_thread_token_usage",
+            new=AsyncMock(
+                return_value=ThreadTokenUsage(
+                    thread_id="thread-1",
+                    used=150,
+                    input_tokens=100,
+                    output_tokens=50,
+                )
+            ),
+        ):
+            res = client.get("/threads/thread-1/token-usage")
+
+        assert res.status_code == 200
+        assert res.json() == {
+            "thread_id": "thread-1",
+            "used": 150,
+            "input_tokens": 100,
+            "output_tokens": 50,
+        }
+
+    def test_get_thread_token_usage_not_found(self) -> None:
+        from deep_agent.src.token_budget.service import TokenUsageNotFoundError
+
+        client = TestClient(app)
+        with patch(
+            "deep_agent.src.token_budget.service.get_thread_token_usage",
+            new=AsyncMock(side_effect=TokenUsageNotFoundError("thread-1")),
+        ):
+            res = client.get("/threads/thread-1/token-usage")
+
+        assert res.status_code == 404
+
+    def test_get_thread_token_usage_unavailable(self) -> None:
+        from deep_agent.src.token_budget.service import TokenUsageUnavailableError
+
+        client = TestClient(app)
+        with patch(
+            "deep_agent.src.token_budget.service.get_thread_token_usage",
+            new=AsyncMock(side_effect=TokenUsageUnavailableError("down")),
+        ):
+            res = client.get("/threads/thread-1/token-usage")
+
+        assert res.status_code == 503

--- a/tests/unit/aegra/test_feedback.py
+++ b/tests/unit/aegra/test_feedback.py
@@ -171,6 +171,7 @@ class TestFeedbackHandler:
 
     def test_get_thread_feedback(self):
         client = TestClient(app)
+        thread_uuid = "00000000-0000-0000-0000-000000000001"
 
         mock_repo = MagicMock()
         mock_repo.list_feedback = AsyncMock(
@@ -181,12 +182,12 @@ class TestFeedbackHandler:
             return_value=mock_repo,
         ):
             res = client.get(
-                "/feedback/thread-1",
+                f"/feedback/{thread_uuid}",
                 params={"user_id": "u1"},
             )
         assert res.status_code == 200
         assert res.json() == {"feedback": [{"message_id": "m1", "feedback": "up"}]}
-        mock_repo.list_feedback.assert_awaited_once_with("thread-1", "u1")
+        mock_repo.list_feedback.assert_awaited_once_with(thread_uuid, "u1")
 
 
 class TestTokenUsageEndpoint:
@@ -194,23 +195,24 @@ class TestTokenUsageEndpoint:
         from deep_agent.src.token_budget.service import ThreadTokenUsage
 
         client = TestClient(app)
+        thread_uuid = "00000000-0000-0000-0000-000000000001"
 
         with patch(
             "deep_agent.src.token_budget.service.get_thread_token_usage",
             new=AsyncMock(
                 return_value=ThreadTokenUsage(
-                    thread_id="thread-1",
+                    thread_id=thread_uuid,
                     used=150,
                     input_tokens=100,
                     output_tokens=50,
                 )
             ),
         ):
-            res = client.get("/threads/thread-1/token-usage")
+            res = client.get(f"/threads/{thread_uuid}/token-usage")
 
         assert res.status_code == 200
         assert res.json() == {
-            "thread_id": "thread-1",
+            "thread_id": thread_uuid,
             "used": 150,
             "input_tokens": 100,
             "output_tokens": 50,
@@ -220,11 +222,12 @@ class TestTokenUsageEndpoint:
         from deep_agent.src.token_budget.service import TokenUsageNotFoundError
 
         client = TestClient(app)
+        thread_uuid = "00000000-0000-0000-0000-000000000001"
         with patch(
             "deep_agent.src.token_budget.service.get_thread_token_usage",
-            new=AsyncMock(side_effect=TokenUsageNotFoundError("thread-1")),
+            new=AsyncMock(side_effect=TokenUsageNotFoundError(thread_uuid)),
         ):
-            res = client.get("/threads/thread-1/token-usage")
+            res = client.get(f"/threads/{thread_uuid}/token-usage")
 
         assert res.status_code == 404
 
@@ -232,10 +235,11 @@ class TestTokenUsageEndpoint:
         from deep_agent.src.token_budget.service import TokenUsageUnavailableError
 
         client = TestClient(app)
+        thread_uuid = "00000000-0000-0000-0000-000000000001"
         with patch(
             "deep_agent.src.token_budget.service.get_thread_token_usage",
             new=AsyncMock(side_effect=TokenUsageUnavailableError("down")),
         ):
-            res = client.get("/threads/thread-1/token-usage")
+            res = client.get(f"/threads/{thread_uuid}/token-usage")
 
         assert res.status_code == 503

--- a/tests/unit/aegra/test_startup.py
+++ b/tests/unit/aegra/test_startup.py
@@ -63,6 +63,7 @@ class TestEnsureDatabase:
     async def test_no_db(self):
         mock_settings = MagicMock()
         mock_settings.database_uri = ""
+        mock_settings.MONGODB_URI = ""
         with patch("deep_agent.src.settings.settings", mock_settings):
             result = await startup._ensure_database()
         assert "skipped" in result
@@ -70,6 +71,7 @@ class TestEnsureDatabase:
     async def test_db_ok(self):
         mock_settings = MagicMock()
         mock_settings.database_uri = "postgresql://test"
+        mock_settings.MONGODB_URI = ""
         mock_personalization = AsyncMock()
         mock_feedback = AsyncMock()
         with (
@@ -87,6 +89,27 @@ class TestEnsureDatabase:
         assert result == "ok"
         mock_personalization.ensure_tables.assert_awaited_once()
         mock_feedback.ensure_table.assert_awaited_once()
+
+    async def test_mongo_indexes_when_configured(self):
+        import sys
+
+        mock_settings = MagicMock()
+        mock_settings.database_uri = ""
+        mock_settings.MONGODB_URI = "mongodb://test"
+        mock_settings.MONGODB_DB = "tokenusage"
+        mock_mongo = AsyncMock()
+        mock_module = MagicMock()
+        mock_module.TokenUsageMongoRepository.return_value = mock_mongo
+        with (
+            patch("deep_agent.src.settings.settings", mock_settings),
+            patch.dict(
+                sys.modules,
+                {"deep_agent.src.token_budget.mongo_repository": mock_module},
+            ),
+        ):
+            result = await startup._ensure_database()
+        assert result == "ok"
+        mock_mongo.ensure_indexes.assert_awaited_once()
 
 
 class TestWarmCaches:

--- a/tests/unit/observability/test_otel_setup.py
+++ b/tests/unit/observability/test_otel_setup.py
@@ -1,0 +1,52 @@
+"""Unit tests for platform-style OTEL bootstrap."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from deep_agent.src.observability import otel_setup
+
+
+def test_setup_otel_metrics_skips_when_disabled() -> None:
+    settings = MagicMock()
+    settings.ENABLE_OTEL_METRICS = False
+    settings.OTEL_EXPORTER_OTLP_ENDPOINT = "otel-gateway:4327"
+    log = MagicMock()
+
+    with patch("opentelemetry.metrics.set_meter_provider") as set_provider:
+        otel_setup.setup_otel_metrics(settings, log)
+
+    set_provider.assert_not_called()
+
+
+def test_setup_otel_traces_skips_when_both_disabled() -> None:
+    settings = MagicMock()
+    settings.ENABLE_OTEL_METRICS = False
+    settings.OTEL_EXPORTER_OTLP_ENDPOINT = ""
+    settings.otel_traces_active.return_value = False
+    settings.resolved_otel_traces_endpoint.return_value = ""
+    log = MagicMock()
+    app = MagicMock()
+
+    with patch.object(otel_setup, "_instrument_fastapi") as instrument:
+        otel_setup.setup_otel_traces(app, settings, log)
+
+    instrument.assert_not_called()
+
+
+def test_setup_otel_metrics_is_idempotent() -> None:
+    otel_setup._metrics_initialized = False
+    settings = MagicMock()
+    settings.ENABLE_OTEL_METRICS = True
+    settings.OTEL_EXPORTER_OTLP_ENDPOINT = "otel-gateway:4327"
+    settings.OTEL_SERVICE_NAME = "template-agent"
+    settings.OTEL_METRIC_EXPORT_INTERVAL_MILLIS = 10000
+    settings.OTEL_AUTH_TOKEN = ""
+    log = MagicMock()
+
+    with patch("opentelemetry.metrics.set_meter_provider") as set_provider:
+        otel_setup.setup_otel_metrics(settings, log)
+        otel_setup.setup_otel_metrics(settings, log)
+
+    set_provider.assert_called_once()
+    otel_setup._metrics_initialized = False

--- a/tests/unit/token_budget/test_callback.py
+++ b/tests/unit/token_budget/test_callback.py
@@ -1,0 +1,27 @@
+"""Unit tests for token budget callback."""
+
+from __future__ import annotations
+
+from deep_agent.src.token_budget.callback import (
+    thread_id_from_metadata,
+    user_id_from_metadata,
+)
+
+
+def test_thread_id_from_metadata_prefers_token_budget_key() -> None:
+    assert thread_id_from_metadata({"token_budget_thread_id": "abc"}) == "abc"
+
+
+def test_thread_id_from_metadata_falls_back_to_langfuse_session() -> None:
+    assert thread_id_from_metadata({"langfuse_session_id": "xyz"}) == "xyz"
+
+
+def test_thread_id_from_metadata_missing() -> None:
+    assert thread_id_from_metadata({}) is None
+    assert thread_id_from_metadata(None) is None
+
+
+def test_user_id_from_metadata() -> None:
+    assert user_id_from_metadata({"token_budget_user_id": "dev-user"}) == "dev-user"
+    assert user_id_from_metadata({}) is None
+    assert user_id_from_metadata(None) is None

--- a/tests/unit/token_budget/test_mongo_repository.py
+++ b/tests/unit/token_budget/test_mongo_repository.py
@@ -1,0 +1,97 @@
+"""Unit tests for Mongo token usage repository retries."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, PropertyMock, patch
+
+import pytest
+from pymongo.errors import ServerSelectionTimeoutError
+
+from deep_agent.src.token_budget.mongo_repository import TokenUsageMongoRepository
+
+
+@pytest.mark.asyncio
+async def test_increment_usage_retries_transient_mongo_error() -> None:
+    expected = {
+        "thread_id": "thread-1",
+        "total_tokens": 150,
+        "input_tokens": 100,
+        "output_tokens": 50,
+    }
+
+    collection = AsyncMock()
+    collection.find_one_and_update = AsyncMock(
+        side_effect=[
+            ServerSelectionTimeoutError("timeout"),
+            expected,
+        ]
+    )
+
+    with (
+        patch.object(
+            TokenUsageMongoRepository,
+            "_thread_collection",
+            new_callable=PropertyMock,
+            return_value=collection,
+        ),
+        patch.object(TokenUsageMongoRepository, "ensure_indexes", new=AsyncMock()),
+    ):
+        repo = TokenUsageMongoRepository("mongodb://mongodb:27017", db_name="tokenusage")
+        result = await repo.increment_usage("thread-1", 100, 50, agent_name="health-assistant")
+
+    assert result == expected
+    assert collection.find_one_and_update.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_increment_usage_does_not_retry_runtime_error() -> None:
+    collection = AsyncMock()
+    collection.find_one_and_update = AsyncMock(return_value=None)
+
+    with (
+        patch.object(
+            TokenUsageMongoRepository,
+            "_thread_collection",
+            new_callable=PropertyMock,
+            return_value=collection,
+        ),
+        patch.object(TokenUsageMongoRepository, "ensure_indexes", new=AsyncMock()),
+    ):
+        repo = TokenUsageMongoRepository("mongodb://mongodb:27017", db_name="tokenusage")
+        with pytest.raises(RuntimeError, match="Failed to increment Mongo token usage"):
+            await repo.increment_usage("thread-1", 100, 50)
+
+    assert collection.find_one_and_update.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_indexes_runs_once_per_process() -> None:
+    import deep_agent.src.token_budget.mongo_repository as mongo_module
+
+    mongo_module._INDEXES_ENSURED = False
+
+    thread_collection = AsyncMock()
+    daily_collection = AsyncMock()
+
+    with (
+        patch.object(
+            TokenUsageMongoRepository,
+            "_thread_collection",
+            new_callable=PropertyMock,
+            return_value=thread_collection,
+        ),
+        patch.object(
+            TokenUsageMongoRepository,
+            "_daily_collection",
+            new_callable=PropertyMock,
+            return_value=daily_collection,
+        ),
+    ):
+        repo = TokenUsageMongoRepository("mongodb://mongodb:27017", db_name="tokenusage")
+        await repo.ensure_indexes()
+        await repo.ensure_indexes()
+
+    assert thread_collection.create_index.await_count == 2
+    assert daily_collection.create_index.await_count == 2
+
+    mongo_module._INDEXES_ENSURED = False

--- a/tests/unit/token_budget/test_otel.py
+++ b/tests/unit/token_budget/test_otel.py
@@ -1,0 +1,205 @@
+"""Unit tests for token budget OTEL emission."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deep_agent.src.token_budget import otel_emit
+
+
+@pytest.fixture(autouse=True)
+def reset_otel_emit_state() -> None:
+    otel_emit._counters_initialized = False
+    otel_emit._token_counter = None
+    otel_emit._thread_total_counter = None
+    otel_emit._daily_total_counter = None
+
+
+def test_token_budget_otel_enabled_requires_metrics_flag_and_endpoint() -> None:
+    mock_settings = MagicMock()
+    mock_settings.ENABLE_OTEL_METRICS = True
+    mock_settings.OTEL_EXPORTER_OTLP_ENDPOINT = "otel-gateway:4327"
+    with patch("deep_agent.src.token_budget.otel_emit.settings", mock_settings):
+        assert otel_emit.token_budget_otel_enabled() is True
+
+    mock_settings.ENABLE_OTEL_METRICS = False
+    with patch("deep_agent.src.token_budget.otel_emit.settings", mock_settings):
+        assert otel_emit.token_budget_otel_enabled() is False
+
+
+def test_emit_token_usage_skipped_when_metrics_disabled() -> None:
+    mock_settings = MagicMock()
+    mock_settings.ENABLE_OTEL_METRICS = False
+    mock_settings.OTEL_EXPORTER_OTLP_ENDPOINT = ""
+    with (
+        patch("deep_agent.src.token_budget.otel_emit.settings", mock_settings),
+        patch.object(otel_emit.logger, "info") as log_info,
+    ):
+        otel_emit.emit_token_usage(
+            thread_id="thread-1",
+            user_id="user-1",
+            input_tokens=10,
+            output_tokens=5,
+            cumulative_total=15,
+            cumulative_input=10,
+            cumulative_output=5,
+        )
+
+    log_info.assert_not_called()
+
+
+def test_emit_token_usage_logs_expected_payload() -> None:
+    mock_settings = MagicMock()
+    mock_settings.ENABLE_OTEL_METRICS = True
+    mock_settings.OTEL_EXPORTER_OTLP_ENDPOINT = "otel-gateway:4327"
+    mock_settings.ENABLE_OTEL_TRACES = False
+    mock_settings.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = ""
+
+    with (
+        patch("deep_agent.src.token_budget.otel_emit.settings", mock_settings),
+        patch("deep_agent.src.token_budget.otel_emit._agent_name", return_value="health-assistant"),
+        patch.object(otel_emit, "_ensure_counters"),
+        patch.object(otel_emit.logger, "info") as log_info,
+    ):
+        otel_emit.emit_token_usage(
+            thread_id="thread-abc",
+            user_id="user-xyz",
+            input_tokens=100,
+            output_tokens=25,
+            cumulative_total=125,
+            cumulative_input=100,
+            cumulative_output=25,
+            timestamp="2026-06-23T12:00:00+00:00",
+        )
+
+    log_info.assert_called_once_with(
+        "token_budget_usage",
+        thread_id="thread-abc",
+        user_id="user-xyz",
+        input_tokens=100,
+        output_tokens=25,
+        total_tokens=125,
+        cumulative_total_tokens=125,
+        cumulative_input_tokens=100,
+        cumulative_output_tokens=25,
+        timestamp="2026-06-23T12:00:00+00:00",
+        **{"agent.name": "health-assistant"},
+    )
+
+
+def test_emit_token_usage_records_metrics() -> None:
+    mock_token_counter = MagicMock()
+    mock_thread_counter = MagicMock()
+    mock_settings = MagicMock()
+    mock_settings.ENABLE_OTEL_METRICS = True
+    mock_settings.OTEL_EXPORTER_OTLP_ENDPOINT = "otel-gateway:4327"
+    mock_settings.ENABLE_OTEL_TRACES = False
+    mock_settings.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = ""
+
+    with (
+        patch("deep_agent.src.token_budget.otel_emit.settings", mock_settings),
+        patch("deep_agent.src.token_budget.otel_emit._agent_name", return_value="health-assistant"),
+        patch.object(otel_emit, "_token_counter", mock_token_counter),
+        patch.object(otel_emit, "_thread_total_counter", mock_thread_counter),
+        patch.object(otel_emit, "_counters_initialized", True),
+        patch.object(otel_emit.logger, "info"),
+    ):
+        otel_emit.emit_token_usage(
+            thread_id="thread-1",
+            user_id="user-1",
+            input_tokens=80,
+            output_tokens=20,
+            cumulative_total=100,
+            cumulative_input=80,
+            cumulative_output=20,
+        )
+
+    base_attrs = {
+        "agent.name": "health-assistant",
+        "thread_id": "thread-1",
+        "user_id": "user-1",
+    }
+    mock_token_counter.add.assert_any_call(80, {**base_attrs, "token.type": "input"})
+    mock_token_counter.add.assert_any_call(20, {**base_attrs, "token.type": "output"})
+    mock_thread_counter.add.assert_called_once_with(
+        100,
+        {**base_attrs, "aggregation": "cumulative"},
+    )
+
+
+def test_emit_token_usage_adds_span_event_when_traces_enabled() -> None:
+    mock_settings = MagicMock()
+    mock_settings.ENABLE_OTEL_METRICS = True
+    mock_settings.OTEL_EXPORTER_OTLP_ENDPOINT = "otel-gateway:4327"
+    mock_settings.ENABLE_OTEL_TRACES = True
+    mock_settings.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = "jaeger:4317"
+    mock_settings.otel_traces_active.return_value = True
+    mock_settings.resolved_otel_traces_endpoint.return_value = "jaeger:4317"
+    mock_span = MagicMock()
+    mock_span.is_recording.return_value = True
+
+    with (
+        patch("deep_agent.src.token_budget.otel_emit.settings", mock_settings),
+        patch("deep_agent.src.token_budget.otel_emit._agent_name", return_value="health-assistant"),
+        patch.object(otel_emit, "_ensure_counters"),
+        patch.object(otel_emit.logger, "info"),
+        patch("opentelemetry.trace.get_current_span", return_value=mock_span),
+    ):
+        otel_emit.emit_token_usage(
+            thread_id="thread-1",
+            user_id=None,
+            input_tokens=10,
+            output_tokens=5,
+            cumulative_total=15,
+            cumulative_input=10,
+            cumulative_output=5,
+        )
+
+    mock_span.add_event.assert_called_once()
+    event_name = mock_span.add_event.call_args[0][0]
+    kwargs = mock_span.add_event.call_args[1]
+    assert event_name == "token_budget.usage"
+    assert kwargs["attributes"]["thread_id"] == "thread-1"
+    assert kwargs["attributes"]["timestamp"]
+
+
+def test_emit_daily_token_usage_logs_expected_payload() -> None:
+    mock_settings = MagicMock()
+    mock_settings.ENABLE_OTEL_METRICS = True
+    mock_settings.OTEL_EXPORTER_OTLP_ENDPOINT = "otel-gateway:4327"
+    mock_settings.ENABLE_OTEL_TRACES = False
+    mock_settings.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = ""
+    mock_daily_counter = MagicMock()
+
+    with (
+        patch("deep_agent.src.token_budget.otel_emit.settings", mock_settings),
+        patch("deep_agent.src.token_budget.otel_emit._agent_name", return_value="health-assistant"),
+        patch.object(otel_emit, "_daily_total_counter", mock_daily_counter),
+        patch.object(otel_emit, "_counters_initialized", True),
+        patch.object(otel_emit.logger, "info") as log_info,
+    ):
+        otel_emit.emit_daily_token_usage(
+            user_id="user-1",
+            total_tokens=5000,
+            date="2026-06-23",
+            timestamp="2026-06-23T18:30:00+00:00",
+        )
+
+    log_info.assert_called_once_with(
+        "token_budget_daily_usage",
+        user_id="user-1",
+        total_tokens=5000,
+        date="2026-06-23",
+        timestamp="2026-06-23T18:30:00+00:00",
+        **{"agent.name": "health-assistant"},
+    )
+    mock_daily_counter.add.assert_called_once_with(
+        5000,
+        {
+            "agent.name": "health-assistant",
+            "user_id": "user-1",
+            "date": "2026-06-23",
+        },
+    )

--- a/tests/unit/token_budget/test_service.py
+++ b/tests/unit/token_budget/test_service.py
@@ -1,0 +1,229 @@
+"""Unit tests for token budget service."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
+
+import pytest
+
+from deep_agent.src.token_budget.config import TokenBudgetConfig
+from deep_agent.src.token_budget.service import (
+    TokenUsageNotFoundError,
+    TokenUsageUnavailableError,
+    _mongo_repo,
+    check_and_record,
+    extract_tokens_from_message,
+    get_thread_token_usage,
+)
+
+
+class _FakeMessage:
+    def __init__(self, usage_metadata: dict | None = None) -> None:
+        self.usage_metadata = usage_metadata
+        self.response_metadata = {}
+
+
+def test_extract_tokens_from_message_usage_metadata() -> None:
+    msg = _FakeMessage({"input_tokens": 100, "output_tokens": 50})
+    assert extract_tokens_from_message(msg) == (100, 50)
+
+
+def test_extract_tokens_from_message_includes_reasoning_in_output() -> None:
+    """Gemini visible output_tokens excludes reasoning; budget must include both."""
+    msg = _FakeMessage(
+        {
+            "input_tokens": 8567,
+            "output_tokens": 29,
+            "total_tokens": 8737,
+            "output_token_details": {"reasoning": 141},
+        }
+    )
+    assert extract_tokens_from_message(msg) == (8567, 170)
+    assert sum(extract_tokens_from_message(msg)) == 8737
+
+
+def test_extract_tokens_from_message_zero_input_uses_total_minus_input() -> None:
+    """Cached prompts may report input_tokens=0 while total_tokens is authoritative."""
+    msg = _FakeMessage(
+        {
+            "input_tokens": 0,
+            "output_tokens": 40,
+            "total_tokens": 100,
+        }
+    )
+    assert extract_tokens_from_message(msg) == (0, 100)
+
+
+def test_extract_tokens_from_message_zero_input_without_total_uses_output() -> None:
+    msg = _FakeMessage({"input_tokens": 0, "output_tokens": 50})
+    assert extract_tokens_from_message(msg) == (0, 50)
+
+
+@pytest.mark.asyncio
+async def test_check_and_record_increments_mongo_and_daily_usage() -> None:
+    config = TokenBudgetConfig(enabled=True)
+    row = {
+        "total_tokens": 150,
+        "input_tokens": 100,
+        "output_tokens": 50,
+    }
+
+    mock_repo = AsyncMock()
+    mock_repo.increment_usage.return_value = row
+    mock_repo.increment_daily_usage.return_value = {
+        "user_id": "user-1",
+        "total_tokens": 150,
+        "date": "2026-06-23",
+        "updated_at": datetime(2026, 6, 23, 12, 0, tzinfo=UTC),
+    }
+
+    mock_settings = MagicMock()
+    mock_settings.MONGODB_URI = "mongodb://mongodb:27017"
+    mock_settings.MONGODB_DB = "tokenusage"
+
+    with (
+        patch(
+            "deep_agent.src.token_budget.service.agent_config.get_token_budget_config",
+            return_value=config,
+        ),
+        patch(
+            "deep_agent.src.token_budget.service.agent_config.get_name",
+            return_value="health-assistant",
+        ),
+        patch("deep_agent.src.token_budget.service.settings", mock_settings),
+        patch(
+            "deep_agent.src.token_budget.service._mongo_repo",
+            return_value=mock_repo,
+        ),
+        patch("deep_agent.src.token_budget.otel_emit.emit_token_usage") as emit_usage,
+        patch("deep_agent.src.token_budget.otel_emit.emit_daily_token_usage") as emit_daily,
+    ):
+        await check_and_record("thread-1", 100, 50, user_id="user-1")
+
+    mock_repo.increment_usage.assert_awaited_once_with(
+        "thread-1",
+        100,
+        50,
+        agent_name="health-assistant",
+    )
+    mock_repo.increment_daily_usage.assert_awaited_once_with("user-1", 150)
+    emit_usage.assert_called_once_with(
+        thread_id="thread-1",
+        user_id="user-1",
+        input_tokens=100,
+        output_tokens=50,
+        cumulative_total=150,
+        cumulative_input=100,
+        cumulative_output=50,
+        timestamp=ANY,
+    )
+    emit_daily.assert_called_once_with(
+        user_id="user-1",
+        total_tokens=150,
+        date="2026-06-23",
+        timestamp=ANY,
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_and_record_skips_daily_without_user_id() -> None:
+    config = TokenBudgetConfig(enabled=True)
+    row = {
+        "total_tokens": 150,
+        "input_tokens": 100,
+        "output_tokens": 50,
+    }
+
+    mock_repo = AsyncMock()
+    mock_repo.increment_usage.return_value = row
+
+    mock_settings = MagicMock()
+    mock_settings.MONGODB_URI = "mongodb://mongodb:27017"
+    mock_settings.MONGODB_DB = "tokenusage"
+
+    with (
+        patch(
+            "deep_agent.src.token_budget.service.agent_config.get_token_budget_config",
+            return_value=config,
+        ),
+        patch(
+            "deep_agent.src.token_budget.service.agent_config.get_name",
+            return_value="health-assistant",
+        ),
+        patch("deep_agent.src.token_budget.service.settings", mock_settings),
+        patch(
+            "deep_agent.src.token_budget.service._mongo_repo",
+            return_value=mock_repo,
+        ),
+        patch("deep_agent.src.token_budget.otel_emit.emit_token_usage"),
+        patch("deep_agent.src.token_budget.otel_emit.emit_daily_token_usage"),
+    ):
+        await check_and_record("thread-1", 100, 50)
+
+    mock_repo.increment_daily_usage.assert_not_awaited()
+
+
+def test_mongo_repo_returns_singleton() -> None:
+    import deep_agent.src.token_budget.service as service_module
+
+    service_module._mongo_repo_instance = None
+    mock_settings = MagicMock()
+    mock_settings.MONGODB_URI = "mongodb://mongodb:27017"
+    mock_settings.MONGODB_DB = "tokenusage"
+
+    with (
+        patch("deep_agent.src.token_budget.service.settings", mock_settings),
+        patch(
+            "deep_agent.src.token_budget.mongo_repository.TokenUsageMongoRepository",
+        ) as repo_cls,
+    ):
+        first = _mongo_repo()
+        second = _mongo_repo()
+
+    assert first is second
+    repo_cls.assert_called_once_with(
+        "mongodb://mongodb:27017",
+        db_name="tokenusage",
+    )
+    service_module._mongo_repo_instance = None
+
+
+@pytest.mark.asyncio
+async def test_get_thread_token_usage_raises_when_not_configured() -> None:
+    config = TokenBudgetConfig(enabled=False)
+    mock_settings = MagicMock()
+    mock_settings.MONGODB_URI = ""
+
+    with (
+        patch(
+            "deep_agent.src.token_budget.service.agent_config.get_token_budget_config",
+            return_value=config,
+        ),
+        patch("deep_agent.src.token_budget.service.settings", mock_settings),
+    ):
+        with pytest.raises(TokenUsageUnavailableError):
+            await get_thread_token_usage("thread-1")
+
+
+@pytest.mark.asyncio
+async def test_get_thread_token_usage_raises_when_thread_missing() -> None:
+    config = TokenBudgetConfig(enabled=True)
+    mock_repo = AsyncMock()
+    mock_repo.get_thread_usage.return_value = None
+    mock_settings = MagicMock()
+    mock_settings.MONGODB_URI = "mongodb://mongodb:27017"
+
+    with (
+        patch(
+            "deep_agent.src.token_budget.service.agent_config.get_token_budget_config",
+            return_value=config,
+        ),
+        patch("deep_agent.src.token_budget.service.settings", mock_settings),
+        patch(
+            "deep_agent.src.token_budget.service._mongo_repo",
+            return_value=mock_repo,
+        ),
+    ):
+        with pytest.raises(TokenUsageNotFoundError):
+            await get_thread_token_usage("thread-1")


### PR DESCRIPTION
Adds per-thread and per-user daily LLM token tracking with MongoDB persistence and OTEL metrics export.

Tracking: LangChain callback records tokens per thread_id; daily rollups in user_daily_token_usage (UTC day, new doc each day).
Storage: Mongo tokenusage DB — thread_token_usage, user_daily_token_usage; indexes ensured at startup.
Observability: OTEL metrics (token_budget.tokens, thread_total, daily_total) ; bootstrap in app lifespan.
API: GET /threads/{id}/token-usage with 404/503 semantics.
Hardening: Mongo transient retries, repo singleton, idempotent OTEL init, parallel startup DB setup, zero-input token fix, and assorted review cleanups.