### PR TITLE
feat: add per-MCP OAuth/DCR support with token store and HTTP routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,7 @@ ENABLE_USER_ID_ENCRYPTION=false
 # USER_ID_ENCRYPTION_KEY=your-32-byte-hex-key
 
 # MCP OAuth token encryption (Fernet key — required when using auth_mode oauth/dcr)
+# Encrypts access/refresh tokens in Redis and DCR client secrets in Postgres.
 # Generate: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 # MCP_TOKEN_ENCRYPTION_KEY=
 # Optional previous key during rotation (decrypt only — see README)

--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,8 @@ ENABLE_USER_ID_ENCRYPTION=false
 # MCP OAuth token encryption (Fernet key — required when using auth_mode oauth/dcr)
 # Generate: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 # MCP_TOKEN_ENCRYPTION_KEY=
+# Optional previous key during rotation (decrypt only — see README)
+# MCP_TOKEN_ENCRYPTION_KEY_PREVIOUS=
 # AGENT_PUBLIC_BASE_URL=http://localhost:5002
 
 # --- Infrastructure ---
@@ -67,3 +69,6 @@ GOOGLE_APPLICATION_CREDENTIALS_CONTENT='{
 # --- Runtime (rarely changed) ---
 
 PYTHON_LOG_LEVEL=INFO
+
+# Per-MCP OAuth client secret (auth_mode: oauth — referenced via oauth.client_secret_env in mcp.json)
+# MY_OAUTH_MCP_CLIENT_SECRET=your-client-secret

--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,11 @@ SSO_DEV_USER_ID=dev-user
 ENABLE_USER_ID_ENCRYPTION=false
 # USER_ID_ENCRYPTION_KEY=your-32-byte-hex-key
 
+# MCP OAuth token encryption (Fernet key — required when using auth_mode oauth/dcr)
+# Generate: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+# MCP_TOKEN_ENCRYPTION_KEY=
+# AGENT_PUBLIC_BASE_URL=http://localhost:5002
+
 # --- Infrastructure ---
 
 # Postgres (checkpoints, memory, feedback)

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ orchestrator's MCP list.
 | `auth_mode` | When to use | How credentials work |
 |---|---|---|
 | `sso` (default) | MCP accepts the same SSO token as the agent (e.g. RH-SSO) | User's request Bearer token is forwarded to the MCP on every tool call |
-| `oauth` | MCP has a pre-registered OAuth client | User connects once via the chat UI; per-user tokens are stored in Postgres |
+| `oauth` | MCP has a pre-registered OAuth client | User connects once via the chat UI; per-user tokens are stored encrypted in Redis |
 | `dcr` | MCP supports OAuth Dynamic Client Registration | Agent registers a client at startup/connect, then same per-user OAuth flow as `oauth` |
 
 Set `"auth": false` to call an MCP without an `Authorization` header (public/local servers only).
@@ -252,7 +252,7 @@ tools:
 When using `auth_mode: "oauth"` or `"dcr"`:
 
 ```bash
-# Fernet key for encrypting tokens at rest in Postgres (required)
+# Fernet key for encrypting tokens at rest in Redis (required)
 # Generate: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 MCP_TOKEN_ENCRYPTION_KEY=...
 
@@ -267,10 +267,10 @@ MCP_TOKEN_ENCRYPTION_KEY=...
 # Local dev: http://localhost:5002  |  Production: https://your-agent.example.com
 AGENT_PUBLIC_BASE_URL=http://localhost:5002
 
-# Redis stores short-lived OAuth PKCE state during the connect flow (required)
+# Redis stores encrypted per-user OAuth tokens and short-lived PKCE state (required)
 REDIS_URL=redis://localhost:6379/0
 
-# Postgres stores per-user tokens and DCR client records (required)
+# Postgres stores DCR client records (required for auth_mode: dcr)
 POSTGRES_HOST=...
 ```
 
@@ -281,10 +281,10 @@ Do not use `http://` outside local development — tokens can be intercepted in 
 
 ### Encryption key rotation
 
-`MCP_TOKEN_ENCRYPTION_KEY` encrypts OAuth access/refresh tokens and DCR client secrets
-in Postgres (`mcp_oauth_tokens`, `mcp_oauth_clients`). The agent supports **dual-key
-decryption** so you can rotate without wiping the database or forcing every user to
-re-authenticate immediately.
+`MCP_TOKEN_ENCRYPTION_KEY` encrypts OAuth access/refresh tokens in Redis and DCR
+client secrets in Postgres (`mcp_oauth_clients`). The agent supports **dual-key
+decryption** so you can rotate without wiping stored credentials or forcing every
+user to re-authenticate immediately.
 
 **Planned rotation (zero-downtime):**
 
@@ -294,8 +294,8 @@ re-authenticate immediately.
 3. Rolling-restart all agent pods. New writes use the new key; reads succeed for
    ciphertext encrypted with either key.
 4. Wait for natural re-encryption: tokens are rewritten with the new key on OAuth
-   callback, token refresh, or reconnect. DCR `client_secret` values are rewritten
-   on the next `upsert_client`.
+   callback or token refresh. DCR `client_secret` values are rewritten on the next
+   `upsert_client`.
 5. When all rows have been touched (or after a maintenance window), remove
    `MCP_TOKEN_ENCRYPTION_KEY_PREVIOUS` and restart again.
 
@@ -303,11 +303,12 @@ re-authenticate immediately.
 
 1. Generate a new Fernet key and set it as `MCP_TOKEN_ENCRYPTION_KEY`.
 2. Delete stored credentials so nothing encrypted with the leaked key remains:
-   `DELETE FROM mcp_oauth_tokens; DELETE FROM mcp_oauth_clients;`
+   - Redis tokens: `redis-cli --scan --pattern 'aegra:mcp_oauth_token:*' | xargs redis-cli DEL`
+   - DCR clients: `DELETE FROM mcp_oauth_clients;`
 3. Restart agent pods. Users must reconnect OAuth/DCR MCPs; DCR servers re-register
    on next connect.
 4. Revoke OAuth clients at the identity provider if the old key exposure could have
-   leaked plaintext tokens from Postgres backups or dumps.
+   leaked plaintext tokens from Redis dumps or Postgres backups.
 
 If decryption fails (wrong keys or corrupt data), the agent logs an error and the
 affected MCP call returns an authorization error until the user reconnects.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Client examples (Streamlit, Python async) are in [`examples/`](./examples/).
 | `SSL_KEYFILE` | — | No |
 | `SSL_CERTFILE` | — | No |
 | `MCP_TOKEN_ENCRYPTION_KEY` | — | Yes (for `oauth` / `dcr` MCPs) |
+| `MCP_TOKEN_ENCRYPTION_KEY_PREVIOUS` | — | No (decrypt-only; set during key rotation) |
 | `AGENT_PUBLIC_BASE_URL` | `http://localhost:{AGENT_PORT}` | Yes (for `oauth` / `dcr` in production) |
 
 Runtime configuration (cache TTLs, memory settings, agent identity) is in `config/agent/runtime/agent.yaml`.
@@ -123,8 +124,8 @@ Use when the MCP server validates the same SSO access token as the agent (token 
 
 #### OAuth example (pre-registered client)
 
-Use when you already have a `client_id` (and optionally `client_secret`) from the MCP
-provider. Users connect through the chat UI before tools are available.
+Use when you already have a `client_id` (and optionally a client secret via environment
+variable) from the MCP provider. Users connect through the chat UI before tools are available.
 
 ```json
 {
@@ -139,16 +140,18 @@ provider. Users connect through the chat UI before tools are available.
       "timeout": 30,
       "oauth": {
         "client_id": "your-client-id",
-        "client_secret": "your-client-secret",
+        "client_secret_env": "MY_OAUTH_MCP_CLIENT_SECRET",
         "authorization_endpoint": "https://auth.example.com/authorize",
         "token_endpoint": "https://auth.example.com/token",
-        "redirect_uri": "http://localhost:5002/mcp/oauth/callback",
         "scopes": ["read", "write"]
       }
     }
   }
 }
 ```
+
+The OAuth redirect URI is derived at runtime from `AGENT_PUBLIC_BASE_URL` as
+`{AGENT_PUBLIC_BASE_URL}/mcp/oauth/callback` — do not set `redirect_uri` in `mcp.json`.
 
 **Required `oauth` fields for `auth_mode: "oauth"`:**
 
@@ -157,9 +160,16 @@ provider. Users connect through the chat UI before tools are available.
 | `client_id` | **Yes** | Pre-registered OAuth client ID |
 | `authorization_endpoint` | **Yes** | Authorization URL |
 | `token_endpoint` | **Yes** | Token exchange URL |
-| `redirect_uri` | **Yes** | Must be `{AGENT_PUBLIC_BASE_URL}/mcp/oauth/callback` |
-| `client_secret` | No | Client secret (if the provider issued one) |
+| `client_secret_env` | No | Name of an environment variable holding the client secret (preferred) |
 | `scopes` | No | OAuth scopes (array of strings) |
+
+**Security:** Never put `client_secret` in `mcp.json` — it is version-controlled and
+easy to leak. Use `client_secret_env` and set the secret in `.env` or your secret
+manager. Inline `client_secret` in config still works but logs a deprecation warning.
+
+**HTTPS:** Set `AGENT_PUBLIC_BASE_URL` to `https://…` in production. Use
+`http://localhost:{AGENT_PORT}` only for local development; authorization codes and
+tokens can be intercepted when OAuth callbacks use plain HTTP.
 
 #### DCR example (dynamic client registration)
 
@@ -182,7 +192,6 @@ Use when the MCP provider exposes a registration endpoint (e.g. Atlassian MCP, l
         "authorization_endpoint": "https://mcp.atlassian.com/v1/authorize",
         "token_endpoint": "https://cf.mcp.atlassian.com/v1/token",
         "registration_endpoint": "https://cf.mcp.atlassian.com/v1/register",
-        "redirect_uri": "http://localhost:5002/mcp/oauth/callback",
         "scopes": ["jira:read"]
       }
     }
@@ -197,7 +206,6 @@ Use when the MCP provider exposes a registration endpoint (e.g. Atlassian MCP, l
 | `authorization_endpoint` | **Yes** | Authorization URL |
 | `token_endpoint` | **Yes** | Token exchange and refresh URL |
 | `registration_endpoint` | **Yes** | DCR registration URL |
-| `redirect_uri` | **Yes** | Must be `{AGENT_PUBLIC_BASE_URL}/mcp/oauth/callback` |
 | `scopes` | No | OAuth scopes requested at registration and authorize time |
 
 `client_id` and `client_secret` are **not** set in config — they are created at runtime
@@ -248,8 +256,15 @@ When using `auth_mode: "oauth"` or `"dcr"`:
 # Generate: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 MCP_TOKEN_ENCRYPTION_KEY=...
 
-# Public URL where the agent is reachable (used in redirect_uri and connect URLs)
-# Must match oauth.redirect_uri host in mcp.json
+# Optional previous key during rotation (decrypt-only; see "Encryption key rotation" below)
+# MCP_TOKEN_ENCRYPTION_KEY_PREVIOUS=...
+
+# Per-MCP OAuth client secret (auth_mode: oauth — set in .env, referenced via
+# oauth.client_secret_env in mcp.json; never commit real secrets in mcp.json)
+# MY_OAUTH_MCP_CLIENT_SECRET=your-client-secret
+
+# Public URL where the agent is reachable (OAuth redirect URI and connect URLs)
+# Local dev: http://localhost:5002  |  Production: https://your-agent.example.com
 AGENT_PUBLIC_BASE_URL=http://localhost:5002
 
 # Redis stores short-lived OAuth PKCE state during the connect flow (required)
@@ -260,8 +275,42 @@ POSTGRES_HOST=...
 ```
 
 In production behind a gateway or ingress, set `AGENT_PUBLIC_BASE_URL` to the
-externally reachable agent URL and update every `oauth.redirect_uri` in `mcp.json`
-to `{AGENT_PUBLIC_BASE_URL}/mcp/oauth/callback`.
+externally reachable **HTTPS** URL (e.g. `https://agent.example.com`). The OAuth
+redirect URI is derived automatically as `{AGENT_PUBLIC_BASE_URL}/mcp/oauth/callback`.
+Do not use `http://` outside local development — tokens can be intercepted in transit.
+
+### Encryption key rotation
+
+`MCP_TOKEN_ENCRYPTION_KEY` encrypts OAuth access/refresh tokens and DCR client secrets
+in Postgres (`mcp_oauth_tokens`, `mcp_oauth_clients`). The agent supports **dual-key
+decryption** so you can rotate without wiping the database or forcing every user to
+re-authenticate immediately.
+
+**Planned rotation (zero-downtime):**
+
+1. Generate a new Fernet key.
+2. Set `MCP_TOKEN_ENCRYPTION_KEY_PREVIOUS` to the **current** key and
+   `MCP_TOKEN_ENCRYPTION_KEY` to the **new** key.
+3. Rolling-restart all agent pods. New writes use the new key; reads succeed for
+   ciphertext encrypted with either key.
+4. Wait for natural re-encryption: tokens are rewritten with the new key on OAuth
+   callback, token refresh, or reconnect. DCR `client_secret` values are rewritten
+   on the next `upsert_client`.
+5. When all rows have been touched (or after a maintenance window), remove
+   `MCP_TOKEN_ENCRYPTION_KEY_PREVIOUS` and restart again.
+
+**Emergency rotation (key compromised):**
+
+1. Generate a new Fernet key and set it as `MCP_TOKEN_ENCRYPTION_KEY`.
+2. Delete stored credentials so nothing encrypted with the leaked key remains:
+   `DELETE FROM mcp_oauth_tokens; DELETE FROM mcp_oauth_clients;`
+3. Restart agent pods. Users must reconnect OAuth/DCR MCPs; DCR servers re-register
+   on next connect.
+4. Revoke OAuth clients at the identity provider if the old key exposure could have
+   leaked plaintext tokens from Postgres backups or dumps.
+
+If decryption fails (wrong keys or corrupt data), the agent logs an error and the
+affected MCP call returns an authorization error until the user reconnects.
 
 ### OAuth HTTP endpoints
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Client examples (Streamlit, Python async) are in [`examples/`](./examples/).
 | `POSTGRES_DB` | `pgvector` | Yes |
 | `POSTGRES_HOST` | `pgvector` | Yes |
 | `POSTGRES_PORT` | `5432` | Yes |
-| `REDIS_URL` | `redis://redis:6379/0` | No |
+| `REDIS_URL` | `redis://redis:6379/0` | No (Yes for `oauth` / `dcr` MCPs) |
 | `GOOGLE_SERVICE_ACCOUNT_FILE` | — | Yes |
 | `LANGFUSE_PUBLIC_KEY` | — | No |
 | `LANGFUSE_SECRET_KEY` | — | No |
@@ -59,8 +59,234 @@ Client examples (Streamlit, Python async) are in [`examples/`](./examples/).
 | `LANGFUSE_TRACING_ENVIRONMENT` | `development` | No |
 | `SSL_KEYFILE` | — | No |
 | `SSL_CERTFILE` | — | No |
+| `MCP_TOKEN_ENCRYPTION_KEY` | — | Yes (for `oauth` / `dcr` MCPs) |
+| `AGENT_PUBLIC_BASE_URL` | `http://localhost:{AGENT_PORT}` | Yes (for `oauth` / `dcr` in production) |
 
 Runtime configuration (cache TTLs, memory settings, agent identity) is in `config/agent/runtime/agent.yaml`.
+
+## MCP Server Configuration
+
+MCP servers are defined in `config/agent/mcp.json` and attached to agents via the
+`mcps` frontmatter field in `config/agent/PROMPT.md` (orchestrator) or
+`config/agent/subagents/*.md`. Subagents that omit `mcps` inherit the
+orchestrator's MCP list.
+
+### Auth modes
+
+| `auth_mode` | When to use | How credentials work |
+|---|---|---|
+| `sso` (default) | MCP accepts the same SSO token as the agent (e.g. RH-SSO) | User's request Bearer token is forwarded to the MCP on every tool call |
+| `oauth` | MCP has a pre-registered OAuth client | User connects once via the chat UI; per-user tokens are stored in Postgres |
+| `dcr` | MCP supports OAuth Dynamic Client Registration | Agent registers a client at startup/connect, then same per-user OAuth flow as `oauth` |
+
+Set `"auth": false` to call an MCP without an `Authorization` header (public/local servers only).
+
+### `mcp.json` schema
+
+Each entry under `mcpServers` is keyed by a **server name** (referenced in agent frontmatter).
+The name must match exactly in `mcps:` lists.
+
+#### Common properties (all modes)
+
+| Property | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `url` | string | **Yes** | — | MCP server endpoint (e.g. `http://localhost:5001/mcp`) |
+| `transport` | string | No | `streamable_http` | MCP transport (`streamable_http`, `http`, etc.) |
+| `enabled` | boolean | No | `true` | When `false`, the server is ignored at runtime |
+| `auth` | boolean | No | `true` | When `false`, no Bearer token is sent |
+| `auth_mode` | string | No | `sso` | One of `sso`, `oauth`, `dcr` |
+| `ssl_verify` | boolean | No | `true` | TLS certificate verification for MCP HTTP calls |
+| `timeout` | number | No | `30` | Connection timeout in seconds |
+
+#### SSO example
+
+Use when the MCP server validates the same SSO access token as the agent (token pass-through).
+
+```json
+{
+  "mcpServers": {
+    "template-mcp-server": {
+      "url": "http://localhost:5001/mcp",
+      "transport": "streamable_http",
+      "enabled": true,
+      "auth": true,
+      "auth_mode": "sso",
+      "ssl_verify": false,
+      "timeout": 30
+    }
+  }
+}
+```
+
+**Required:** `url`
+**No `oauth` block needed.**
+
+#### OAuth example (pre-registered client)
+
+Use when you already have a `client_id` (and optionally `client_secret`) from the MCP
+provider. Users connect through the chat UI before tools are available.
+
+```json
+{
+  "mcpServers": {
+    "my-oauth-mcp": {
+      "url": "https://mcp.example.com/mcp",
+      "transport": "streamable_http",
+      "enabled": true,
+      "auth": true,
+      "auth_mode": "oauth",
+      "ssl_verify": true,
+      "timeout": 30,
+      "oauth": {
+        "client_id": "your-client-id",
+        "client_secret": "your-client-secret",
+        "authorization_endpoint": "https://auth.example.com/authorize",
+        "token_endpoint": "https://auth.example.com/token",
+        "redirect_uri": "http://localhost:5002/mcp/oauth/callback",
+        "scopes": ["read", "write"]
+      }
+    }
+  }
+}
+```
+
+**Required `oauth` fields for `auth_mode: "oauth"`:**
+
+| Field | Required | Description |
+|---|---|---|
+| `client_id` | **Yes** | Pre-registered OAuth client ID |
+| `authorization_endpoint` | **Yes** | Authorization URL |
+| `token_endpoint` | **Yes** | Token exchange URL |
+| `redirect_uri` | **Yes** | Must be `{AGENT_PUBLIC_BASE_URL}/mcp/oauth/callback` |
+| `client_secret` | No | Client secret (if the provider issued one) |
+| `scopes` | No | OAuth scopes (array of strings) |
+
+#### DCR example (dynamic client registration)
+
+Use when the MCP provider exposes a registration endpoint (e.g. Atlassian MCP, local
+`template-mcp-server-rh-sso`). The agent registers itself and stores the resulting
+`client_id` in Postgres — no manual `client_id` in config.
+
+```json
+{
+  "mcpServers": {
+    "jira-mcp-server-dcr": {
+      "url": "https://mcp.atlassian.com/v1/mcp/authv2",
+      "transport": "streamable_http",
+      "enabled": true,
+      "auth": true,
+      "auth_mode": "dcr",
+      "ssl_verify": true,
+      "timeout": 30,
+      "oauth": {
+        "authorization_endpoint": "https://mcp.atlassian.com/v1/authorize",
+        "token_endpoint": "https://cf.mcp.atlassian.com/v1/token",
+        "registration_endpoint": "https://cf.mcp.atlassian.com/v1/register",
+        "redirect_uri": "http://localhost:5002/mcp/oauth/callback",
+        "scopes": ["jira:read"]
+      }
+    }
+  }
+}
+```
+
+**Required `oauth` fields for `auth_mode: "dcr"`:**
+
+| Field | Required | Description |
+|---|---|---|
+| `authorization_endpoint` | **Yes** | Authorization URL |
+| `token_endpoint` | **Yes** | Token exchange and refresh URL |
+| `registration_endpoint` | **Yes** | DCR registration URL |
+| `redirect_uri` | **Yes** | Must be `{AGENT_PUBLIC_BASE_URL}/mcp/oauth/callback` |
+| `scopes` | No | OAuth scopes requested at registration and authorize time |
+
+`client_id` and `client_secret` are **not** set in config — they are created at runtime
+and stored in the `mcp_oauth_clients` table.
+
+#### Unauthenticated example
+
+```json
+{
+  "mcpServers": {
+    "local-mock-mcp": {
+      "url": "http://localhost:8000/mcp",
+      "transport": "streamable_http",
+      "enabled": true,
+      "auth": false
+    }
+  }
+}
+```
+
+### Wiring MCPs to agents
+
+Reference server names from `mcp.json` in agent frontmatter:
+
+```yaml
+---
+name: jira
+model: gemini-2.5-pro
+mcps:
+  - jira-mcp-server-dcr
+tools:
+  - searchJiraIssuesUsingJql
+  - getJiraIssue
+---
+```
+
+- **Orchestrator:** add `mcps:` to `config/agent/PROMPT.md` frontmatter.
+- **Subagent:** add `mcps:` to `config/agent/subagents/<name>.md` frontmatter.
+- **Inheritance:** subagents without `mcps` inherit the orchestrator's list.
+- **Validation:** every name in `mcps` must exist in `mcp.json` and have `enabled: true`.
+
+### Environment variables for OAuth / DCR
+
+When using `auth_mode: "oauth"` or `"dcr"`:
+
+```bash
+# Fernet key for encrypting tokens at rest in Postgres (required)
+# Generate: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+MCP_TOKEN_ENCRYPTION_KEY=...
+
+# Public URL where the agent is reachable (used in redirect_uri and connect URLs)
+# Must match oauth.redirect_uri host in mcp.json
+AGENT_PUBLIC_BASE_URL=http://localhost:5002
+
+# Redis stores short-lived OAuth PKCE state during the connect flow (required)
+REDIS_URL=redis://localhost:6379/0
+
+# Postgres stores per-user tokens and DCR client records (required)
+POSTGRES_HOST=...
+```
+
+In production behind a gateway or ingress, set `AGENT_PUBLIC_BASE_URL` to the
+externally reachable agent URL and update every `oauth.redirect_uri` in `mcp.json`
+to `{AGENT_PUBLIC_BASE_URL}/mcp/oauth/callback`.
+
+### OAuth HTTP endpoints
+
+These routes are registered on the Aegra custom app (`deep_agent/aegra/http_app.py`):
+
+| Endpoint | Method | Auth | Description |
+|---|---|---|---|
+| `/mcp/{name}/connect` | POST | Bearer (SSO) | Start OAuth flow; returns `{ "authorize_url": "..." }` |
+| `/mcp/oauth/callback` | GET | None (state-bound) | OAuth redirect target; exchanges code and stores tokens |
+| `/mcp/{name}/status` | GET | Bearer (SSO) | Returns `{ "connected": true/false }` for the current user |
+| `/info` | GET | None | Returns agent name and list of OAuth/DCR MCP server names |
+
+The chat UI calls connect/status through its BFF proxy. The OAuth provider redirects
+the user's browser directly to `/mcp/oauth/callback` on the agent.
+
+### Choosing an auth mode
+
+| Scenario | Recommended mode |
+|---|---|
+| MCP shares RH-SSO / Keycloak with the agent | `sso` |
+| MCP issued you a static OAuth client | `oauth` |
+| MCP supports RFC 7591 dynamic registration (Atlassian, template-mcp-server-rh-sso) | `dcr` |
+| Local dev mock with no auth | `auth: false` |
+
+See `config/agent/mcp.json` for working examples of `sso`, `dcr`, and Jira/Atlassian MCP.
 
 ## Project Structure
 

--- a/aegra.json
+++ b/aegra.json
@@ -10,7 +10,7 @@
   "env": ".env",
   "python_version": "3.12",
   "http": {
-    "app": "./deep_agent/aegra/feedback.py:app",
+    "app": "./deep_agent/aegra/http_app.py:app",
     "cors": {
       "allow_origins": ["http://localhost:3000", "http://127.0.0.1:3000", "http://localhost:8080", "http://127.0.0.1:8080"],
       "allow_methods": ["*"],

--- a/config/agent/mcp.json
+++ b/config/agent/mcp.json
@@ -5,8 +5,41 @@
             "transport": "streamable_http",
             "enabled": true,
             "auth": true,
+            "auth_mode": "sso",
             "ssl_verify": false,
             "timeout": 30
+        },
+        "template-mcp-server-dcr": {
+            "url": "http://localhost:5001/mcp",
+            "transport": "streamable_http",
+            "enabled": false,
+            "auth": true,
+            "auth_mode": "dcr",
+            "ssl_verify": false,
+            "timeout": 30,
+            "oauth": {
+                "authorization_endpoint": "http://localhost:5001/auth/authorize",
+                "token_endpoint": "http://localhost:5001/auth/token",
+                "registration_endpoint": "http://localhost:5001/auth/register",
+                "scopes": ["email", "openid", "profile", "session:role-any"],
+                "redirect_uri": "http://localhost:5002/mcp/oauth/callback"
+            }
+        },
+        "jira-mcp-server-dcr": {
+            "url": "https://mcp.atlassian.com/v1/mcp/authv2",
+            "transport": "streamable_http",
+            "enabled": true,
+            "auth": true,
+            "auth_mode": "dcr",
+            "ssl_verify": false,
+            "timeout": 30,
+            "oauth": {
+                "authorization_endpoint": "https://mcp.atlassian.com/v1/authorize",
+                "token_endpoint": "https://cf.mcp.atlassian.com/v1/token",
+                "registration_endpoint": "https://cf.mcp.atlassian.com/v1/register",
+                "scopes": ["jira:read"],
+                "redirect_uri": "http://localhost:5002/mcp/oauth/callback"
+            }
         }
     }
 }

--- a/config/agent/mcp.json
+++ b/config/agent/mcp.json
@@ -21,8 +21,7 @@
                 "authorization_endpoint": "http://localhost:5001/auth/authorize",
                 "token_endpoint": "http://localhost:5001/auth/token",
                 "registration_endpoint": "http://localhost:5001/auth/register",
-                "scopes": ["email", "openid", "profile", "session:role-any"],
-                "redirect_uri": "http://localhost:5002/mcp/oauth/callback"
+                "scopes": ["email", "openid", "profile", "session:role-any"]
             }
         }
     }

--- a/config/agent/mcp.json
+++ b/config/agent/mcp.json
@@ -24,22 +24,6 @@
                 "scopes": ["email", "openid", "profile", "session:role-any"],
                 "redirect_uri": "http://localhost:5002/mcp/oauth/callback"
             }
-        },
-        "jira-mcp-server-dcr": {
-            "url": "https://mcp.atlassian.com/v1/mcp/authv2",
-            "transport": "streamable_http",
-            "enabled": true,
-            "auth": true,
-            "auth_mode": "dcr",
-            "ssl_verify": false,
-            "timeout": 30,
-            "oauth": {
-                "authorization_endpoint": "https://mcp.atlassian.com/v1/authorize",
-                "token_endpoint": "https://cf.mcp.atlassian.com/v1/token",
-                "registration_endpoint": "https://cf.mcp.atlassian.com/v1/register",
-                "scopes": ["jira:read"],
-                "redirect_uri": "http://localhost:5002/mcp/oauth/callback"
-            }
         }
     }
 }

--- a/deep_agent/aegra/feedback.py
+++ b/deep_agent/aegra/feedback.py
@@ -1,8 +1,8 @@
-"""User feedback HTTP endpoint for Langfuse scores (B-1).
+"""User feedback HTTP endpoints for Langfuse scores (B-1).
 
-Registers ``POST /feedback`` on the Aegra custom FastAPI app (see
-``http.app`` in ``aegra.json``). Aegra loads this app as the base
-application and merges core LangGraph Platform routes onto it.
+Registers ``POST /feedback`` and ``GET /feedback/{thread_id}`` on the
+Aegra custom FastAPI app via :data:`feedback_router` (mounted from
+``http_app.py``).
 
 When Langfuse credentials are absent, submissions are logged and accepted
 without contacting Langfuse.
@@ -15,84 +15,20 @@ from __future__ import annotations
 
 import json
 from typing import Any, Literal
-from uuid import uuid4
 
-from fastapi import FastAPI, Request
+from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
-from starlette.middleware.base import BaseHTTPMiddleware
 
 from deep_agent.aegra.telemetry import get_langfuse_client
-from deep_agent.src.agent.config import agent_config
 from deep_agent.src.feedback.repository import FeedbackRepository
 from deep_agent.src.schema import FeedbackRequest, FeedbackResponse
 from deep_agent.src.settings import settings
-from deep_agent.utils.pylogger import (
-    bind_request_context,
-    clear_request_context,
-    get_python_logger,
-)
+from deep_agent.utils.pylogger import get_python_logger
 
 logger = get_python_logger()
 
-
-def _patch_aegra_persistence_if_inmemory() -> None:
-    """Disable aegra_api database initialization when running in-memory mode.
-
-    The aegra_api lifespan unconditionally calls db_manager.initialize() which
-    opens a PostgreSQL connection pool. When deploying without a database
-    (USE_INMEMORY_SAVER=true), this causes the pod to crash. This patch
-    replaces initialize() with a no-op so the lifespan completes cleanly.
-    """
-    import os
-
-    disable_persistence = os.environ.get("AEGRA_DISABLE_PERSISTENCE", "").lower() in (
-        "true",
-        "1",
-    )
-    use_inmemory = os.environ.get("USE_INMEMORY_SAVER", "").lower() in ("true", "1")
-
-    if not (disable_persistence or use_inmemory):
-        return
-
-    try:
-        from aegra_api.core.database import db_manager
-
-        async def _noop_initialize() -> None:
-            logger.info("aegra_db_initialize_skipped_inmemory_mode")
-
-        db_manager.initialize = _noop_initialize  # type: ignore[method-assign]
-        logger.info("aegra_persistence_patched_for_inmemory_mode")
-    except ImportError:
-        pass
-
-
-_patch_aegra_persistence_if_inmemory()
-
-from deep_agent.aegra.shutdown import register_atexit
-
-register_atexit()
-
-app = FastAPI(title="template-agent-custom")
-
-
-class TraceIDMiddleware(BaseHTTPMiddleware):
-    """Propagate X-Trace-ID from incoming requests into the logging context.
-
-    Every log line emitted during a request will include the trace_id,
-    enabling end-to-end correlation across UI → BFF → Agent.
-    """
-
-    async def dispatch(self, request: Request, call_next: Any) -> Any:
-        trace_id = request.headers.get("x-trace-id") or uuid4().hex
-        bind_request_context(trace_id=trace_id)
-        response = await call_next(request)
-        response.headers["X-Trace-ID"] = trace_id
-        clear_request_context()
-        return response
-
-
-app.add_middleware(TraceIDMiddleware)
+feedback_router = APIRouter(tags=["feedback"])
 
 
 def _score_to_feedback_polarity(req: FeedbackRequest) -> Literal["up", "down"]:
@@ -276,7 +212,7 @@ async def feedback_handler(request: Request) -> JSONResponse:
     )
 
 
-@app.get("/feedback/{thread_id}")
+@feedback_router.get("/feedback/{thread_id}")
 async def get_thread_feedback(
     thread_id: str, user_id: str = "anonymous"
 ) -> dict[str, Any]:
@@ -288,10 +224,4 @@ async def get_thread_feedback(
     return {"feedback": items}
 
 
-@app.get("/info")
-async def get_agent_info() -> dict[str, str]:
-    """Return agent identity metadata from config."""
-    return {"name": agent_config.get_name()}
-
-
-app.add_api_route("/feedback", feedback_handler, methods=["POST"])
+feedback_router.add_api_route("/feedback", feedback_handler, methods=["POST"])

--- a/deep_agent/aegra/graph.py
+++ b/deep_agent/aegra/graph.py
@@ -57,6 +57,13 @@ _graph_cache: dict[str, Any] = {}
 _graph_cache_ts: dict[str, float] = {}
 
 
+def invalidate_graph_cache() -> None:
+    """Clear the compiled graph cache (e.g. after MCP OAuth connect)."""
+    global _graph_cache, _graph_cache_ts  # noqa: PLW0603
+    _graph_cache.clear()
+    _graph_cache_ts.clear()
+
+
 def _graph_fingerprint(
     model_name: str,
     system_prompt: str,
@@ -103,12 +110,12 @@ async def agent(runtime: ServerRuntime) -> Any:
         refresh_access_token,
         set_mcp_auth_context,
     )
+    from deep_agent.aegra.mcp_tool_auth import wrap_mcp_tools_for_auth
     from deep_agent.src.agent.config import agent_config
     from deep_agent.src.infrastructure.async_tasks import build_async_middleware
     from deep_agent.src.infrastructure.backend import get_configured_backend
     from deep_agent.src.infrastructure.providers import (
         register_profiles_from_config,
-        resolve_model_from_config,
     )
     from deep_agent.src.infrastructure.subagents import load_subagents
 
@@ -119,8 +126,9 @@ async def agent(runtime: ServerRuntime) -> Any:
     if sso_token:
         sso_token = await refresh_access_token(sso_token, refresh_token)
 
-    set_mcp_auth_context(sso_token, refresh_token)
+    user_identity = getattr(user, "identity", None) if user else None
 
+    set_mcp_auth_context(sso_token, refresh_token, user_identity)
     orchestrator_cfg = agent_config.get_orchestrator_config()
     agent_name = orchestrator_cfg.get("name", "orchestrator")
     orch_model_raw = orchestrator_cfg.get("model", "gemini-3.1-pro-preview")
@@ -129,7 +137,6 @@ async def agent(runtime: ServerRuntime) -> Any:
     tool_names = orchestrator_cfg.get("tools", [])
     mcp_server_names = orchestrator_cfg.get("mcps", [])
 
-    user_identity = getattr(user, "identity", None) if user else None
     if user_identity:
         try:
             from deep_agent.src.cache.personalization_cache import (
@@ -199,7 +206,9 @@ async def agent(runtime: ServerRuntime) -> Any:
     mcp_tools = await get_mcp_tools(
         sso_token=sso_token,
         server_names=mcp_server_names or None,
+        user_id=user_identity,
     )
+    mcp_tools = wrap_mcp_tools_for_auth(mcp_tools)
     tools = agent_config.resolve_tools(tool_names, mcp_tools, agent_name=agent_name)
     if not tools and not tool_names and mcp_server_names and mcp_tools:
         logger.info(

--- a/deep_agent/aegra/http_app.py
+++ b/deep_agent/aegra/http_app.py
@@ -1,0 +1,85 @@
+"""Aegra custom FastAPI application (``http.app`` entry point).
+
+Registers route modules on a single app that Aegra loads as the base
+application and merges core LangGraph Platform routes onto.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+from fastapi import FastAPI, Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from deep_agent.aegra.feedback import feedback_router
+from deep_agent.aegra.mcp_routes import router as mcp_router
+from deep_agent.utils.pylogger import (
+    bind_request_context,
+    clear_request_context,
+    get_python_logger,
+)
+
+logger = get_python_logger()
+
+
+def _patch_aegra_persistence_if_inmemory() -> None:
+    """Disable aegra_api database initialization when running in-memory mode.
+
+    The aegra_api lifespan unconditionally calls db_manager.initialize() which
+    opens a PostgreSQL connection pool. When deploying without a database
+    (USE_INMEMORY_SAVER=true), this causes the pod to crash. This patch
+    replaces initialize() with a no-op so the lifespan completes cleanly.
+    """
+    import os
+
+    disable_persistence = os.environ.get("AEGRA_DISABLE_PERSISTENCE", "").lower() in (
+        "true",
+        "1",
+    )
+    use_inmemory = os.environ.get("USE_INMEMORY_SAVER", "").lower() in ("true", "1")
+
+    if not (disable_persistence or use_inmemory):
+        return
+
+    try:
+        from aegra_api.core.database import db_manager
+
+        async def _noop_initialize() -> None:
+            logger.info("aegra_db_initialize_skipped_inmemory_mode")
+
+        db_manager.initialize = _noop_initialize
+        logger.info("aegra_persistence_patched_for_inmemory_mode")
+    except ImportError:
+        pass
+
+
+_patch_aegra_persistence_if_inmemory()
+
+from deep_agent.aegra.shutdown import register_atexit  # noqa: E402
+
+register_atexit()
+
+app = FastAPI(title="template-agent-custom")
+
+
+class TraceIDMiddleware(BaseHTTPMiddleware):
+    """Propagate X-Trace-ID from incoming requests into the logging context.
+
+    Every log line emitted during a request will include the trace_id,
+    enabling end-to-end correlation across UI → BFF → Agent.
+    """
+
+    async def dispatch(self, request: Request, call_next: Any) -> Any:
+        """Bind trace ID to logging context and echo it on the response."""
+        trace_id = request.headers.get("x-trace-id") or uuid4().hex
+        bind_request_context(trace_id=trace_id)
+        response = await call_next(request)
+        response.headers["X-Trace-ID"] = trace_id
+        clear_request_context()
+        return response
+
+
+app.add_middleware(TraceIDMiddleware)
+app.include_router(mcp_router)
+app.include_router(feedback_router)

--- a/deep_agent/aegra/mcp.py
+++ b/deep_agent/aegra/mcp.py
@@ -46,11 +46,18 @@ _current_access_token: contextvars.ContextVar[str | None] = contextvars.ContextV
 _current_refresh_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "_current_refresh_token", default=None
 )
+_current_user_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "_current_user_id", default=None
+)
+_mcp_tool_discovery: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "_mcp_tool_discovery", default=False
+)
 
 
 def set_mcp_auth_context(
     access_token: str | None,
     refresh_token: str | None,
+    user_id: str | None = None,
 ) -> None:
     """Store the current request's tokens for tool-call-time auth injection.
 
@@ -60,24 +67,65 @@ def set_mcp_auth_context(
     """
     _current_access_token.set(access_token)
     _current_refresh_token.set(refresh_token)
+    _current_user_id.set(user_id)
 
 
 class _TokenInjectorInterceptor:
-    """Inject the current request's SSO token into every MCP tool call.
+    """Inject the correct per-MCP bearer token into every MCP tool call."""
 
-    Reads the access token from the ``_current_access_token`` ContextVar
-    (set per-request by ``set_mcp_auth_context``) and overrides the
-    ``Authorization`` header on the outgoing MCP request. This ensures
-    cached tool objects always use the correct user's token.
-    """
+    def __init__(self, mcp_name: str, server_cfg: dict[str, Any]) -> None:
+        self._mcp_name = mcp_name
+        self._server_cfg = server_cfg
 
     async def __call__(self, request: Any, handler: Any) -> Any:
-        access = _current_access_token.get()
+        from deep_agent.aegra.mcp_auth import (
+            NeedsAuthorization,
+            get_mcp_credential_resolver,
+        )
+
+        user_id = _current_user_id.get()
+        auth_mode = self._server_cfg.get("auth_mode", "sso")
+
+        try:
+            if auth_mode in ("oauth", "dcr"):
+                if not user_id:
+                    if _mcp_tool_discovery.get():
+                        access = None
+                    else:
+                        raise NeedsAuthorization(
+                            self._mcp_name,
+                            get_mcp_credential_resolver().connect_url(self._mcp_name),
+                        )
+                else:
+                    try:
+                        access = await get_mcp_credential_resolver().resolve(
+                            user_id, self._mcp_name, self._server_cfg
+                        )
+                    except NeedsAuthorization:
+                        if _mcp_tool_discovery.get():
+                            access = None
+                        else:
+                            raise
+            else:
+                access = _current_access_token.get()
+                if access:
+                    access = await refresh_access_token(
+                        access, _current_refresh_token.get()
+                    )
+        except NeedsAuthorization:
+            raise
+        except Exception:
+            logger.error(
+                "[%s] credential resolution failed", self._mcp_name, exc_info=True
+            )
+            access = _current_access_token.get()
+
         if access:
             request = request.override(headers={"Authorization": f"Bearer {access}"})
-        else:
+        elif self._server_cfg.get("auth", True):
             logger.warning(
-                "TokenInjector: no access token in ContextVar — MCP call will use cached/anonymous auth"
+                "TokenInjector: no token for MCP '%s' — call may fail auth",
+                self._mcp_name,
             )
         return await handler(request)
 
@@ -173,6 +221,11 @@ async def refresh_access_token(
         return access_token
 
 
+def mcp_httpx_verify(server_cfg: dict[str, Any]) -> bool:
+    """Return the httpx ``verify`` flag for an MCP server config (default True)."""
+    return bool(server_cfg.get("ssl_verify", True))
+
+
 def _get_server_configs() -> dict[str, dict[str, Any]]:
     """Get pre-loaded MCP server configurations.
 
@@ -182,15 +235,40 @@ def _get_server_configs() -> dict[str, dict[str, Any]]:
     return agent_config.get_mcp_servers()
 
 
-def _build_server_config(
+async def _resolve_connection_token(
+    name: str,
     entry: dict[str, Any],
     sso_token: str | None,
+    user_id: str | None,
+) -> str | None:
+    """Resolve the bearer token used for MCP connection/tool discovery."""
+    auth_mode = entry.get("auth_mode", "sso")
+    if auth_mode == "sso":
+        return sso_token
+
+    if not user_id:
+        return None
+
+    from deep_agent.aegra.mcp_auth import (
+        NeedsAuthorization,
+        get_mcp_credential_resolver,
+    )
+
+    try:
+        return await get_mcp_credential_resolver().resolve(user_id, name, entry)
+    except NeedsAuthorization:
+        return None
+
+
+def _build_server_config(
+    entry: dict[str, Any],
+    bearer_token: str | None,
 ) -> dict[str, Any]:
     """Build MultiServerMCPClient config from server definition.
 
     Args:
         entry: Server definition with url, auth, ssl_verify, transport.
-        sso_token: Optional bearer token (should already be refreshed).
+        bearer_token: Optional bearer token for this MCP server.
 
     Returns:
         Config dict for MultiServerMCPClient.
@@ -198,8 +276,8 @@ def _build_server_config(
     from deep_agent.utils.pylogger import _trace_id_var
 
     headers: dict[str, str] = {}
-    if entry.get("auth", True) and sso_token:
-        headers["Authorization"] = f"Bearer {sso_token}"
+    if entry.get("auth", True) and bearer_token:
+        headers["Authorization"] = f"Bearer {bearer_token}"
 
     trace_id = _trace_id_var.get()
     if trace_id:
@@ -211,7 +289,7 @@ def _build_server_config(
         "headers": headers,
     }
 
-    if not entry.get("ssl_verify", True):
+    if not mcp_httpx_verify(entry):
         config["httpx_client_factory"] = lambda **kw: httpx.AsyncClient(
             verify=False, **kw
         )  # nosec B501
@@ -220,7 +298,12 @@ def _build_server_config(
 
 
 async def _connect_single_server(
-    name: str, config: dict[str, Any], timeout: int, *, required: bool = False
+    name: str,
+    config: dict[str, Any],
+    server_cfg: dict[str, Any],
+    timeout: int,
+    *,
+    required: bool = False,
 ) -> list[Any]:
     """Connect to one MCP server and return its tools.
 
@@ -230,6 +313,7 @@ async def _connect_single_server(
     Args:
         name: Human-readable server identifier used in log messages.
         config: MCP client connection config (url, transport, headers, etc.).
+        server_cfg: Raw MCP server definition from ``mcp.json`` (auth, ssl_verify).
         timeout: Seconds before the connection attempt is cancelled.
         required: If True the server is explicitly enabled in config,
             so connection failures are logged at error level.
@@ -243,7 +327,9 @@ async def _connect_single_server(
         async with asyncio.timeout(timeout):
             client = MultiServerMCPClient(
                 {name: config},
-                tool_interceptors=[_TokenInjectorInterceptor()],
+                tool_interceptors=[
+                    _TokenInjectorInterceptor(name, server_cfg),
+                ],
             )
             tools: list[Any] = await client.get_tools()
         logger.info(f"[{name}] loaded {len(tools)} tool(s)")
@@ -253,8 +339,27 @@ async def _connect_single_server(
         breaker.record_failure()
         logger.error(f"[{name}] timeout after {timeout}s ({config.get('url')})")
     except Exception as exc:
-        if _is_auth_error(exc):
-            logger.warning(f"[{name}] MCP auth failed — {type(exc).__name__}: {exc}")
+        from deep_agent.aegra.mcp_auth import get_mcp_credential_resolver
+
+        if _is_needs_authorization(exc):
+            logger.info(
+                "[%s] MCP OAuth required — connect at %s",
+                name,
+                get_mcp_credential_resolver().connect_url(name),
+            )
+        elif _is_auth_error(exc):
+            auth_mode = server_cfg.get("auth_mode", "sso")
+            if auth_mode in ("oauth", "dcr"):
+                logger.info(
+                    "[%s] MCP tool discovery auth failed — connect OAuth first "
+                    "(POST /mcp/%s/connect)",
+                    name,
+                    name,
+                )
+            else:
+                logger.warning(
+                    f"[{name}] MCP auth failed — {type(exc).__name__}: {exc}"
+                )
         elif _is_connection_error(exc) and not required:
             breaker.record_failure()
             logger.warning(f"[{name}] not reachable ({config.get('url')}) — skipped")
@@ -266,15 +371,41 @@ async def _connect_single_server(
     return []
 
 
+def _is_needs_authorization(exc: BaseException) -> bool:
+    """Check if an exception chain contains NeedsAuthorization."""
+    from deep_agent.aegra.mcp_auth import NeedsAuthorization
+
+    for sub in getattr(exc, "exceptions", [exc]):
+        if isinstance(sub, NeedsAuthorization):
+            return True
+        if (
+            hasattr(sub, "__cause__")
+            and sub.__cause__
+            and _is_needs_authorization(sub.__cause__)
+        ):
+            return True
+    return False
+
+
 def _is_auth_error(exc: BaseException) -> bool:
     """Check if an exception is caused by an HTTP 401/403 response."""
     for sub in getattr(exc, "exceptions", [exc]):
+        response = getattr(sub, "response", None)
+        if response is not None:
+            status = getattr(response, "status_code", None)
+            if status in (401, 403):
+                return True
         msg: str = str(sub)
         if "401" in msg or "403" in msg or "Unauthorized" in msg or "Forbidden" in msg:
             return True
-        if hasattr(sub, "__cause__") and sub.__cause__:
-            if _is_auth_error(sub.__cause__):
-                return True
+        if sub.__cause__ and _is_auth_error(sub.__cause__):
+            return True
+        if (
+            sub.__context__
+            and sub is not sub.__context__
+            and _is_auth_error(sub.__context__)
+        ):
+            return True
     return False
 
 
@@ -311,9 +442,17 @@ def _filter_by_names(
     return {k: v for k, v in enabled.items() if k in requested}
 
 
+def invalidate_mcp_tool_cache() -> None:
+    """Clear the global MCP tool list cache (e.g. after OAuth connect)."""
+    global _cached_tools, _cached_tools_ts  # noqa: PLW0603
+    _cached_tools = []
+    _cached_tools_ts = 0.0
+
+
 async def get_mcp_tools(
     sso_token: str | None = None,
     server_names: list[str] | None = None,
+    user_id: str | None = None,
 ) -> list[Any]:
     """Connect to MCP server(s) and retrieve available tools.
 
@@ -346,7 +485,11 @@ async def get_mcp_tools(
     """
     global _cached_tools, _cached_tools_ts  # noqa: PLW0603
 
-    if _cached_tools and (time.time() - _cached_tools_ts) < _MCP_TOOL_CACHE_TTL:
+    if (
+        _cached_tools
+        and len(_cached_tools) > 0
+        and (time.time() - _cached_tools_ts) < _MCP_TOOL_CACHE_TTL
+    ):
         logger.info(
             "MCP tool cache hit (%d tools, %.0fs old)",
             len(_cached_tools),
@@ -367,18 +510,24 @@ async def get_mcp_tools(
 
     logger.warning(f"Connecting to {len(enabled)} MCP server(s): {', '.join(enabled)}")
 
-    has_auth: bool = bool(sso_token)
-    results: list[list[Any]] = await asyncio.gather(
-        *[
-            _connect_single_server(
-                name=name,
-                config=_build_server_config(entry, sso_token),
-                timeout=entry.get("timeout", 30),
-                required=has_auth,
+    has_auth: bool = bool(sso_token or user_id)
+    discovery_token = _mcp_tool_discovery.set(True)
+    try:
+        connect_jobs = []
+        for name, entry in enabled.items():
+            bearer = await _resolve_connection_token(name, entry, sso_token, user_id)
+            connect_jobs.append(
+                _connect_single_server(
+                    name=name,
+                    config=_build_server_config(entry, bearer),
+                    server_cfg=entry,
+                    timeout=entry.get("timeout", 30),
+                    required=has_auth,
+                )
             )
-            for name, entry in enabled.items()
-        ]
-    )
+        results: list[list[Any]] = await asyncio.gather(*connect_jobs)
+    finally:
+        _mcp_tool_discovery.reset(discovery_token)
 
     seen: set[str] = set()
     tools: list[Any] = []
@@ -391,7 +540,17 @@ async def get_mcp_tools(
                 logger.warning(f"Duplicate tool '{tool.name}' skipped")
 
     if not tools:
-        if sso_token:
+        oauth_mcps = [
+            name
+            for name, entry in enabled.items()
+            if entry.get("auth_mode") in ("oauth", "dcr")
+        ]
+        if oauth_mcps:
+            logger.warning(
+                "All MCP servers failed to load tools — connect OAuth first: %s",
+                ", ".join(f"POST /mcp/{n}/connect" for n in oauth_mcps),
+            )
+        elif sso_token:
             logger.warning("All MCP servers failed to load tools (token present)")
         else:
             logger.warning("MCP tools deferred — no auth token at startup")

--- a/deep_agent/aegra/mcp_auth.py
+++ b/deep_agent/aegra/mcp_auth.py
@@ -76,7 +76,7 @@ class McpCredentialResolver:
     """Resolve the bearer token to send to a specific MCP server."""
 
     def __init__(self, token_store: McpTokenStore | None = None) -> None:
-        """Initialize with an optional token store (defaults to Postgres)."""
+        """Initialize with an optional token store (defaults to Redis + Postgres)."""
         self._store = token_store or McpTokenStore(settings.database_uri)
         self._cache: dict[tuple[str, str], tuple[str, float]] = {}
 

--- a/deep_agent/aegra/mcp_auth.py
+++ b/deep_agent/aegra/mcp_auth.py
@@ -1,0 +1,227 @@
+"""Per-MCP credential resolution for SSO pass-through and OAuth/DCR flows."""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+
+from deep_agent.aegra.mcp import (
+    _current_access_token,
+    _current_refresh_token,
+    mcp_httpx_verify,
+    refresh_access_token,
+)
+from deep_agent.aegra.mcp_token_store import McpOAuthToken, McpTokenStore
+from deep_agent.src.settings import settings
+from deep_agent.utils.pylogger import get_python_logger
+
+logger = get_python_logger()
+
+_RESOLVED_TOKEN_TTL_SECONDS = 30.0
+_TOKEN_EXPIRY_BUFFER_SECONDS = 30.0
+
+
+class NeedsAuthorization(Exception):
+    """Raised when an oauth/dcr MCP has no usable token for the user."""
+
+    def __init__(self, mcp_name: str, connect_url: str) -> None:
+        """Store MCP name and connect URL for the authorization interrupt."""
+        self.mcp_name = mcp_name
+        self.connect_url = connect_url
+        super().__init__(f"MCP authorization required for {mcp_name}")
+
+
+class McpCredentialResolver:
+    """Resolve the bearer token to send to a specific MCP server."""
+
+    def __init__(self, token_store: McpTokenStore | None = None) -> None:
+        """Initialize with an optional token store (defaults to Postgres)."""
+        self._store = token_store or McpTokenStore(settings.database_uri)
+        self._cache: dict[tuple[str, str], tuple[str, float]] = {}
+
+    @staticmethod
+    def connect_url(mcp_name: str) -> str:
+        """Build the agent connect endpoint URL for *mcp_name*."""
+        base = settings.agent_public_base_url.rstrip("/")
+        return f"{base}/mcp/{mcp_name}/connect"
+
+    async def resolve(
+        self, user_id: str, mcp_name: str, server_cfg: dict[str, Any]
+    ) -> str:
+        """Return a bearer token for this MCP, or raise :class:`NeedsAuthorization`."""
+        auth_mode = server_cfg.get("auth_mode", "sso")
+
+        if auth_mode == "sso":
+            return await self._resolve_sso()
+
+        cache_key = (user_id, mcp_name)
+        cached = self._cache.get(cache_key)
+        if cached and (time.time() - cached[1]) < _RESOLVED_TOKEN_TTL_SECONDS:
+            return cached[0]
+
+        token = await self._resolve_oauth(user_id, mcp_name, server_cfg)
+        self._cache[cache_key] = (token, time.time())
+        return token
+
+    async def has_valid_token(
+        self, user_id: str, mcp_name: str, server_cfg: dict[str, Any]
+    ) -> bool:
+        """Return True when a usable token exists (or can be refreshed)."""
+        auth_mode = server_cfg.get("auth_mode", "sso")
+        if auth_mode == "sso":
+            access = _current_access_token.get()
+            return bool(access)
+
+        stored = await self._store.get_token(user_id, mcp_name)
+        if stored is None:
+            return False
+        if self._token_valid(stored):
+            return True
+        return bool(stored.refresh_token)
+
+    def invalidate_cache(self, user_id: str, mcp_name: str) -> None:
+        """Drop a cached resolved token after OAuth callback or logout."""
+        self._cache.pop((user_id, mcp_name), None)
+
+    async def _resolve_sso(self) -> str:
+        """Return the refreshed SSO token from the current request context."""
+        access = _current_access_token.get()
+        refresh = _current_refresh_token.get()
+        if not access:
+            logger.warning(
+                "MCP SSO auth: no access token in context — call may be anonymous"
+            )
+            return ""
+        return await refresh_access_token(access, refresh)
+
+    async def _resolve_oauth(
+        self,
+        user_id: str,
+        mcp_name: str,
+        server_cfg: dict[str, Any],
+    ) -> str:
+        stored = await self._store.get_token(user_id, mcp_name)
+        if stored is None:
+            raise NeedsAuthorization(mcp_name, self.connect_url(mcp_name))
+
+        if self._token_valid(stored):
+            return stored.access_token
+
+        if stored.refresh_token:
+            refreshed = await self._refresh_mcp_token(stored, server_cfg)
+            if refreshed:
+                self.invalidate_cache(user_id, mcp_name)
+                return refreshed
+
+        raise NeedsAuthorization(mcp_name, self.connect_url(mcp_name))
+
+    @staticmethod
+    def _token_valid(token: McpOAuthToken) -> bool:
+        if not token.access_token:
+            return False
+        if token.expires_at is None:
+            return True
+        remaining = (token.expires_at - datetime.now(UTC)).total_seconds()
+        return remaining > _TOKEN_EXPIRY_BUFFER_SECONDS
+
+    async def _refresh_mcp_token(
+        self,
+        stored: McpOAuthToken,
+        server_cfg: dict[str, Any],
+    ) -> str | None:
+        oauth_cfg = server_cfg.get("oauth") or {}
+        token_endpoint = oauth_cfg.get("token_endpoint")
+        if not token_endpoint:
+            logger.error(
+                "Cannot refresh MCP token for '%s' — token_endpoint missing in config",
+                stored.mcp_name,
+            )
+            return None
+
+        client_id, client_secret = await self._resolve_client_credentials(
+            stored.mcp_name, server_cfg
+        )
+        if not client_id:
+            logger.error(
+                "Cannot refresh MCP token for '%s' — client_id unavailable",
+                stored.mcp_name,
+            )
+            return None
+
+        data: dict[str, str] = {
+            "grant_type": "refresh_token",
+            "refresh_token": stored.refresh_token or "",
+            "client_id": client_id,
+        }
+        if client_secret:
+            data["client_secret"] = client_secret
+
+        try:
+            async with httpx.AsyncClient(verify=mcp_httpx_verify(server_cfg)) as client:
+                resp = await client.post(token_endpoint, data=data, timeout=30)
+                resp.raise_for_status()
+                body: dict[str, Any] = resp.json()
+        except Exception:
+            logger.error(
+                "MCP token refresh failed for '%s'", stored.mcp_name, exc_info=True
+            )
+            return None
+
+        new_access_raw = body.get("access_token")
+        if not isinstance(new_access_raw, str) or not new_access_raw:
+            logger.error(
+                "MCP token refresh for '%s' returned no access_token", stored.mcp_name
+            )
+            return None
+        new_access = new_access_raw
+
+        new_refresh = body.get("refresh_token", stored.refresh_token)
+        expires_at = McpTokenStore.expires_at_from_token_response(body)
+        scope_raw = body.get("scope")
+        scopes = (
+            scope_raw.split()
+            if isinstance(scope_raw, str) and scope_raw
+            else stored.scopes
+        )
+
+        await self._store.upsert_token(
+            user_id=stored.user_id,
+            mcp_name=stored.mcp_name,
+            access_token=new_access,
+            refresh_token=new_refresh,
+            expires_at=expires_at,
+            scopes=scopes,
+        )
+        logger.info("Refreshed MCP OAuth token for '%s'", stored.mcp_name)
+        return new_access
+
+    async def _resolve_client_credentials(
+        self, mcp_name: str, server_cfg: dict[str, Any]
+    ) -> tuple[str | None, str | None]:
+        auth_mode = server_cfg.get("auth_mode", "sso")
+        oauth_cfg = server_cfg.get("oauth") or {}
+
+        if auth_mode == "oauth":
+            return oauth_cfg.get("client_id"), oauth_cfg.get("client_secret")
+
+        if auth_mode == "dcr":
+            client = await self._store.get_client(mcp_name)
+            if client is None:
+                return None, None
+            return client.client_id, client.client_secret
+
+        return None, None
+
+
+_default_resolver: McpCredentialResolver | None = None
+
+
+def get_mcp_credential_resolver() -> McpCredentialResolver:
+    """Return the process-wide credential resolver singleton."""
+    global _default_resolver  # noqa: PLW0603
+    if _default_resolver is None:
+        _default_resolver = McpCredentialResolver()
+    return _default_resolver

--- a/deep_agent/aegra/mcp_auth.py
+++ b/deep_agent/aegra/mcp_auth.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import os
 import time
 from datetime import UTC, datetime
 from typing import Any
@@ -14,7 +16,13 @@ from deep_agent.aegra.mcp import (
     mcp_httpx_verify,
     refresh_access_token,
 )
+from deep_agent.aegra.mcp_oauth_scopes import (
+    parse_token_scopes,
+    requested_scopes,
+    validate_granted_scopes,
+)
 from deep_agent.aegra.mcp_token_store import McpOAuthToken, McpTokenStore
+from deep_agent.aegra.redis import distributed_lock
 from deep_agent.src.settings import settings
 from deep_agent.utils.pylogger import get_python_logger
 
@@ -22,6 +30,36 @@ logger = get_python_logger()
 
 _RESOLVED_TOKEN_TTL_SECONDS = 30.0
 _TOKEN_EXPIRY_BUFFER_SECONDS = 30.0
+_TOKEN_REFRESH_LOCK_TTL_SECONDS = 30
+_TOKEN_REFRESH_LOCK_WAIT_SECONDS = 10.0
+_TOKEN_REFRESH_WAIT_POLL_SECONDS = 0.1
+_TOKEN_REFRESH_WAIT_ATTEMPTS = 50
+
+
+def resolve_oauth_client_secret(oauth_cfg: dict[str, Any], mcp_name: str) -> str | None:
+    """Resolve OAuth client secret from env (preferred) or legacy inline config."""
+    env_var = oauth_cfg.get("client_secret_env")
+    if env_var:
+        value = os.environ.get(env_var)
+        if not value:
+            logger.error(
+                "MCP '%s': environment variable %r is not set (oauth.client_secret_env)",
+                mcp_name,
+                env_var,
+            )
+            return None
+        return value
+
+    inline = oauth_cfg.get("client_secret")
+    if inline:
+        logger.warning(
+            "MCP '%s': oauth.client_secret in mcp.json is insecure — "
+            "set oauth.client_secret_env to an environment variable name instead",
+            mcp_name,
+        )
+        return str(inline)
+
+    return None
 
 
 class NeedsAuthorization(Exception):
@@ -110,13 +148,59 @@ class McpCredentialResolver:
         if self._token_valid(stored):
             return stored.access_token
 
-        if stored.refresh_token:
+        if not stored.refresh_token:
+            raise NeedsAuthorization(mcp_name, self.connect_url(mcp_name))
+
+        lock_name = f"mcp_token_refresh:{user_id}:{mcp_name}"
+        async with distributed_lock(
+            lock_name,
+            ttl_seconds=_TOKEN_REFRESH_LOCK_TTL_SECONDS,
+            wait_seconds=_TOKEN_REFRESH_LOCK_WAIT_SECONDS,
+        ) as lock_state:
+            stored = await self._store.get_token(user_id, mcp_name)
+            if stored is None:
+                raise NeedsAuthorization(mcp_name, self.connect_url(mcp_name))
+            if self._token_valid(stored):
+                return stored.access_token
+            if not stored.refresh_token:
+                raise NeedsAuthorization(mcp_name, self.connect_url(mcp_name))
+
+            if lock_state == "timeout":
+                refreshed_by_peer = await self._wait_for_refreshed_token(
+                    user_id, mcp_name
+                )
+                if refreshed_by_peer:
+                    return refreshed_by_peer
+                raise NeedsAuthorization(mcp_name, self.connect_url(mcp_name))
+
+            if lock_state == "no_redis":
+                logger.warning(
+                    "Redis unavailable; refreshing MCP token for '%s' without lock",
+                    mcp_name,
+                )
+
             refreshed = await self._refresh_mcp_token(stored, server_cfg)
             if refreshed:
                 self.invalidate_cache(user_id, mcp_name)
                 return refreshed
 
         raise NeedsAuthorization(mcp_name, self.connect_url(mcp_name))
+
+    async def _wait_for_refreshed_token(
+        self, user_id: str, mcp_name: str
+    ) -> str | None:
+        """Poll storage while another request holds the refresh lock."""
+        for _ in range(_TOKEN_REFRESH_WAIT_ATTEMPTS):
+            await asyncio.sleep(_TOKEN_REFRESH_WAIT_POLL_SECONDS)
+            stored = await self._store.get_token(user_id, mcp_name)
+            if stored is not None and self._token_valid(stored):
+                return stored.access_token
+        logger.error(
+            "Timed out waiting for MCP token refresh for '%s' user '%s'",
+            mcp_name,
+            user_id,
+        )
+        return None
 
     @staticmethod
     def _token_valid(token: McpOAuthToken) -> bool:
@@ -180,12 +264,20 @@ class McpCredentialResolver:
 
         new_refresh = body.get("refresh_token", stored.refresh_token)
         expires_at = McpTokenStore.expires_at_from_token_response(body)
-        scope_raw = body.get("scope")
-        scopes = (
-            scope_raw.split()
-            if isinstance(scope_raw, str) and scope_raw
-            else stored.scopes
-        )
+        requested_scope_list = requested_scopes(oauth_cfg)
+        parsed_scopes = parse_token_scopes(body)
+        if parsed_scopes is not None:
+            scopes = validate_granted_scopes(
+                parsed_scopes, requested_scope_list, stored.mcp_name
+            )
+            if scopes is None and requested_scope_list:
+                logger.error(
+                    "MCP token refresh for '%s' returned insufficient scopes",
+                    stored.mcp_name,
+                )
+                return None
+        else:
+            scopes = stored.scopes
 
         await self._store.upsert_token(
             user_id=stored.user_id,
@@ -205,7 +297,9 @@ class McpCredentialResolver:
         oauth_cfg = server_cfg.get("oauth") or {}
 
         if auth_mode == "oauth":
-            return oauth_cfg.get("client_id"), oauth_cfg.get("client_secret")
+            return oauth_cfg.get("client_id"), resolve_oauth_client_secret(
+                oauth_cfg, mcp_name
+            )
 
         if auth_mode == "dcr":
             client = await self._store.get_client(mcp_name)

--- a/deep_agent/aegra/mcp_crypto.py
+++ b/deep_agent/aegra/mcp_crypto.py
@@ -11,39 +11,77 @@ from deep_agent.utils.pylogger import get_python_logger
 
 logger = get_python_logger()
 
-_fernet: Fernet | None = None
+_fernet_primary: Fernet | None = None
+_fernet_previous: Fernet | None | bool = False
 
 
-def _get_fernet() -> Fernet:
-    """Return a process-wide Fernet instance keyed by ``MCP_TOKEN_ENCRYPTION_KEY``."""
-    global _fernet  # noqa: PLW0603
-    if _fernet is not None:
-        return _fernet
+def _fernet_key_help() -> str:
+    return (
+        'Generate one with: python -c "from cryptography.fernet import Fernet; '
+        'print(Fernet.generate_key().decode())"'
+    )
 
-    key = os.environ.get("MCP_TOKEN_ENCRYPTION_KEY", "").strip()
+
+def _parse_fernet_key(env_var: str) -> str:
+    key = os.environ.get(env_var, "").strip()
     if not key:
         raise RuntimeError(
-            "MCP_TOKEN_ENCRYPTION_KEY is required for MCP OAuth token storage. "
-            'Generate one with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"'
+            f"{env_var} is required for MCP OAuth token storage. {_fernet_key_help()}"
         )
+    return key
 
-    _fernet = Fernet(key.encode())
-    return _fernet
+
+def _get_fernet_primary() -> Fernet:
+    """Return the current encryption key (``MCP_TOKEN_ENCRYPTION_KEY``)."""
+    global _fernet_primary  # noqa: PLW0603
+    if _fernet_primary is None:
+        _fernet_primary = Fernet(_parse_fernet_key("MCP_TOKEN_ENCRYPTION_KEY").encode())
+    return _fernet_primary
+
+
+def _get_fernet_previous() -> Fernet | None:
+    """Return the optional previous key used during rotation."""
+    global _fernet_previous  # noqa: PLW0603
+    if _fernet_previous is False:
+        previous_key = os.environ.get("MCP_TOKEN_ENCRYPTION_KEY_PREVIOUS", "").strip()
+        _fernet_previous = Fernet(previous_key.encode()) if previous_key else None
+    return cast(Fernet | None, _fernet_previous)
+
+
+def reset_mcp_crypto_cache() -> None:
+    """Clear cached Fernet instances (used by tests and config reload)."""
+    global _fernet_primary, _fernet_previous  # noqa: PLW0603
+    _fernet_primary = None
+    _fernet_previous = False
 
 
 def encrypt_secret(plaintext: str | None) -> str | None:
     """Encrypt a secret value for Postgres storage."""
     if plaintext is None:
         return None
-    return cast(str, _get_fernet().encrypt(plaintext.encode()).decode())
+    return cast(str, _get_fernet_primary().encrypt(plaintext.encode()).decode())
 
 
 def decrypt_secret(ciphertext: str | None) -> str | None:
-    """Decrypt a value previously stored by :func:`encrypt_secret`."""
+    """Decrypt a value previously stored by :func:`encrypt_secret`.
+
+    Tries ``MCP_TOKEN_ENCRYPTION_KEY`` first, then ``MCP_TOKEN_ENCRYPTION_KEY_PREVIOUS``
+    when set, so ciphertext can be read during key rotation.
+    """
     if ciphertext is None:
         return None
-    try:
-        return cast(str, _get_fernet().decrypt(ciphertext.encode()).decode())
-    except InvalidToken as exc:
-        logger.error("Failed to decrypt MCP secret — key mismatch or corrupt data")
-        raise RuntimeError("MCP token decryption failed") from exc
+
+    keys: list[Fernet] = [_get_fernet_primary()]
+    previous = _get_fernet_previous()
+    if previous is not None:
+        keys.append(previous)
+
+    last_exc: InvalidToken | None = None
+    for fernet in keys:
+        try:
+            return cast(str, fernet.decrypt(ciphertext.encode()).decode())
+        except InvalidToken as exc:
+            last_exc = exc
+
+    logger.error("Failed to decrypt MCP secret — key mismatch or corrupt data")
+    raise RuntimeError("MCP token decryption failed") from last_exc

--- a/deep_agent/aegra/mcp_crypto.py
+++ b/deep_agent/aegra/mcp_crypto.py
@@ -1,0 +1,49 @@
+"""Symmetric encryption for MCP OAuth tokens and client secrets at rest."""
+
+from __future__ import annotations
+
+import os
+from typing import cast
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from deep_agent.utils.pylogger import get_python_logger
+
+logger = get_python_logger()
+
+_fernet: Fernet | None = None
+
+
+def _get_fernet() -> Fernet:
+    """Return a process-wide Fernet instance keyed by ``MCP_TOKEN_ENCRYPTION_KEY``."""
+    global _fernet  # noqa: PLW0603
+    if _fernet is not None:
+        return _fernet
+
+    key = os.environ.get("MCP_TOKEN_ENCRYPTION_KEY", "").strip()
+    if not key:
+        raise RuntimeError(
+            "MCP_TOKEN_ENCRYPTION_KEY is required for MCP OAuth token storage. "
+            'Generate one with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"'
+        )
+
+    _fernet = Fernet(key.encode())
+    return _fernet
+
+
+def encrypt_secret(plaintext: str | None) -> str | None:
+    """Encrypt a secret value for Postgres storage."""
+    if plaintext is None:
+        return None
+    return cast(str, _get_fernet().encrypt(plaintext.encode()).decode())
+
+
+def decrypt_secret(ciphertext: str | None) -> str | None:
+    """Decrypt a value previously stored by :func:`encrypt_secret`."""
+    if ciphertext is None:
+        return None
+    try:
+        return cast(str, _get_fernet().decrypt(ciphertext.encode()).decode())
+    except InvalidToken as exc:
+        logger.error("Failed to decrypt MCP secret — key mismatch or corrupt data")
+        raise RuntimeError("MCP token decryption failed") from exc

--- a/deep_agent/aegra/mcp_crypto.py
+++ b/deep_agent/aegra/mcp_crypto.py
@@ -56,7 +56,7 @@ def reset_mcp_crypto_cache() -> None:
 
 
 def encrypt_secret(plaintext: str | None) -> str | None:
-    """Encrypt a secret value for Postgres storage."""
+    """Encrypt a secret value for Redis/Postgres storage."""
     if plaintext is None:
         return None
     return cast(str, _get_fernet_primary().encrypt(plaintext.encode()).decode())

--- a/deep_agent/aegra/mcp_oauth_handlers.py
+++ b/deep_agent/aegra/mcp_oauth_handlers.py
@@ -1,0 +1,297 @@
+"""OAuth connect/callback/status handlers for per-MCP DCR and oauth flows."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import secrets
+from typing import Any
+from urllib.parse import urlencode
+
+import httpx
+from fastapi import HTTPException
+from fastapi.responses import HTMLResponse
+
+from deep_agent.aegra.mcp import mcp_httpx_verify
+from deep_agent.aegra.mcp_auth import get_mcp_credential_resolver
+from deep_agent.aegra.mcp_token_store import McpTokenStore
+from deep_agent.aegra.redis import cache_get, cache_set
+from deep_agent.src.agent.config import agent_config
+from deep_agent.src.settings import settings
+from deep_agent.utils.pylogger import get_python_logger
+
+logger = get_python_logger()
+
+_OAUTH_STATE_TTL_SECONDS = 600
+
+
+def _pkce_pair() -> tuple[str, str]:
+    verifier = secrets.token_urlsafe(64)
+    digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+def _get_mcp_server_config(mcp_name: str) -> dict[str, Any]:
+    servers = agent_config.get_mcp_servers()
+    cfg = servers.get(mcp_name)
+    if not isinstance(cfg, dict) or not cfg.get("enabled", False):
+        raise HTTPException(
+            status_code=404, detail=f"MCP server '{mcp_name}' not found"
+        )
+    return cfg
+
+
+async def _register_dcr_client(
+    mcp_name: str,
+    oauth_cfg: dict[str, Any],
+    server_cfg: dict[str, Any],
+) -> tuple[str, str | None]:
+    registration_endpoint = oauth_cfg.get("registration_endpoint")
+    if not registration_endpoint:
+        raise HTTPException(
+            status_code=400,
+            detail=f"MCP '{mcp_name}' is missing oauth.registration_endpoint",
+        )
+
+    scopes = oauth_cfg.get("scopes") or []
+    scope_str = " ".join(scopes) if isinstance(scopes, list) else str(scopes)
+    redirect_uri = oauth_cfg["redirect_uri"]
+
+    body = {
+        "client_name": f"template-agent-{mcp_name}",
+        "redirect_uris": [redirect_uri],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "scope": scope_str or "read write",
+    }
+
+    async with httpx.AsyncClient(verify=mcp_httpx_verify(server_cfg)) as client:
+        resp = await client.post(registration_endpoint, json=body, timeout=30)
+        if not resp.is_success:
+            logger.error(
+                "DCR registration failed for '%s': %s %s",
+                mcp_name,
+                resp.status_code,
+                resp.text,
+            )
+            raise HTTPException(
+                status_code=502,
+                detail=f"MCP client registration failed: {resp.text}",
+            )
+        data = resp.json()
+
+    client_id = data.get("client_id")
+    if not client_id:
+        raise HTTPException(status_code=502, detail="DCR response missing client_id")
+
+    client_secret = data.get("client_secret")
+    store = McpTokenStore(settings.database_uri)
+    await store.upsert_client(
+        mcp_name=mcp_name,
+        client_id=client_id,
+        client_secret=client_secret,
+        registration_data=data,
+    )
+    return client_id, client_secret
+
+
+async def handle_mcp_connect(user_id: str, mcp_name: str) -> dict[str, str]:
+    """Start the OAuth authorization flow for *mcp_name*."""
+    server_cfg = _get_mcp_server_config(mcp_name)
+    auth_mode = server_cfg.get("auth_mode", "sso")
+    if auth_mode not in ("oauth", "dcr"):
+        raise HTTPException(
+            status_code=400,
+            detail=f"MCP '{mcp_name}' does not use OAuth/DCR authentication",
+        )
+
+    oauth_cfg = server_cfg.get("oauth") or {}
+    for field in ("authorization_endpoint", "token_endpoint", "redirect_uri"):
+        if not oauth_cfg.get(field):
+            raise HTTPException(
+                status_code=400,
+                detail=f"MCP '{mcp_name}' missing oauth.{field}",
+            )
+
+    store = McpTokenStore(settings.database_uri)
+    if auth_mode == "dcr":
+        client = await store.get_client(mcp_name)
+        if client is None:
+            await _register_dcr_client(mcp_name, oauth_cfg, server_cfg)
+            client = await store.get_client(mcp_name)
+        client_id = client.client_id if client else None
+    else:
+        client_id = oauth_cfg.get("client_id")
+
+    if not client_id:
+        raise HTTPException(
+            status_code=400, detail=f"No OAuth client_id for '{mcp_name}'"
+        )
+
+    scopes = oauth_cfg.get("scopes") or []
+    scope_str = " ".join(scopes) if isinstance(scopes, list) else str(scopes)
+
+    code_verifier, code_challenge = _pkce_pair()
+    state = secrets.token_urlsafe(32)
+
+    state_payload = json.dumps(
+        {"user_id": user_id, "mcp_name": mcp_name, "code_verifier": code_verifier}
+    )
+    if not cache_set(
+        f"mcp_oauth_state:{state}", state_payload, _OAUTH_STATE_TTL_SECONDS
+    ):
+        raise HTTPException(status_code=503, detail="OAuth state storage unavailable")
+
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": oauth_cfg["redirect_uri"],
+        "scope": scope_str,
+        "state": state,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+    }
+    authorize_url = f"{oauth_cfg['authorization_endpoint']}?{urlencode(params)}"
+    return {"authorize_url": authorize_url}
+
+
+async def handle_mcp_oauth_callback(
+    code: str | None, state: str | None
+) -> HTMLResponse:
+    """Exchange authorization code and persist tokens, then notify the opener."""
+    if not code or not state:
+        return HTMLResponse(
+            _callback_html(error="Missing code or state parameter"),
+            status_code=400,
+        )
+
+    raw = cache_get(f"mcp_oauth_state:{state}")
+    if not raw:
+        return HTMLResponse(
+            _callback_html(error="OAuth state expired or invalid"),
+            status_code=400,
+        )
+
+    try:
+        state_data = json.loads(raw)
+        user_id = state_data["user_id"]
+        mcp_name = state_data["mcp_name"]
+        code_verifier = state_data["code_verifier"]
+    except (json.JSONDecodeError, KeyError):
+        return HTMLResponse(
+            _callback_html(error="Corrupt OAuth state"),
+            status_code=400,
+        )
+
+    server_cfg = _get_mcp_server_config(mcp_name)
+    oauth_cfg = server_cfg.get("oauth") or {}
+    token_endpoint = oauth_cfg.get("token_endpoint")
+    redirect_uri = oauth_cfg.get("redirect_uri")
+    if not token_endpoint or not redirect_uri:
+        return HTMLResponse(
+            _callback_html(error="MCP OAuth is not configured"),
+            status_code=500,
+        )
+
+    store = McpTokenStore(settings.database_uri)
+    auth_mode = server_cfg.get("auth_mode", "sso")
+    if auth_mode == "oauth":
+        client_id = oauth_cfg.get("client_id")
+        client_secret = oauth_cfg.get("client_secret")
+    else:
+        client = await store.get_client(mcp_name)
+        client_id = client.client_id if client else None
+        client_secret = client.client_secret if client else None
+
+    if not client_id:
+        return HTMLResponse(
+            _callback_html(error="OAuth client not registered"),
+            status_code=400,
+        )
+
+    data: dict[str, str] = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "client_id": client_id,
+        "code_verifier": code_verifier,
+    }
+    if client_secret:
+        data["client_secret"] = client_secret
+
+    try:
+        async with httpx.AsyncClient(verify=mcp_httpx_verify(server_cfg)) as client:
+            resp = await client.post(token_endpoint, data=data, timeout=30)
+            resp.raise_for_status()
+            body: dict[str, Any] = resp.json()
+    except Exception as exc:
+        logger.error("OAuth token exchange failed for '%s'", mcp_name, exc_info=True)
+        return HTMLResponse(
+            _callback_html(error=f"Token exchange failed: {exc}"),
+            status_code=502,
+        )
+
+    access_token = body.get("access_token")
+    if not access_token:
+        return HTMLResponse(
+            _callback_html(error="Token response missing access_token"),
+            status_code=502,
+        )
+
+    expires_at = McpTokenStore.expires_at_from_token_response(body)
+    scope_raw = body.get("scope")
+    scopes = scope_raw.split() if isinstance(scope_raw, str) and scope_raw else None
+
+    await store.upsert_token(
+        user_id=user_id,
+        mcp_name=mcp_name,
+        access_token=access_token,
+        refresh_token=body.get("refresh_token"),
+        expires_at=expires_at,
+        scopes=scopes,
+    )
+    get_mcp_credential_resolver().invalidate_cache(user_id, mcp_name)
+    from deep_agent.aegra.mcp import invalidate_mcp_tool_cache
+
+    invalidate_mcp_tool_cache()
+    try:
+        from deep_agent.aegra.graph import invalidate_graph_cache
+
+        invalidate_graph_cache()
+    except Exception:
+        logger.debug("Graph cache invalidation skipped", exc_info=True)
+
+    return HTMLResponse(_callback_html(mcp_name=mcp_name))
+
+
+async def handle_mcp_status(user_id: str, mcp_name: str) -> dict[str, Any]:
+    """Return whether the user has a usable token for *mcp_name*."""
+    server_cfg = _get_mcp_server_config(mcp_name)
+    resolver = get_mcp_credential_resolver()
+    connected = await resolver.has_valid_token(user_id, mcp_name, server_cfg)
+    return {"mcp_name": mcp_name, "connected": connected}
+
+
+def _callback_html(
+    mcp_name: str | None = None,
+    error: str | None = None,
+) -> str:
+    if error:
+        return f"""<!DOCTYPE html>
+<html><head><title>MCP OAuth Error</title></head>
+<body><p>{error}</p></body></html>"""
+
+    safe_name = json.dumps(mcp_name)
+    return f"""<!DOCTYPE html>
+<html><head><title>MCP Connected</title></head>
+<body>
+<p>Connected. You can close this window.</p>
+<script>
+  if (window.opener) {{
+    window.opener.postMessage({{ type: "mcp_oauth_done", mcp_name: {safe_name} }}, "*");
+  }}
+  window.close();
+</script>
+</body></html>"""

--- a/deep_agent/aegra/mcp_oauth_handlers.py
+++ b/deep_agent/aegra/mcp_oauth_handlers.py
@@ -10,11 +10,19 @@ from typing import Any
 from urllib.parse import urlencode
 
 import httpx
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 from fastapi.responses import HTMLResponse
 
 from deep_agent.aegra.mcp import mcp_httpx_verify
-from deep_agent.aegra.mcp_auth import get_mcp_credential_resolver
+from deep_agent.aegra.mcp_auth import (
+    get_mcp_credential_resolver,
+    resolve_oauth_client_secret,
+)
+from deep_agent.aegra.mcp_oauth_scopes import (
+    parse_token_scopes,
+    requested_scopes,
+    validate_granted_scopes,
+)
 from deep_agent.aegra.mcp_token_store import McpTokenStore
 from deep_agent.aegra.redis import cache_get, cache_set
 from deep_agent.src.agent.config import agent_config
@@ -23,7 +31,13 @@ from deep_agent.utils.pylogger import get_python_logger
 
 logger = get_python_logger()
 
-_OAUTH_STATE_TTL_SECONDS = 600
+_OAUTH_STATE_TTL_SECONDS = 300
+
+
+def _callback_redirect_uri(request: Request) -> str:
+    """Reconstruct the OAuth callback URL (scheme + host + path, no query)."""
+    url = request.url
+    return f"{url.scheme}://{url.netloc}{url.path}"
 
 
 def _pkce_pair() -> tuple[str, str]:
@@ -57,7 +71,7 @@ async def _register_dcr_client(
 
     scopes = oauth_cfg.get("scopes") or []
     scope_str = " ".join(scopes) if isinstance(scopes, list) else str(scopes)
-    redirect_uri = oauth_cfg["redirect_uri"]
+    redirect_uri = settings.oauth_callback_url
 
     body = {
         "client_name": f"template-agent-{mcp_name}",
@@ -108,12 +122,14 @@ async def handle_mcp_connect(user_id: str, mcp_name: str) -> dict[str, str]:
         )
 
     oauth_cfg = server_cfg.get("oauth") or {}
-    for field in ("authorization_endpoint", "token_endpoint", "redirect_uri"):
+    for field in ("authorization_endpoint", "token_endpoint"):
         if not oauth_cfg.get(field):
             raise HTTPException(
                 status_code=400,
                 detail=f"MCP '{mcp_name}' missing oauth.{field}",
             )
+
+    redirect_uri = settings.oauth_callback_url
 
     store = McpTokenStore(settings.database_uri)
     if auth_mode == "dcr":
@@ -147,7 +163,7 @@ async def handle_mcp_connect(user_id: str, mcp_name: str) -> dict[str, str]:
     params = {
         "response_type": "code",
         "client_id": client_id,
-        "redirect_uri": oauth_cfg["redirect_uri"],
+        "redirect_uri": redirect_uri,
         "scope": scope_str,
         "state": state,
         "code_challenge": code_challenge,
@@ -158,7 +174,7 @@ async def handle_mcp_connect(user_id: str, mcp_name: str) -> dict[str, str]:
 
 
 async def handle_mcp_oauth_callback(
-    code: str | None, state: str | None
+    code: str | None, state: str | None, request: Request
 ) -> HTMLResponse:
     """Exchange authorization code and persist tokens, then notify the opener."""
     if not code or not state:
@@ -188,18 +204,31 @@ async def handle_mcp_oauth_callback(
     server_cfg = _get_mcp_server_config(mcp_name)
     oauth_cfg = server_cfg.get("oauth") or {}
     token_endpoint = oauth_cfg.get("token_endpoint")
-    redirect_uri = oauth_cfg.get("redirect_uri")
-    if not token_endpoint or not redirect_uri:
+    redirect_uri = settings.oauth_callback_url
+    if not token_endpoint:
         return HTMLResponse(
             _callback_html(error="MCP OAuth is not configured"),
             status_code=500,
+        )
+
+    callback_uri = _callback_redirect_uri(request)
+    if callback_uri != redirect_uri:
+        logger.warning(
+            "OAuth callback redirect_uri mismatch for '%s': expected %r, got %r",
+            mcp_name,
+            redirect_uri,
+            callback_uri,
+        )
+        return HTMLResponse(
+            _callback_html(error="OAuth redirect URI mismatch"),
+            status_code=400,
         )
 
     store = McpTokenStore(settings.database_uri)
     auth_mode = server_cfg.get("auth_mode", "sso")
     if auth_mode == "oauth":
         client_id = oauth_cfg.get("client_id")
-        client_secret = oauth_cfg.get("client_secret")
+        client_secret = resolve_oauth_client_secret(oauth_cfg, mcp_name)
     else:
         client = await store.get_client(mcp_name)
         client_id = client.client_id if client else None
@@ -226,10 +255,10 @@ async def handle_mcp_oauth_callback(
             resp = await client.post(token_endpoint, data=data, timeout=30)
             resp.raise_for_status()
             body: dict[str, Any] = resp.json()
-    except Exception as exc:
+    except Exception:
         logger.error("OAuth token exchange failed for '%s'", mcp_name, exc_info=True)
         return HTMLResponse(
-            _callback_html(error=f"Token exchange failed: {exc}"),
+            _callback_html(error="Authentication failed. Please try again."),
             status_code=502,
         )
 
@@ -241,8 +270,19 @@ async def handle_mcp_oauth_callback(
         )
 
     expires_at = McpTokenStore.expires_at_from_token_response(body)
-    scope_raw = body.get("scope")
-    scopes = scope_raw.split() if isinstance(scope_raw, str) and scope_raw else None
+    requested_scope_list = requested_scopes(oauth_cfg)
+    scopes = validate_granted_scopes(
+        parse_token_scopes(body),
+        requested_scope_list,
+        mcp_name,
+    )
+    if scopes is None and requested_scope_list:
+        return HTMLResponse(
+            _callback_html(
+                error="Authentication failed. Required permissions were not granted."
+            ),
+            status_code=502,
+        )
 
     await store.upsert_token(
         user_id=user_id,
@@ -290,7 +330,7 @@ def _callback_html(
 <p>Connected. You can close this window.</p>
 <script>
   if (window.opener) {{
-    window.opener.postMessage({{ type: "mcp_oauth_done", mcp_name: {safe_name} }}, "*");
+    window.opener.postMessage({{ type: "mcp_oauth_done", mcp_name: {safe_name} }}, window.location.origin);
   }}
   window.close();
 </script>

--- a/deep_agent/aegra/mcp_oauth_scopes.py
+++ b/deep_agent/aegra/mcp_oauth_scopes.py
@@ -1,0 +1,59 @@
+"""OAuth scope parsing and validation for MCP token flows."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from deep_agent.utils.pylogger import get_python_logger
+
+logger = get_python_logger()
+
+
+def requested_scopes(oauth_cfg: dict[str, Any]) -> list[str]:
+    """Return normalized scope list from MCP OAuth config."""
+    scopes = oauth_cfg.get("scopes") or []
+    if isinstance(scopes, list):
+        return [str(s) for s in scopes if s]
+    if isinstance(scopes, str) and scopes:
+        return scopes.split()
+    return []
+
+
+def parse_token_scopes(body: dict[str, Any]) -> list[str] | None:
+    """Parse granted scopes from an OAuth token response body."""
+    scope_raw = body.get("scope")
+    if isinstance(scope_raw, str) and scope_raw:
+        return scope_raw.split()
+    if isinstance(scope_raw, list):
+        return [str(s) for s in scope_raw if s]
+    return None
+
+
+def validate_granted_scopes(
+    granted: list[str] | None,
+    requested: list[str],
+    mcp_name: str,
+) -> list[str] | None:
+    """Return granted scopes when they include all requested scopes, else None."""
+    if not requested:
+        return granted
+
+    if not granted:
+        logger.error(
+            "OAuth token for '%s' returned no scopes; requested %s",
+            mcp_name,
+            requested,
+        )
+        return None
+
+    missing = [scope for scope in requested if scope not in set(granted)]
+    if missing:
+        logger.error(
+            "OAuth token for '%s' missing requested scopes %s (granted: %s)",
+            mcp_name,
+            missing,
+            granted,
+        )
+        return None
+
+    return granted

--- a/deep_agent/aegra/mcp_routes.py
+++ b/deep_agent/aegra/mcp_routes.py
@@ -41,13 +41,14 @@ async def mcp_connect(mcp_name: str, request: Request) -> JSONResponse:
 
 @router.get("/mcp/oauth/callback")
 async def mcp_oauth_callback(
+    request: Request,
     code: str | None = None,
     state: str | None = None,
 ) -> HTMLResponse:
     """Handle the OAuth redirect — exchange code and notify the UI opener."""
     from deep_agent.aegra.mcp_oauth_handlers import handle_mcp_oauth_callback
 
-    return await handle_mcp_oauth_callback(code, state)
+    return await handle_mcp_oauth_callback(code, state, request)
 
 
 @router.get("/mcp/{mcp_name}/status")

--- a/deep_agent/aegra/mcp_routes.py
+++ b/deep_agent/aegra/mcp_routes.py
@@ -1,0 +1,72 @@
+"""HTTP routes for per-MCP OAuth/DCR connect, callback, and status."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+
+from deep_agent.src.agent.config import agent_config
+
+router = APIRouter(tags=["mcp-oauth"])
+
+
+async def _authenticated_user_id(request: Request) -> str:
+    """Return the SSO ``sub`` from the incoming Bearer token."""
+    from deep_agent.aegra.auth import DEV_USER_ID, ENABLE_AUTH, _decode_token
+
+    if not ENABLE_AUTH:
+        return DEV_USER_ID
+
+    auth_header = request.headers.get("authorization", "")
+    if not auth_header.startswith("Bearer "):
+        raise HTTPException(
+            status_code=401, detail="Missing or invalid Authorization header"
+        )
+
+    payload = _decode_token(auth_header[7:])
+    return str(payload["sub"])
+
+
+@router.post("/mcp/{mcp_name}/connect")
+async def mcp_connect(mcp_name: str, request: Request) -> JSONResponse:
+    """Start OAuth/DCR authorization for an MCP server."""
+    from deep_agent.aegra.mcp_oauth_handlers import handle_mcp_connect
+
+    user_id = await _authenticated_user_id(request)
+    result = await handle_mcp_connect(user_id, mcp_name)
+    return JSONResponse(content=result)
+
+
+@router.get("/mcp/oauth/callback")
+async def mcp_oauth_callback(
+    code: str | None = None,
+    state: str | None = None,
+) -> HTMLResponse:
+    """Handle the OAuth redirect — exchange code and notify the UI opener."""
+    from deep_agent.aegra.mcp_oauth_handlers import handle_mcp_oauth_callback
+
+    return await handle_mcp_oauth_callback(code, state)
+
+
+@router.get("/mcp/{mcp_name}/status")
+async def mcp_status(mcp_name: str, request: Request) -> JSONResponse:
+    """Return whether the current user has a valid token for the MCP."""
+    from deep_agent.aegra.mcp_oauth_handlers import handle_mcp_status
+
+    user_id = await _authenticated_user_id(request)
+    result = await handle_mcp_status(user_id, mcp_name)
+    return JSONResponse(content=result)
+
+
+@router.get("/info")
+async def get_agent_info() -> dict[str, Any]:
+    """Return agent identity metadata from config."""
+    servers = agent_config.get_mcp_servers()
+    oauth_mcps = sorted(
+        name
+        for name, cfg in servers.items()
+        if cfg.get("enabled") and cfg.get("auth_mode") in ("oauth", "dcr")
+    )
+    return {"name": agent_config.get_name(), "oauth_mcps": oauth_mcps}

--- a/deep_agent/aegra/mcp_token_store.py
+++ b/deep_agent/aegra/mcp_token_store.py
@@ -1,0 +1,268 @@
+"""Postgres repository for per-user MCP OAuth tokens and DCR client records."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import psycopg
+from psycopg.rows import dict_row
+from psycopg.types.json import Jsonb
+
+from deep_agent.aegra.mcp_crypto import decrypt_secret, encrypt_secret
+from deep_agent.utils.pylogger import get_python_logger
+
+logger = get_python_logger()
+
+_TABLES_ENSURED = False
+
+CREATE_OAUTH_CLIENTS_TABLE = """
+CREATE TABLE IF NOT EXISTS mcp_oauth_clients (
+    mcp_name           TEXT PRIMARY KEY,
+    client_id          TEXT NOT NULL,
+    client_secret      TEXT,
+    registration_data  JSONB,
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+"""
+
+CREATE_OAUTH_TOKENS_TABLE = """
+CREATE TABLE IF NOT EXISTS mcp_oauth_tokens (
+    user_id        TEXT NOT NULL,
+    mcp_name       TEXT NOT NULL,
+    access_token   TEXT NOT NULL,
+    refresh_token  TEXT,
+    expires_at     TIMESTAMPTZ,
+    scopes         TEXT[],
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, mcp_name)
+);
+"""
+
+MIGRATE_OAUTH_TABLES = """
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'mcp_oauth_tokens'
+    ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'mcp_oauth_tokens'
+          AND column_name = 'user_id'
+    ) THEN
+        DROP TABLE mcp_oauth_tokens;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'mcp_oauth_clients'
+    ) AND (
+        NOT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'mcp_oauth_clients'
+              AND column_name = 'client_id'
+        )
+        OR NOT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'mcp_oauth_clients'
+              AND column_name = 'registration_data'
+        )
+        OR NOT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'mcp_oauth_clients'
+              AND column_name = 'updated_at'
+        )
+    ) THEN
+        DROP TABLE mcp_oauth_clients;
+    END IF;
+END $$;
+"""
+
+
+@dataclass
+class McpOAuthClient:
+    """Registered OAuth client for a DCR-backed MCP server."""
+
+    mcp_name: str
+    client_id: str
+    client_secret: str | None = None
+    registration_data: dict[str, Any] | None = None
+    updated_at: datetime | None = None
+
+
+@dataclass
+class McpOAuthToken:
+    """Stored OAuth tokens for a (user, MCP) pair."""
+
+    user_id: str
+    mcp_name: str
+    access_token: str
+    refresh_token: str | None = None
+    expires_at: datetime | None = None
+    scopes: list[str] | None = None
+    updated_at: datetime | None = None
+
+
+class McpTokenStore:
+    """Async Postgres store for MCP OAuth clients and user tokens."""
+
+    def __init__(self, database_uri: str) -> None:
+        """Initialize with a Postgres connection URI."""
+        self._uri = database_uri
+
+    async def ensure_tables(self) -> None:
+        """Create MCP OAuth tables if they do not already exist."""
+        global _TABLES_ENSURED  # noqa: PLW0603
+        async with await psycopg.AsyncConnection.connect(self._uri) as conn:
+            await conn.execute(MIGRATE_OAUTH_TABLES)
+            await conn.execute(CREATE_OAUTH_CLIENTS_TABLE)
+            await conn.execute(CREATE_OAUTH_TOKENS_TABLE)
+            await conn.commit()
+        if not _TABLES_ENSURED:
+            _TABLES_ENSURED = True
+            logger.info("MCP OAuth tables ensured")
+
+    async def get_client(self, mcp_name: str) -> McpOAuthClient | None:
+        """Return the registered OAuth client for *mcp_name*, if any."""
+        await self.ensure_tables()
+        async with await psycopg.AsyncConnection.connect(
+            self._uri, row_factory=dict_row
+        ) as conn:
+            cur = await conn.execute(
+                "SELECT * FROM mcp_oauth_clients WHERE mcp_name = %s",
+                (mcp_name,),
+            )
+            row = await cur.fetchone()
+            if row is None:
+                return None
+            return McpOAuthClient(
+                mcp_name=row["mcp_name"],
+                client_id=row["client_id"],
+                client_secret=decrypt_secret(row["client_secret"]),
+                registration_data=row["registration_data"],
+                updated_at=row["updated_at"],
+            )
+
+    async def upsert_client(
+        self,
+        mcp_name: str,
+        client_id: str,
+        client_secret: str | None = None,
+        registration_data: dict[str, Any] | None = None,
+    ) -> McpOAuthClient:
+        """Insert or update the OAuth client record for *mcp_name*."""
+        await self.ensure_tables()
+        enc_secret = encrypt_secret(client_secret)
+        async with await psycopg.AsyncConnection.connect(self._uri) as conn:
+            await conn.execute(
+                """
+                INSERT INTO mcp_oauth_clients (
+                    mcp_name, client_id, client_secret, registration_data, updated_at
+                )
+                VALUES (%s, %s, %s, %s, now())
+                ON CONFLICT (mcp_name) DO UPDATE SET
+                    client_id = EXCLUDED.client_id,
+                    client_secret = EXCLUDED.client_secret,
+                    registration_data = EXCLUDED.registration_data,
+                    updated_at = now()
+                """,
+                (
+                    mcp_name,
+                    client_id,
+                    enc_secret,
+                    Jsonb(registration_data) if registration_data is not None else None,
+                ),
+            )
+            await conn.commit()
+        return McpOAuthClient(
+            mcp_name=mcp_name,
+            client_id=client_id,
+            client_secret=client_secret,
+            registration_data=registration_data,
+        )
+
+    async def get_token(self, user_id: str, mcp_name: str) -> McpOAuthToken | None:
+        """Return stored OAuth tokens for *(user_id, mcp_name)*."""
+        await self.ensure_tables()
+        async with await psycopg.AsyncConnection.connect(
+            self._uri, row_factory=dict_row
+        ) as conn:
+            cur = await conn.execute(
+                "SELECT * FROM mcp_oauth_tokens WHERE user_id = %s AND mcp_name = %s",
+                (user_id, mcp_name),
+            )
+            row = await cur.fetchone()
+            if row is None:
+                return None
+            return McpOAuthToken(
+                user_id=row["user_id"],
+                mcp_name=row["mcp_name"],
+                access_token=decrypt_secret(row["access_token"]) or "",
+                refresh_token=decrypt_secret(row["refresh_token"]),
+                expires_at=row["expires_at"],
+                scopes=list(row["scopes"]) if row["scopes"] else None,
+                updated_at=row["updated_at"],
+            )
+
+    async def upsert_token(
+        self,
+        user_id: str,
+        mcp_name: str,
+        access_token: str,
+        refresh_token: str | None = None,
+        expires_at: datetime | None = None,
+        scopes: list[str] | None = None,
+    ) -> McpOAuthToken:
+        """Insert or update OAuth tokens for *(user_id, mcp_name)*."""
+        await self.ensure_tables()
+        enc_access = encrypt_secret(access_token)
+        enc_refresh = encrypt_secret(refresh_token)
+        async with await psycopg.AsyncConnection.connect(self._uri) as conn:
+            await conn.execute(
+                """
+                INSERT INTO mcp_oauth_tokens (
+                    user_id, mcp_name, access_token, refresh_token,
+                    expires_at, scopes, updated_at
+                )
+                VALUES (%s, %s, %s, %s, %s, %s, now())
+                ON CONFLICT (user_id, mcp_name) DO UPDATE SET
+                    access_token = EXCLUDED.access_token,
+                    refresh_token = EXCLUDED.refresh_token,
+                    expires_at = EXCLUDED.expires_at,
+                    scopes = EXCLUDED.scopes,
+                    updated_at = now()
+                """,
+                (
+                    user_id,
+                    mcp_name,
+                    enc_access,
+                    enc_refresh,
+                    expires_at,
+                    scopes,
+                ),
+            )
+            await conn.commit()
+        return McpOAuthToken(
+            user_id=user_id,
+            mcp_name=mcp_name,
+            access_token=access_token,
+            refresh_token=refresh_token,
+            expires_at=expires_at,
+            scopes=scopes,
+        )
+
+    @staticmethod
+    def expires_at_from_token_response(data: dict[str, Any]) -> datetime | None:
+        """Compute expiry from an OAuth token endpoint JSON body."""
+        expires_in = data.get("expires_in")
+        if expires_in is None:
+            return None
+        try:
+            return datetime.now(UTC) + timedelta(seconds=int(expires_in))
+        except (TypeError, ValueError):
+            return None

--- a/deep_agent/aegra/mcp_token_store.py
+++ b/deep_agent/aegra/mcp_token_store.py
@@ -1,7 +1,9 @@
-"""Postgres repository for per-user MCP OAuth tokens and DCR client records."""
+"""Repository for MCP OAuth tokens (Redis) and DCR client records (Postgres)."""
 
 from __future__ import annotations
 
+import asyncio
+import json
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -11,11 +13,13 @@ from psycopg.rows import dict_row
 from psycopg.types.json import Jsonb
 
 from deep_agent.aegra.mcp_crypto import decrypt_secret, encrypt_secret
+from deep_agent.aegra.redis import cache_delete, cache_get, cache_set_persistent
 from deep_agent.utils.pylogger import get_python_logger
 
 logger = get_python_logger()
 
 _TABLES_ENSURED = False
+_TOKEN_KEY_PREFIX = "mcp_oauth_token:"
 
 CREATE_OAUTH_CLIENTS_TABLE = """
 CREATE TABLE IF NOT EXISTS mcp_oauth_clients (
@@ -27,34 +31,9 @@ CREATE TABLE IF NOT EXISTS mcp_oauth_clients (
 );
 """
 
-CREATE_OAUTH_TOKENS_TABLE = """
-CREATE TABLE IF NOT EXISTS mcp_oauth_tokens (
-    user_id        TEXT NOT NULL,
-    mcp_name       TEXT NOT NULL,
-    access_token   TEXT NOT NULL,
-    refresh_token  TEXT,
-    expires_at     TIMESTAMPTZ,
-    scopes         TEXT[],
-    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
-    PRIMARY KEY (user_id, mcp_name)
-);
-"""
-
 MIGRATE_OAUTH_TABLES = """
 DO $$
 BEGIN
-    IF EXISTS (
-        SELECT 1 FROM information_schema.tables
-        WHERE table_schema = 'public' AND table_name = 'mcp_oauth_tokens'
-    ) AND NOT EXISTS (
-        SELECT 1 FROM information_schema.columns
-        WHERE table_schema = 'public'
-          AND table_name = 'mcp_oauth_tokens'
-          AND column_name = 'user_id'
-    ) THEN
-        DROP TABLE mcp_oauth_tokens;
-    END IF;
-
     IF EXISTS (
         SELECT 1 FROM information_schema.tables
         WHERE table_schema = 'public' AND table_name = 'mcp_oauth_clients'
@@ -109,23 +88,72 @@ class McpOAuthToken:
 
 
 class McpTokenStore:
-    """Async Postgres store for MCP OAuth clients and user tokens."""
+    """Async store for MCP OAuth user tokens (Redis) and DCR clients (Postgres)."""
 
     def __init__(self, database_uri: str) -> None:
-        """Initialize with a Postgres connection URI."""
+        """Initialize with a Postgres connection URI for DCR client records."""
         self._uri = database_uri
 
+    @staticmethod
+    def _token_key(user_id: str, mcp_name: str) -> str:
+        return f"{_TOKEN_KEY_PREFIX}{user_id}:{mcp_name}"
+
+    @staticmethod
+    def _serialize_datetime(value: datetime | None) -> str | None:
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=UTC)
+        return value.astimezone(UTC).isoformat()
+
+    @staticmethod
+    def _deserialize_datetime(value: str | None) -> datetime | None:
+        if not value:
+            return None
+        parsed = datetime.fromisoformat(value)
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=UTC)
+        return parsed.astimezone(UTC)
+
+    def _token_to_payload(
+        self,
+        access_token: str,
+        refresh_token: str | None,
+        expires_at: datetime | None,
+        scopes: list[str] | None,
+    ) -> dict[str, Any]:
+        now = datetime.now(UTC)
+        return {
+            "access_token": encrypt_secret(access_token),
+            "refresh_token": encrypt_secret(refresh_token),
+            "expires_at": self._serialize_datetime(expires_at),
+            "scopes": scopes,
+            "updated_at": self._serialize_datetime(now),
+        }
+
+    def _payload_to_token(
+        self, user_id: str, mcp_name: str, payload: dict[str, Any]
+    ) -> McpOAuthToken:
+        return McpOAuthToken(
+            user_id=user_id,
+            mcp_name=mcp_name,
+            access_token=decrypt_secret(payload.get("access_token")) or "",
+            refresh_token=decrypt_secret(payload.get("refresh_token")),
+            expires_at=self._deserialize_datetime(payload.get("expires_at")),
+            scopes=list(payload["scopes"]) if payload.get("scopes") else None,
+            updated_at=self._deserialize_datetime(payload.get("updated_at")),
+        )
+
     async def ensure_tables(self) -> None:
-        """Create MCP OAuth tables if they do not already exist."""
+        """Create MCP OAuth client table in Postgres if it does not already exist."""
         global _TABLES_ENSURED  # noqa: PLW0603
         async with await psycopg.AsyncConnection.connect(self._uri) as conn:
             await conn.execute(MIGRATE_OAUTH_TABLES)
             await conn.execute(CREATE_OAUTH_CLIENTS_TABLE)
-            await conn.execute(CREATE_OAUTH_TOKENS_TABLE)
             await conn.commit()
         if not _TABLES_ENSURED:
             _TABLES_ENSURED = True
-            logger.info("MCP OAuth tables ensured")
+            logger.info("MCP OAuth client table ensured")
 
     async def get_client(self, mcp_name: str) -> McpOAuthClient | None:
         """Return the registered OAuth client for *mcp_name*, if any."""
@@ -187,27 +215,27 @@ class McpTokenStore:
         )
 
     async def get_token(self, user_id: str, mcp_name: str) -> McpOAuthToken | None:
-        """Return stored OAuth tokens for *(user_id, mcp_name)*."""
-        await self.ensure_tables()
-        async with await psycopg.AsyncConnection.connect(
-            self._uri, row_factory=dict_row
-        ) as conn:
-            cur = await conn.execute(
-                "SELECT * FROM mcp_oauth_tokens WHERE user_id = %s AND mcp_name = %s",
-                (user_id, mcp_name),
+        """Return stored OAuth tokens for *(user_id, mcp_name)* from Redis."""
+        raw = await asyncio.to_thread(cache_get, self._token_key(user_id, mcp_name))
+        if raw is None:
+            return None
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.error(
+                "Corrupt MCP OAuth token payload for user '%s' MCP '%s'",
+                user_id,
+                mcp_name,
             )
-            row = await cur.fetchone()
-            if row is None:
-                return None
-            return McpOAuthToken(
-                user_id=row["user_id"],
-                mcp_name=row["mcp_name"],
-                access_token=decrypt_secret(row["access_token"]) or "",
-                refresh_token=decrypt_secret(row["refresh_token"]),
-                expires_at=row["expires_at"],
-                scopes=list(row["scopes"]) if row["scopes"] else None,
-                updated_at=row["updated_at"],
+            return None
+        if not isinstance(payload, dict):
+            logger.error(
+                "Invalid MCP OAuth token payload type for user '%s' MCP '%s'",
+                user_id,
+                mcp_name,
             )
+            return None
+        return self._payload_to_token(user_id, mcp_name, payload)
 
     async def upsert_token(
         self,
@@ -218,35 +246,16 @@ class McpTokenStore:
         expires_at: datetime | None = None,
         scopes: list[str] | None = None,
     ) -> McpOAuthToken:
-        """Insert or update OAuth tokens for *(user_id, mcp_name)*."""
-        await self.ensure_tables()
-        enc_access = encrypt_secret(access_token)
-        enc_refresh = encrypt_secret(refresh_token)
-        async with await psycopg.AsyncConnection.connect(self._uri) as conn:
-            await conn.execute(
-                """
-                INSERT INTO mcp_oauth_tokens (
-                    user_id, mcp_name, access_token, refresh_token,
-                    expires_at, scopes, updated_at
-                )
-                VALUES (%s, %s, %s, %s, %s, %s, now())
-                ON CONFLICT (user_id, mcp_name) DO UPDATE SET
-                    access_token = EXCLUDED.access_token,
-                    refresh_token = EXCLUDED.refresh_token,
-                    expires_at = EXCLUDED.expires_at,
-                    scopes = EXCLUDED.scopes,
-                    updated_at = now()
-                """,
-                (
-                    user_id,
-                    mcp_name,
-                    enc_access,
-                    enc_refresh,
-                    expires_at,
-                    scopes,
-                ),
+        """Insert or update OAuth tokens for *(user_id, mcp_name)* in Redis."""
+        payload = self._token_to_payload(
+            access_token, refresh_token, expires_at, scopes
+        )
+        key = self._token_key(user_id, mcp_name)
+        stored = await asyncio.to_thread(cache_set_persistent, key, json.dumps(payload))
+        if not stored:
+            raise RuntimeError(
+                f"Failed to persist MCP OAuth token for user '{user_id}' MCP '{mcp_name}'"
             )
-            await conn.commit()
         return McpOAuthToken(
             user_id=user_id,
             mcp_name=mcp_name,
@@ -254,7 +263,12 @@ class McpTokenStore:
             refresh_token=refresh_token,
             expires_at=expires_at,
             scopes=scopes,
+            updated_at=self._deserialize_datetime(payload["updated_at"]),
         )
+
+    async def delete_token(self, user_id: str, mcp_name: str) -> bool:
+        """Delete stored OAuth tokens for *(user_id, mcp_name)* from Redis."""
+        return await asyncio.to_thread(cache_delete, self._token_key(user_id, mcp_name))
 
     @staticmethod
     def expires_at_from_token_response(data: dict[str, Any]) -> datetime | None:

--- a/deep_agent/aegra/mcp_tool_auth.py
+++ b/deep_agent/aegra/mcp_tool_auth.py
@@ -1,0 +1,73 @@
+"""Wrap MCP tools to raise LangGraph interrupts when OAuth is required."""
+
+from __future__ import annotations
+
+import inspect
+import json
+from typing import Any
+
+from langgraph.types import interrupt
+
+from deep_agent.aegra.mcp_auth import NeedsAuthorization
+from deep_agent.utils.pylogger import get_python_logger
+
+logger = get_python_logger()
+
+
+def _mcp_auth_interrupt_payload(exc: NeedsAuthorization) -> str:
+    return json.dumps(
+        {
+            "type": "mcp_auth_required",
+            "mcp_name": exc.mcp_name,
+            "connect_url": exc.connect_url,
+            "message": f"Connect to {exc.mcp_name} to use these tools",
+        }
+    )
+
+
+def wrap_mcp_tools_for_auth(tools: list[Any]) -> list[Any]:
+    """Wrap MCP tools so ``NeedsAuthorization`` becomes a resumable interrupt."""
+    wrapped: list[Any] = []
+    for tool in tools:
+        wrapped.append(_wrap_single_tool(tool))
+    return wrapped
+
+
+def _wrap_single_tool(tool: Any) -> Any:
+    coroutine = getattr(tool, "coroutine", None)
+    func = getattr(tool, "func", None)
+
+    if inspect.iscoroutinefunction(coroutine):
+
+        async def wrapped_coroutine(**kwargs: Any) -> Any:
+            while True:
+                try:
+                    return await coroutine(**kwargs)
+                except NeedsAuthorization as exc:
+                    logger.info(
+                        "MCP auth required for '%s' — interrupting run",
+                        exc.mcp_name,
+                    )
+                    interrupt(_mcp_auth_interrupt_payload(exc))
+
+        try:
+            return tool.model_copy(update={"coroutine": wrapped_coroutine})
+        except Exception:
+            tool.coroutine = wrapped_coroutine
+            return tool
+
+    if func is not None and inspect.isfunction(func):
+
+        def wrapped_func(**kwargs: Any) -> Any:
+            try:
+                return func(**kwargs)
+            except NeedsAuthorization as exc:
+                interrupt(_mcp_auth_interrupt_payload(exc))
+
+        try:
+            return tool.model_copy(update={"func": wrapped_func})
+        except Exception:
+            tool.func = wrapped_func
+            return tool
+
+    return tool

--- a/deep_agent/aegra/middleware.py
+++ b/deep_agent/aegra/middleware.py
@@ -51,7 +51,9 @@ def validate_jwt_token(token: str) -> dict[str, Any]:
     try:
         import jwt
 
-        claims = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
+        claims: dict[str, Any] = jwt.decode(
+            token, JWT_SECRET, algorithms=[JWT_ALGORITHM]
+        )
         if claims.get("exp") and claims["exp"] < time.time():
             raise AuthError("Token expired")
         return claims

--- a/deep_agent/aegra/redis.py
+++ b/deep_agent/aegra/redis.py
@@ -119,6 +119,19 @@ def cache_set(key: str, value: str, ttl_seconds: int = 300) -> bool:
         return False
 
 
+def cache_set_persistent(key: str, value: str) -> bool:
+    """Write a value to Redis without expiry. Returns False on error."""
+    client = get_redis_client()
+    if client is None:
+        return False
+    try:
+        client.set(f"{REDIS_KEY_PREFIX}{key}", value)
+        return True
+    except Exception:
+        logger.debug("Persistent cache write failed for key '%s'", key, exc_info=True)
+        return False
+
+
 def cache_delete(key: str) -> bool:
     """Delete a key from Redis cache. Returns False on error."""
     client = get_redis_client()

--- a/deep_agent/aegra/redis.py
+++ b/deep_agent/aegra/redis.py
@@ -11,8 +11,13 @@ Environment variables:
     REDIS_RETRY_ON_TIMEOUT: Enable retry (default: true)
 """
 
+import asyncio
 import os
-from typing import Any
+import secrets
+import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any, Literal
 
 from deep_agent.utils.pylogger import get_python_logger
 
@@ -124,3 +129,88 @@ def cache_delete(key: str) -> bool:
         return True
     except Exception:
         return False
+
+
+_RELEASE_LOCK_LUA = """
+if redis.call("get", KEYS[1]) == ARGV[1] then
+    return redis.call("del", KEYS[1])
+else
+    return 0
+end
+"""
+
+
+def _lock_key(name: str) -> str:
+    return f"{REDIS_KEY_PREFIX}lock:{name}"
+
+
+def acquire_distributed_lock(
+    name: str,
+    *,
+    ttl_seconds: int = 30,
+    wait_seconds: float = 10.0,
+    poll_interval: float = 0.05,
+) -> str | None:
+    """Acquire a Redis lock. Returns a token, or None if unavailable or timed out."""
+    client = get_redis_client()
+    if client is None:
+        return None
+
+    token = secrets.token_urlsafe(16)
+    key = _lock_key(name)
+    deadline = time.monotonic() + wait_seconds
+
+    while True:
+        try:
+            if client.set(key, token, nx=True, ex=ttl_seconds):
+                return token
+        except Exception:
+            logger.debug("Lock acquire failed for '%s'", name, exc_info=True)
+            return None
+
+        if time.monotonic() >= deadline:
+            return None
+        time.sleep(poll_interval)
+
+
+def release_distributed_lock(name: str, token: str) -> bool:
+    """Release a Redis lock when the token still matches."""
+    client = get_redis_client()
+    if client is None:
+        return False
+    try:
+        return bool(client.eval(_RELEASE_LOCK_LUA, 1, _lock_key(name), token))
+    except Exception:
+        logger.debug("Lock release failed for '%s'", name, exc_info=True)
+        return False
+
+
+LockState = Literal["held", "no_redis", "timeout"]
+
+
+@asynccontextmanager
+async def distributed_lock(
+    name: str,
+    *,
+    ttl_seconds: int = 30,
+    wait_seconds: float = 10.0,
+) -> AsyncIterator[LockState]:
+    """Yield lock state for a Redis-backed distributed lock."""
+    if get_redis_client() is None:
+        yield "no_redis"
+        return
+
+    token = await asyncio.to_thread(
+        acquire_distributed_lock,
+        name,
+        ttl_seconds=ttl_seconds,
+        wait_seconds=wait_seconds,
+    )
+    if token is None:
+        yield "timeout"
+        return
+
+    try:
+        yield "held"
+    finally:
+        await asyncio.to_thread(release_distributed_lock, name, token)

--- a/deep_agent/aegra/shutdown.py
+++ b/deep_agent/aegra/shutdown.py
@@ -5,7 +5,7 @@ functions, structured logging, defensive error handling.
 
 Two independent paths trigger shutdown:
 
-1. ``atexit`` callback (registered at import time from ``feedback.py``)
+1. ``atexit`` callback (registered at import time from ``http_app.py``)
    — fires reliably when uvicorn handles SIGTERM and exits normally.
    Runs a synchronous cleanup (Langfuse flush, Redis close, graph
    cache clear). No event loop needed.
@@ -17,7 +17,7 @@ Two independent paths trigger shutdown:
 
 Aegra strips our custom app's lifespan and middleware, so neither
 ASGI lifespan nor middleware-based registration works. The atexit
-path is guaranteed because Aegra always imports ``feedback.py``.
+path is guaranteed because Aegra always imports ``http_app.py``.
 
 Both paths call idempotent cleanup — the second call is a no-op.
 
@@ -86,7 +86,7 @@ def is_shutting_down() -> bool:
 def register_atexit() -> None:
     """Register the sync shutdown as an atexit callback.
 
-    Called at import time from ``feedback.py``. Unlike signal handlers,
+    Called at import time from ``http_app.py``. Unlike signal handlers,
     atexit callbacks are not overwritten by uvicorn. Idempotent — safe
     to call multiple times (tests, reloads).
     """
@@ -205,10 +205,10 @@ async def run_shutdown() -> dict[str, str]:
         ("redis", _close_redis),
     ]:
         try:
-            result = step()
-            if asyncio.iscoroutine(result):
-                result = await result
-            results[key] = result
+            step_result = step()
+            if asyncio.iscoroutine(step_result):
+                step_result = await step_result
+            results[key] = str(step_result)
         except Exception as exc:
             logger.warning("Shutdown step '%s' failed: %s", key, exc)
             results[key] = f"error: {exc}"

--- a/deep_agent/aegra/startup.py
+++ b/deep_agent/aegra/startup.py
@@ -96,6 +96,10 @@ async def _ensure_database() -> str:
         await repo.ensure_tables()
         feedback_repo = FeedbackRepository(settings.database_uri)
         await feedback_repo.ensure_table()
+        from deep_agent.aegra.mcp_token_store import McpTokenStore
+
+        mcp_token_store = McpTokenStore(settings.database_uri)
+        await mcp_token_store.ensure_tables()
         return "ok"
     except Exception as exc:
         logger.error("Database setup failed: %s", exc)

--- a/deep_agent/src/agent/config/loader.py
+++ b/deep_agent/src/agent/config/loader.py
@@ -16,6 +16,7 @@ Classes:
 """
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -40,9 +41,12 @@ logger = get_python_logger(log_level=settings.PYTHON_LOG_LEVEL)
 
 # Config directory path - read from CONFIG_PATH env var for base image pattern
 # Falls back to repo-root config/agent/ for backward compatibility
-import os
-_AGENT_CONFIG_DIR = Path(os.getenv("CONFIG_PATH",
-    str(Path(__file__).parent.parent.parent.parent.parent / "config" / "agent")))
+_AGENT_CONFIG_DIR = Path(
+    os.getenv(
+        "CONFIG_PATH",
+        str(Path(__file__).parent.parent.parent.parent.parent / "config" / "agent"),
+    )
+)
 
 
 class AgentConfig:
@@ -124,7 +128,7 @@ class AgentConfig:
             if self._configs_loaded:
                 logger.debug("CONFIG_AUTO_RELOAD=true: reloading configs from disk")
             self._configs_loaded = False
-        
+
         if self._configs_loaded:
             return
 
@@ -188,9 +192,7 @@ class AgentConfig:
         Raises:
             AppException: If ``mcps`` is not a list of strings.
         """
-        if not isinstance(mcps, list) or not all(
-            isinstance(s, str) for s in mcps
-        ):
+        if not isinstance(mcps, list) or not all(isinstance(s, str) for s in mcps):
             raise AppException(
                 f"Agent '{agent_name}': 'mcps' must be a list of strings",
                 ErrorCodes.CONFIGURATION_VALIDATION_ERROR,
@@ -274,6 +276,57 @@ class AgentConfig:
 
         return subagents
 
+    @staticmethod
+    def _validate_mcp_server(name: str, cfg: dict[str, Any]) -> None:
+        """Log clear errors for invalid per-MCP OAuth/DCR configuration."""
+        auth_mode = cfg.get("auth_mode", "sso")
+        cfg["auth_mode"] = auth_mode
+
+        if auth_mode not in ("sso", "oauth", "dcr"):
+            logger.error(
+                "MCP server '%s': invalid auth_mode '%s' (expected sso, oauth, or dcr)",
+                name,
+                auth_mode,
+            )
+            return
+
+        if auth_mode not in ("oauth", "dcr"):
+            return
+
+        oauth = cfg.get("oauth")
+        if not isinstance(oauth, dict):
+            logger.error(
+                "MCP server '%s': auth_mode '%s' requires an 'oauth' block",
+                name,
+                auth_mode,
+            )
+            return
+
+        for field in (
+            "authorization_endpoint",
+            "token_endpoint",
+            "redirect_uri",
+        ):
+            if not oauth.get(field):
+                logger.error(
+                    "MCP server '%s': oauth.%s is required for auth_mode '%s'",
+                    name,
+                    field,
+                    auth_mode,
+                )
+
+        if auth_mode == "oauth" and not oauth.get("client_id"):
+            logger.error(
+                "MCP server '%s': oauth.client_id is required for auth_mode 'oauth'",
+                name,
+            )
+
+        if auth_mode == "dcr" and not oauth.get("registration_endpoint"):
+            logger.error(
+                "MCP server '%s': oauth.registration_endpoint is required for auth_mode 'dcr'",
+                name,
+            )
+
     def _load_mcp_servers(self) -> dict[str, Any]:
         """Load MCP server configuration at initialization.
 
@@ -288,6 +341,9 @@ class AgentConfig:
         try:
             data = json.loads(mcp_path.read_bytes())
             servers: dict[str, Any] = data.get("mcpServers", {})
+            for name, cfg in servers.items():
+                if isinstance(cfg, dict):
+                    self._validate_mcp_server(name, cfg)
             logger.info(f"Loaded {len(servers)} MCP server config(s)")
             return servers
         except Exception as e:

--- a/deep_agent/src/agent/config/loader.py
+++ b/deep_agent/src/agent/config/loader.py
@@ -305,7 +305,6 @@ class AgentConfig:
         for field in (
             "authorization_endpoint",
             "token_endpoint",
-            "redirect_uri",
         ):
             if not oauth.get(field):
                 logger.error(
@@ -315,9 +314,23 @@ class AgentConfig:
                     auth_mode,
                 )
 
+        if oauth.get("redirect_uri"):
+            logger.warning(
+                "MCP server '%s': oauth.redirect_uri in mcp.json is ignored — "
+                "redirect URI is derived from AGENT_PUBLIC_BASE_URL",
+                name,
+            )
+
         if auth_mode == "oauth" and not oauth.get("client_id"):
             logger.error(
                 "MCP server '%s': oauth.client_id is required for auth_mode 'oauth'",
+                name,
+            )
+
+        if oauth.get("client_secret"):
+            logger.warning(
+                "MCP server '%s': oauth.client_secret in mcp.json is insecure — "
+                "use oauth.client_secret_env with an environment variable name instead",
                 name,
             )
 

--- a/deep_agent/src/agent/config/model.py
+++ b/deep_agent/src/agent/config/model.py
@@ -82,9 +82,7 @@ def parse_model_config(raw: str | dict[str, Any]) -> ModelSpec:
         return ModelSpec(provider=infer_provider(name), name=name)
 
     if not isinstance(raw, dict):
-        raise TypeError(
-            f"model config must be str or dict, got {type(raw).__name__}"
-        )
+        raise TypeError(f"model config must be str or dict, got {type(raw).__name__}")
 
     allowed_keys = {"provider", "name", "fallback"}
     unknown = set(raw.keys()) - allowed_keys
@@ -94,14 +92,15 @@ def parse_model_config(raw: str | dict[str, Any]) -> ModelSpec:
             f"allowed: {sorted(allowed_keys)}"
         )
 
-    name = raw.get("name")
-    if not name or not str(name).strip():
+    name_raw = raw.get("name")
+    if not isinstance(name_raw, str) or not name_raw.strip():
         raise ValueError("model config object requires non-empty 'name'")
+    name = name_raw.strip()
 
     # Provider is optional - infer from name if not provided
     provider_raw = raw.get("provider")
     if provider_raw is None:
-        provider = infer_provider(str(name).strip())
+        provider = infer_provider(name)
     else:
         try:
             provider = Provider(provider_raw)

--- a/deep_agent/src/cache/warming.py
+++ b/deep_agent/src/cache/warming.py
@@ -59,9 +59,7 @@ def _warm_models() -> bool:
             if sub_model:
                 spec = parse_model_config(sub_model)
                 get_or_create_model_from_spec(spec)
-                logger.info(
-                    "Warmed subagent '%s' model: %s", name, spec.display_name()
-                )
+                logger.info("Warmed subagent '%s' model: %s", name, spec.display_name())
 
         return True
     except Exception:

--- a/deep_agent/src/feedback/repository.py
+++ b/deep_agent/src/feedback/repository.py
@@ -33,6 +33,7 @@ class FeedbackRepository:
     """Thin async wrapper around the message_feedback table."""
 
     def __init__(self, database_uri: str) -> None:
+        """Initialize with a Postgres connection URI."""
         self._uri = database_uri
 
     async def ensure_table(self) -> None:

--- a/deep_agent/src/infrastructure/subagents.py
+++ b/deep_agent/src/infrastructure/subagents.py
@@ -14,7 +14,7 @@ Functions:
     load_subagents: Build all subagents from config/subagents/*.md
 """
 
-from typing import Any
+from typing import Any, cast
 
 from deepagents import SubAgent
 from deepagents.middleware.subagents import CompiledSubAgent
@@ -25,7 +25,11 @@ except ImportError:
     AsyncSubAgent = None
 
 from deep_agent.src.agent.config import agent_config
-from deep_agent.src.agent.config.model import ModelSpec, infer_provider, parse_model_config
+from deep_agent.src.agent.config.model import (
+    ModelSpec,
+    infer_provider,
+    parse_model_config,
+)
 from deep_agent.src.cache.model_cache import get_or_create_model_from_spec
 from deep_agent.src.exceptions import LLMError, SubAgentError
 from deep_agent.src.settings import settings
@@ -146,7 +150,7 @@ def _inherit_from_orchestrator(
 
 
 def _normalize_model_to_dict(
-    raw_model: str | dict[str, Any],
+    raw_model: Any,
     strip_fallback: bool = False,
 ) -> dict[str, Any] | Any:
     """Normalize model config (string or dict) to dict format.
@@ -168,13 +172,11 @@ def _normalize_model_to_dict(
         if strip_fallback and "fallback" in result:
             del result["fallback"]
         return result
-    else:
-        # Invalid type - return as-is and let parse_model_config fail later
-        logger.warning(
-            "Invalid model config type: %s, letting parse_model_config handle error",
-            type(raw_model).__name__,
-        )
-        return raw_model
+    logger.warning(
+        "Invalid model config type: %s, letting parse_model_config handle error",
+        type(raw_model).__name__,
+    )
+    return raw_model
 
 
 def _inject_fallback_if_missing(
@@ -196,7 +198,7 @@ def _inject_fallback_if_missing(
     # Normalize subagent model to dict
     model_dict = _normalize_model_to_dict(subagent_model)
     if not isinstance(model_dict, dict):
-        return model_dict  # Invalid type, will fail later in parse_model_config
+        return cast("str | dict[str, Any]", model_dict)
 
     # Case 3: Subagent already has fallback → keep as-is
     if "fallback" in model_dict:
@@ -231,7 +233,6 @@ def _create_primary_model(spec: ModelSpec) -> object:
     Returns:
         A BaseChatModel instance for the primary model only.
     """
-
     # Create a spec without fallback for the primary model
     primary_spec = ModelSpec(provider=spec.provider, name=spec.name, fallback=None)
 
@@ -279,7 +280,9 @@ def _build_fallback_middleware(spec: ModelSpec) -> list[Any]:
     try:
         from langchain.agents.middleware import ModelFallbackMiddleware
     except ImportError:
-        logger.warning("ModelFallbackMiddleware not available, skipping fallback configuration")
+        logger.warning(
+            "ModelFallbackMiddleware not available, skipping fallback configuration"
+        )
         return []
 
     # Create fallback model using the model cache
@@ -341,7 +344,9 @@ def _build_default_subagent(
         )
 
     spec = parse_model_config(agent_cfg["model"])
-    logger.info("Subagent '%s' [default] using model: %s", name, _format_model_log(spec))
+    logger.info(
+        "Subagent '%s' [default] using model: %s", name, _format_model_log(spec)
+    )
 
     tool_names: list[str] = agent_cfg.get("tools", [])
     mcp_names: list[str] = agent_cfg.get("mcps", [])

--- a/deep_agent/src/settings.py
+++ b/deep_agent/src/settings.py
@@ -10,6 +10,7 @@ Hierarchy (highest wins):
 """
 
 from typing import Optional
+from urllib.parse import urlparse
 
 from dotenv import load_dotenv
 from pydantic import Field
@@ -19,6 +20,8 @@ from deep_agent.src.exceptions import AppException, ErrorCodes
 from deep_agent.utils.pylogger import get_python_logger
 
 logger = get_python_logger()
+
+_DEV_PUBLIC_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 
 try:
     load_dotenv()
@@ -112,6 +115,7 @@ class Settings(BaseSettings):
 
     # ── MCP OAuth ─────────────────────────────────────────────────────
     MCP_TOKEN_ENCRYPTION_KEY: Optional[str] = Field(default=None)
+    MCP_TOKEN_ENCRYPTION_KEY_PREVIOUS: Optional[str] = Field(default=None)
     AGENT_PUBLIC_BASE_URL: Optional[str] = Field(default=None)
 
     # ── Derived ───────────────────────────────────────────────────────
@@ -122,6 +126,17 @@ class Settings(BaseSettings):
         if self.AGENT_PUBLIC_BASE_URL:
             return self.AGENT_PUBLIC_BASE_URL.rstrip("/")
         return f"http://localhost:{self.AGENT_PORT}"
+
+    @property
+    def is_dev_public_url(self) -> bool:
+        """True when the public base URL is an allowed local HTTP dev endpoint."""
+        parsed = urlparse(self.agent_public_base_url)
+        return parsed.scheme == "http" and parsed.hostname in _DEV_PUBLIC_HOSTS
+
+    @property
+    def oauth_callback_url(self) -> str:
+        """Canonical OAuth redirect URI derived from AGENT_PUBLIC_BASE_URL."""
+        return f"{self.agent_public_base_url}/mcp/oauth/callback"
 
     @property
     def database_uri(self) -> str:
@@ -146,6 +161,15 @@ def validate_config(settings: Settings) -> None:
             f"PYTHON_LOG_LEVEL must be one of {valid_log_levels}, got {settings.PYTHON_LOG_LEVEL}",
             ErrorCodes.CONFIGURATION_VALIDATION_ERROR,
         )
+
+    if settings.AGENT_PUBLIC_BASE_URL and not settings.is_dev_public_url:
+        parsed = urlparse(settings.AGENT_PUBLIC_BASE_URL)
+        if parsed.scheme != "https":
+            raise AppException(
+                "AGENT_PUBLIC_BASE_URL must use https:// in production "
+                "(http:// is permitted only for localhost, 127.0.0.1, or ::1)",
+                ErrorCodes.CONFIGURATION_VALIDATION_ERROR,
+            )
 
 
 settings = Settings()

--- a/deep_agent/src/settings.py
+++ b/deep_agent/src/settings.py
@@ -110,7 +110,18 @@ class Settings(BaseSettings):
     # ── FLAG TO SWITCH TO RELOAD FROM DISK ────────────────────────────
     CONFIG_AUTO_RELOAD: bool = Field(default=False)
 
+    # ── MCP OAuth ─────────────────────────────────────────────────────
+    MCP_TOKEN_ENCRYPTION_KEY: Optional[str] = Field(default=None)
+    AGENT_PUBLIC_BASE_URL: Optional[str] = Field(default=None)
+
     # ── Derived ───────────────────────────────────────────────────────
+
+    @property
+    def agent_public_base_url(self) -> str:
+        """Public base URL for MCP OAuth connect/callback endpoints."""
+        if self.AGENT_PUBLIC_BASE_URL:
+            return self.AGENT_PUBLIC_BASE_URL.rstrip("/")
+        return f"http://localhost:{self.AGENT_PORT}"
 
     @property
     def database_uri(self) -> str:

--- a/deep_agent/src/streaming/converter.py
+++ b/deep_agent/src/streaming/converter.py
@@ -7,10 +7,14 @@ rewrites and context metadata injection.
 
 from typing import Any, Dict, List, Union
 
+from langchain_core.messages import BaseMessage
+
 from deep_agent.src.streaming.context import StreamContext
 
 
-def convert_message_to_api_format(chat_message, ctx: StreamContext) -> dict[str, Any]:
+def convert_message_to_api_format(
+    chat_message: Any, ctx: StreamContext
+) -> dict[str, Any]:
     """Convert ChatMessage to simplified API format.
 
     Args:
@@ -76,7 +80,7 @@ def remove_tool_calls(
     ]
 
 
-def should_skip_message(message) -> tuple[bool, str | None]:
+def should_skip_message(message: BaseMessage) -> tuple[bool, str | None]:
     """Determine if a message should be skipped.
 
     Args:

--- a/deep_agent/src/streaming/deduplicator.py
+++ b/deep_agent/src/streaming/deduplicator.py
@@ -5,10 +5,10 @@ LangGraph replays from checkpoints. It tracks message IDs and filters out
 messages that have already been seen in the current stream.
 """
 
-from langchain_core.messages import ToolMessage
+from langchain_core.messages import BaseMessage, ToolMessage
 
 
-def extract_message_id(msg) -> str | None:
+def extract_message_id(msg: BaseMessage) -> str | None:
     """Extract a stable identifier from a message.
 
     Args:
@@ -17,10 +17,14 @@ def extract_message_id(msg) -> str | None:
     Returns:
         A stable ID string, or None if no stable ID exists.
     """
-    msg_id = msg.id
-    if msg_id is None and isinstance(msg, ToolMessage):
+    msg_id: str | None
+    if isinstance(msg.id, str):
+        msg_id = msg.id
+    elif isinstance(msg, ToolMessage):
         # ToolMessages may not have .id set; use tool_call_id as fallback
         msg_id = f"tool_{msg.tool_call_id}"
+    else:
+        msg_id = None
     return msg_id
 
 
@@ -32,15 +36,15 @@ class MessageDeduplicator:
     messages to avoid duplicate streaming.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the deduplicator."""
         self._seen_ids: set[str] = set()
 
-    def reset(self):
+    def reset(self) -> None:
         """Clear all seen message IDs."""
         self._seen_ids.clear()
 
-    def mark_seen(self, msg) -> None:
+    def mark_seen(self, msg: BaseMessage) -> None:
         """Mark a message as seen.
 
         Args:
@@ -50,7 +54,7 @@ class MessageDeduplicator:
         if msg_id:
             self._seen_ids.add(msg_id)
 
-    def is_seen(self, msg) -> bool:
+    def is_seen(self, msg: BaseMessage) -> bool:
         """Check if a message has been seen before.
 
         Args:
@@ -65,7 +69,7 @@ class MessageDeduplicator:
             return False
         return msg_id in self._seen_ids
 
-    def get_unseen_messages(self, messages: list) -> list:
+    def get_unseen_messages(self, messages: list[BaseMessage]) -> list[BaseMessage]:
         """Get only unseen messages from a list, marking them as seen.
 
         Args:
@@ -85,7 +89,7 @@ class MessageDeduplicator:
                 self._seen_ids.add(msg_id)
         return unseen
 
-    def populate_from_history(self, messages: list) -> None:
+    def populate_from_history(self, messages: list[BaseMessage]) -> None:
         """Pre-populate seen IDs from existing message history.
 
         Used when resuming from a checkpoint to avoid replaying

--- a/deep_agent/src/streaming/tracker.py
+++ b/deep_agent/src/streaming/tracker.py
@@ -29,7 +29,8 @@ def extract_tool_call_id(msg: AIMessageChunk) -> str | None:
     """
     try:
         if msg.tool_calls:
-            return msg.tool_calls[0].get("id")
+            tool_call_id = msg.tool_calls[0].get("id")
+            return tool_call_id if isinstance(tool_call_id, str) else None
         return None
     except (IndexError, KeyError) as e:
         logger.debug(f"Could not extract tool call ID: {e}")
@@ -44,11 +45,11 @@ class ToolCallTracker:
     current tool call ID for proper attribution in the UI.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the tracker."""
         self._current_tool_call_id: str | None = None
 
-    def reset(self):
+    def reset(self) -> None:
         """Clear the current tool call ID."""
         self._current_tool_call_id = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "structlog==25.5.0",
     "pyyaml==6.0.3",
     "PyJWT[crypto]>=2.8.0",
+    "cryptography>=43.0.0",
     "httpx>=0.27.0",
     "tenacity>=8.2.0,<10",
     "redis>=5.0.0,<7",

--- a/runtime/config_loader.py
+++ b/runtime/config_loader.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-Config Loader - Validates config volume mount before starting agent runtime.
+"""Config Loader - Validates config volume mount before starting agent runtime.
 
 Expected directory structure at $CONFIG_PATH (/app/config/agent):
   - PROMPT.md
@@ -9,20 +8,22 @@ Expected directory structure at $CONFIG_PATH (/app/config/agent):
   - subagents/
   - runtime/ (optional)
 """
+
+import json
 import os
 import sys
-import json
 from pathlib import Path
 
 CONFIG_PATH = Path(os.getenv("CONFIG_PATH", "/app/config/agent"))
 REQUIRED_FILES = ["PROMPT.md", "mcp.json"]
 
-def validate_config_mount():
+
+def validate_config_mount() -> None:
     """Ensure config volume is mounted and contains required files."""
     if not CONFIG_PATH.exists():
         print(f"❌ ERROR: Config path not found: {CONFIG_PATH}", file=sys.stderr)
-        print(f"   Expected config to be mounted as a volume.", file=sys.stderr)
-        print(f"   Check deployment spec for volume mount.", file=sys.stderr)
+        print("   Expected config to be mounted as a volume.", file=sys.stderr)
+        print("   Check deployment spec for volume mount.", file=sys.stderr)
         sys.exit(1)
 
     missing_files = []
@@ -31,9 +32,15 @@ def validate_config_mount():
             missing_files.append(file)
 
     if missing_files:
-        print(f"❌ ERROR: Missing required config files: {missing_files}", file=sys.stderr)
+        print(
+            f"❌ ERROR: Missing required config files: {missing_files}", file=sys.stderr
+        )
         print(f"   Config path: {CONFIG_PATH}", file=sys.stderr)
-        found_files = [str(p.relative_to(CONFIG_PATH)) for p in CONFIG_PATH.rglob("*") if p.is_file()]
+        found_files = [
+            str(p.relative_to(CONFIG_PATH))
+            for p in CONFIG_PATH.rglob("*")
+            if p.is_file()
+        ]
         print(f"   Found files: {found_files}", file=sys.stderr)
         sys.exit(1)
 
@@ -45,14 +52,15 @@ def validate_config_mount():
     try:
         with open(CONFIG_PATH / "mcp.json") as f:
             mcp_config = json.load(f)
-            servers = list(mcp_config.get('servers', {}).keys())
+            servers = list(mcp_config.get("servers", {}).keys())
             print(f"   MCP servers: {servers if servers else 'none'}")
     except json.JSONDecodeError as e:
         print(f"⚠️  WARNING: Invalid mcp.json: {e}", file=sys.stderr)
     except Exception as e:
         print(f"⚠️  WARNING: Could not read mcp.json: {e}", file=sys.stderr)
 
-def start_agent():
+
+def start_agent() -> None:
     """Start the agent runtime after config validation."""
     import uvicorn
     from aegra_api.main import app
@@ -60,17 +68,13 @@ def start_agent():
     host = os.getenv("AGENT_HOST", "0.0.0.0")
     port = int(os.getenv("AGENT_PORT", "5002"))
 
-    print(f"🚀 Starting agent runtime...")
+    print("🚀 Starting agent runtime...")
     print(f"   Host: {host}")
     print(f"   Port: {port}")
     print(f"   Config: {CONFIG_PATH}")
 
-    uvicorn.run(
-        app,
-        host=host,
-        port=port,
-        log_level="info"
-    )
+    uvicorn.run(app, host=host, port=port, log_level="info")
+
 
 if __name__ == "__main__":
     validate_config_mount()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ Provides:
 import sys
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 

--- a/tests/integration/aegra/test_graceful_shutdown.py
+++ b/tests/integration/aegra/test_graceful_shutdown.py
@@ -59,10 +59,7 @@ class TestShutdownUnderConcurrentActivity:
             await asyncio.sleep(duration)
             completed_tasks.append(task_id)
 
-        tasks = [
-            asyncio.create_task(simulate_graph_run(i, i * 0.05))
-            for i in range(5)
-        ]
+        tasks = [asyncio.create_task(simulate_graph_run(i, i * 0.05)) for i in range(5)]
 
         patches = _mock_all_subsystems(drain_seconds=0.3)
         with patches[0], patches[1], patches[2], patches[3]:

--- a/tests/unit/aegra/test_feedback.py
+++ b/tests/unit/aegra/test_feedback.py
@@ -7,7 +7,8 @@ from pydantic import ValidationError
 from starlette.requests import Request
 from starlette.testclient import TestClient
 
-from deep_agent.aegra.feedback import app, feedback_handler, record_feedback
+from deep_agent.aegra.feedback import feedback_handler, record_feedback
+from deep_agent.aegra.http_app import app
 
 
 class TestRecordFeedback:

--- a/tests/unit/aegra/test_graph.py
+++ b/tests/unit/aegra/test_graph.py
@@ -235,7 +235,9 @@ class TestAgentFactory:
                 return_value=None,
             ),
             patch("deep_agent.aegra.graph._ensure_startup", new_callable=AsyncMock),
-            patch("deepagents.create_deep_agent", return_value=mock_compiled) as mock_create,
+            patch(
+                "deepagents.create_deep_agent", return_value=mock_compiled
+            ) as mock_create,
         ):
             from deep_agent.aegra.graph import agent
 
@@ -244,5 +246,5 @@ class TestAgentFactory:
         assert result is mock_compiled
         assert mock_create.call_args.kwargs["tools"] == [mock_tool]
         mock_get_mcp.assert_awaited_once_with(
-            sso_token=None, server_names=["dataverse-mcp-prod1"]
+            sso_token=None, server_names=["dataverse-mcp-prod1"], user_id=None
         )

--- a/tests/unit/aegra/test_mcp_auth.py
+++ b/tests/unit/aegra/test_mcp_auth.py
@@ -51,8 +51,7 @@ Test prompt.
                   "auth_mode": "oauth",
                   "oauth": {
                     "authorization_endpoint": "https://as.example.com/authorize",
-                    "token_endpoint": "https://as.example.com/token",
-                    "redirect_uri": "https://agent.example.com/mcp/oauth/callback"
+                    "token_endpoint": "https://as.example.com/token"
                   }
                 }
               }
@@ -76,8 +75,7 @@ Test prompt.
                   "auth_mode": "dcr",
                   "oauth": {
                     "authorization_endpoint": "https://as.example.com/authorize",
-                    "token_endpoint": "https://as.example.com/token",
-                    "redirect_uri": "https://agent.example.com/mcp/oauth/callback"
+                    "token_endpoint": "https://as.example.com/token"
                   }
                 }
               }

--- a/tests/unit/aegra/test_mcp_auth.py
+++ b/tests/unit/aegra/test_mcp_auth.py
@@ -1,0 +1,202 @@
+"""Unit tests for MCP config validation and credential resolver."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from deep_agent.aegra.mcp import set_mcp_auth_context
+from deep_agent.aegra.mcp_auth import McpCredentialResolver, NeedsAuthorization
+from deep_agent.aegra.mcp_token_store import McpOAuthToken
+from deep_agent.src.agent.config.loader import AgentConfig
+
+
+class TestMcpConfigValidation:
+    def setup_method(self):
+        AgentConfig._instance = None
+
+    @staticmethod
+    def _write_minimal_config_dir(tmp_path):
+        (tmp_path / "PROMPT.md").write_text(
+            """---
+name: test-orchestrator
+model: gemini-2.5-flash
+---
+Test prompt.
+"""
+        )
+
+    def test_defaults_auth_mode_to_sso(self, tmp_path):
+        self._write_minimal_config_dir(tmp_path)
+        mcp_json = tmp_path / "mcp.json"
+        mcp_json.write_text(
+            '{"mcpServers": {"sso-mcp": {"url": "http://localhost/mcp", "enabled": true}}}'
+        )
+        cfg = AgentConfig(tmp_path)
+        servers = cfg.get_mcp_servers()
+        assert servers["sso-mcp"]["auth_mode"] == "sso"
+
+    def test_logs_error_for_oauth_without_client_id(self, tmp_path, caplog):
+        self._write_minimal_config_dir(tmp_path)
+        mcp_json = tmp_path / "mcp.json"
+        mcp_json.write_text(
+            """
+            {
+              "mcpServers": {
+                "oauth-mcp": {
+                  "url": "http://localhost/mcp",
+                  "enabled": true,
+                  "auth_mode": "oauth",
+                  "oauth": {
+                    "authorization_endpoint": "https://as.example.com/authorize",
+                    "token_endpoint": "https://as.example.com/token",
+                    "redirect_uri": "https://agent.example.com/mcp/oauth/callback"
+                  }
+                }
+              }
+            }
+            """
+        )
+        with caplog.at_level("ERROR"):
+            AgentConfig(tmp_path).get_mcp_servers()
+        assert any("client_id is required" in r.message for r in caplog.records)
+
+    def test_logs_error_for_dcr_without_registration_endpoint(self, tmp_path, caplog):
+        self._write_minimal_config_dir(tmp_path)
+        mcp_json = tmp_path / "mcp.json"
+        mcp_json.write_text(
+            """
+            {
+              "mcpServers": {
+                "dcr-mcp": {
+                  "url": "http://localhost/mcp",
+                  "enabled": true,
+                  "auth_mode": "dcr",
+                  "oauth": {
+                    "authorization_endpoint": "https://as.example.com/authorize",
+                    "token_endpoint": "https://as.example.com/token",
+                    "redirect_uri": "https://agent.example.com/mcp/oauth/callback"
+                  }
+                }
+              }
+            }
+            """
+        )
+        with caplog.at_level("ERROR"):
+            AgentConfig(tmp_path).get_mcp_servers()
+        assert any(
+            "registration_endpoint is required" in r.message for r in caplog.records
+        )
+
+
+@pytest.mark.asyncio
+class TestMcpCredentialResolver:
+    async def test_sso_returns_refreshed_token(self):
+        store = AsyncMock()
+        resolver = McpCredentialResolver(token_store=store)
+        set_mcp_auth_context("access-token", "refresh-token")
+
+        with patch(
+            "deep_agent.aegra.mcp_auth.refresh_access_token",
+            new=AsyncMock(return_value="fresh-token"),
+        ) as refresh:
+            token = await resolver.resolve(
+                "user-1",
+                "sso-mcp",
+                {"auth_mode": "sso"},
+            )
+
+        assert token == "fresh-token"
+        refresh.assert_awaited_once_with("access-token", "refresh-token")
+        store.get_token.assert_not_called()
+
+    async def test_oauth_raises_when_no_stored_token(self):
+        store = AsyncMock()
+        store.get_token = AsyncMock(return_value=None)
+        resolver = McpCredentialResolver(token_store=store)
+
+        with pytest.raises(NeedsAuthorization) as exc:
+            await resolver.resolve(
+                "user-1",
+                "oauth-mcp",
+                {
+                    "auth_mode": "oauth",
+                    "oauth": {"token_endpoint": "https://as.example.com/token"},
+                },
+            )
+
+        assert exc.value.mcp_name == "oauth-mcp"
+        assert exc.value.connect_url.endswith("/mcp/oauth-mcp/connect")
+
+    async def test_oauth_returns_valid_stored_token(self):
+        store = AsyncMock()
+        store.get_token = AsyncMock(
+            return_value=McpOAuthToken(
+                user_id="user-1",
+                mcp_name="oauth-mcp",
+                access_token="stored-access",
+                expires_at=datetime.now(UTC) + timedelta(hours=1),
+            )
+        )
+        resolver = McpCredentialResolver(token_store=store)
+
+        token = await resolver.resolve(
+            "user-1",
+            "oauth-mcp",
+            {"auth_mode": "oauth", "oauth": {}},
+        )
+        assert token == "stored-access"
+
+    async def test_oauth_refreshes_expired_token(self):
+        store = AsyncMock()
+        store.get_token = AsyncMock(
+            return_value=McpOAuthToken(
+                user_id="user-1",
+                mcp_name="oauth-mcp",
+                access_token="expired-access",
+                refresh_token="refresh-me",
+                expires_at=datetime.now(UTC) - timedelta(minutes=5),
+            )
+        )
+        store.upsert_token = AsyncMock()
+        resolver = McpCredentialResolver(token_store=store)
+
+        with patch.object(
+            resolver,
+            "_refresh_mcp_token",
+            new=AsyncMock(return_value="new-access"),
+        ) as refresh:
+            token = await resolver.resolve(
+                "user-1",
+                "oauth-mcp",
+                {
+                    "auth_mode": "oauth",
+                    "oauth": {
+                        "token_endpoint": "https://as.example.com/token",
+                        "client_id": "cid",
+                    },
+                },
+            )
+
+        assert token == "new-access"
+        refresh.assert_awaited_once()
+
+    async def test_resolver_caches_resolved_oauth_token(self):
+        store = AsyncMock()
+        store.get_token = AsyncMock(
+            return_value=McpOAuthToken(
+                user_id="user-1",
+                mcp_name="oauth-mcp",
+                access_token="stored-access",
+                expires_at=datetime.now(UTC) + timedelta(hours=1),
+            )
+        )
+        resolver = McpCredentialResolver(token_store=store)
+
+        cfg = {"auth_mode": "oauth", "oauth": {}}
+        await resolver.resolve("user-1", "oauth-mcp", cfg)
+        await resolver.resolve("user-1", "oauth-mcp", cfg)
+
+        store.get_token.assert_awaited_once()

--- a/tests/unit/aegra/test_mcp_crypto.py
+++ b/tests/unit/aegra/test_mcp_crypto.py
@@ -1,0 +1,85 @@
+"""Unit tests for MCP OAuth token encryption."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from cryptography.fernet import Fernet, InvalidToken
+
+from deep_agent.aegra.mcp_crypto import (
+    decrypt_secret,
+    encrypt_secret,
+    reset_mcp_crypto_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_crypto_cache():
+    reset_mcp_crypto_cache()
+    yield
+    reset_mcp_crypto_cache()
+
+
+@pytest.fixture
+def fernet_keys():
+    primary = Fernet.generate_key().decode()
+    previous = Fernet.generate_key().decode()
+    return primary, previous
+
+
+class TestMcpCrypto:
+    def test_encrypt_decrypt_round_trip(self, fernet_keys, monkeypatch):
+        primary, _ = fernet_keys
+        monkeypatch.setenv("MCP_TOKEN_ENCRYPTION_KEY", primary)
+        ciphertext = encrypt_secret("secret-token")
+        assert ciphertext is not None
+        assert decrypt_secret(ciphertext) == "secret-token"
+
+    def test_none_passthrough(self, fernet_keys, monkeypatch):
+        primary, _ = fernet_keys
+        monkeypatch.setenv("MCP_TOKEN_ENCRYPTION_KEY", primary)
+        assert encrypt_secret(None) is None
+        assert decrypt_secret(None) is None
+
+    def test_decrypt_with_previous_key(self, fernet_keys, monkeypatch):
+        primary, previous = fernet_keys
+        monkeypatch.setenv("MCP_TOKEN_ENCRYPTION_KEY", previous)
+        ciphertext = encrypt_secret("rotated-secret")
+
+        monkeypatch.setenv("MCP_TOKEN_ENCRYPTION_KEY", primary)
+        monkeypatch.setenv("MCP_TOKEN_ENCRYPTION_KEY_PREVIOUS", previous)
+        reset_mcp_crypto_cache()
+
+        assert decrypt_secret(ciphertext) == "rotated-secret"
+
+    def test_encrypt_uses_primary_only(self, fernet_keys, monkeypatch):
+        primary, previous = fernet_keys
+        monkeypatch.setenv("MCP_TOKEN_ENCRYPTION_KEY", primary)
+        monkeypatch.setenv("MCP_TOKEN_ENCRYPTION_KEY_PREVIOUS", previous)
+        ciphertext = encrypt_secret("new-secret")
+
+        with pytest.raises(InvalidToken):
+            Fernet(previous.encode()).decrypt(ciphertext.encode())
+        assert (
+            Fernet(primary.encode()).decrypt(ciphertext.encode()).decode()
+            == "new-secret"
+        )
+
+    def test_missing_primary_key_raises(self, monkeypatch):
+        monkeypatch.delenv("MCP_TOKEN_ENCRYPTION_KEY", raising=False)
+        with pytest.raises(RuntimeError, match="MCP_TOKEN_ENCRYPTION_KEY"):
+            encrypt_secret("x")
+
+    def test_wrong_keys_raise(self, fernet_keys, monkeypatch):
+        primary, previous = fernet_keys
+        other = Fernet.generate_key().decode()
+        monkeypatch.setenv("MCP_TOKEN_ENCRYPTION_KEY", other)
+        ciphertext = encrypt_secret("lost-secret")
+
+        monkeypatch.setenv("MCP_TOKEN_ENCRYPTION_KEY", primary)
+        monkeypatch.setenv("MCP_TOKEN_ENCRYPTION_KEY_PREVIOUS", previous)
+        reset_mcp_crypto_cache()
+
+        with pytest.raises(RuntimeError, match="decryption failed"):
+            decrypt_secret(ciphertext)

--- a/tests/unit/aegra/test_mcp_token_refresh_lock.py
+++ b/tests/unit/aegra/test_mcp_token_refresh_lock.py
@@ -1,0 +1,134 @@
+"""Unit tests for MCP token refresh locking."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from deep_agent.aegra.mcp_auth import McpCredentialResolver
+from deep_agent.aegra.mcp_token_store import McpOAuthToken
+
+
+@asynccontextmanager
+async def _held_lock(*_args, **_kwargs):
+    yield "held"
+
+
+@asynccontextmanager
+async def _timeout_lock(*_args, **_kwargs):
+    yield "timeout"
+
+
+def _expired_token() -> McpOAuthToken:
+    return McpOAuthToken(
+        user_id="user-1",
+        mcp_name="oauth-mcp",
+        access_token="expired-access",
+        refresh_token="refresh-me",
+        expires_at=datetime.now(UTC) - timedelta(minutes=5),
+    )
+
+
+def _fresh_token() -> McpOAuthToken:
+    return McpOAuthToken(
+        user_id="user-1",
+        mcp_name="oauth-mcp",
+        access_token="fresh-access",
+        refresh_token="refresh-me",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+
+
+@pytest.mark.asyncio
+class TestMcpTokenRefreshLock:
+    async def test_skips_refresh_when_peer_refreshed_under_lock(self):
+        store = AsyncMock()
+        store.get_token = AsyncMock(side_effect=[_expired_token(), _fresh_token()])
+        resolver = McpCredentialResolver(token_store=store)
+
+        with (
+            patch("deep_agent.aegra.mcp_auth.distributed_lock", _held_lock),
+            patch.object(
+                resolver,
+                "_refresh_mcp_token",
+                new=AsyncMock(return_value="should-not-run"),
+            ) as refresh,
+        ):
+            token = await resolver.resolve(
+                "user-1",
+                "oauth-mcp",
+                {
+                    "auth_mode": "oauth",
+                    "oauth": {"token_endpoint": "https://as.example.com/token"},
+                },
+            )
+
+        assert token == "fresh-access"
+        refresh.assert_not_called()
+        assert store.get_token.await_count == 2
+
+    async def test_waits_for_peer_refresh_on_lock_timeout(self):
+        store = AsyncMock()
+        store.get_token = AsyncMock(
+            side_effect=[
+                _expired_token(),
+                _expired_token(),
+                _fresh_token(),
+            ]
+        )
+        resolver = McpCredentialResolver(token_store=store)
+
+        with (
+            patch("deep_agent.aegra.mcp_auth.distributed_lock", _timeout_lock),
+            patch(
+                "deep_agent.aegra.mcp_auth.asyncio.sleep",
+                new=AsyncMock(),
+            ),
+            patch.object(
+                resolver,
+                "_refresh_mcp_token",
+                new=AsyncMock(return_value="should-not-run"),
+            ) as refresh,
+        ):
+            token = await resolver.resolve(
+                "user-1",
+                "oauth-mcp",
+                {
+                    "auth_mode": "oauth",
+                    "oauth": {"token_endpoint": "https://as.example.com/token"},
+                },
+            )
+
+        assert token == "fresh-access"
+        refresh.assert_not_called()
+
+    async def test_refreshes_once_when_lock_held(self):
+        store = AsyncMock()
+        store.get_token = AsyncMock(side_effect=[_expired_token(), _expired_token()])
+        resolver = McpCredentialResolver(token_store=store)
+
+        with (
+            patch("deep_agent.aegra.mcp_auth.distributed_lock", _held_lock),
+            patch.object(
+                resolver,
+                "_refresh_mcp_token",
+                new=AsyncMock(return_value="new-access"),
+            ) as refresh,
+        ):
+            token = await resolver.resolve(
+                "user-1",
+                "oauth-mcp",
+                {
+                    "auth_mode": "oauth",
+                    "oauth": {
+                        "token_endpoint": "https://as.example.com/token",
+                        "client_id": "cid",
+                    },
+                },
+            )
+
+        assert token == "new-access"
+        refresh.assert_awaited_once()

--- a/tests/unit/aegra/test_mcp_token_store.py
+++ b/tests/unit/aegra/test_mcp_token_store.py
@@ -1,0 +1,106 @@
+"""Unit tests for MCP OAuth token storage in Redis."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+from cryptography.fernet import Fernet
+
+from deep_agent.aegra.mcp_crypto import reset_mcp_crypto_cache
+from deep_agent.aegra.mcp_token_store import McpTokenStore
+
+
+@pytest.fixture(autouse=True)
+def _clear_crypto_cache():
+    reset_mcp_crypto_cache()
+    yield
+    reset_mcp_crypto_cache()
+
+
+@pytest.fixture
+def fernet_key(monkeypatch):
+    key = Fernet.generate_key().decode()
+    monkeypatch.setenv("MCP_TOKEN_ENCRYPTION_KEY", key)
+    return key
+
+
+@pytest.fixture
+def store():
+    return McpTokenStore("postgresql://unused")
+
+
+@pytest.mark.asyncio
+class TestMcpTokenStoreRedis:
+    async def test_upsert_and_get_token_round_trip(self, store, fernet_key):
+        expires_at = datetime.now(UTC) + timedelta(hours=1)
+        stored_payload: dict[str, str] = {}
+
+        def fake_set_persistent(key: str, value: str) -> bool:
+            stored_payload["key"] = key
+            stored_payload["value"] = value
+            return True
+
+        def fake_get(key: str) -> str | None:
+            if key == stored_payload.get("key"):
+                return stored_payload.get("value")
+            return None
+
+        with (
+            patch(
+                "deep_agent.aegra.mcp_token_store.cache_set_persistent",
+                fake_set_persistent,
+            ),
+            patch("deep_agent.aegra.mcp_token_store.cache_get", fake_get),
+        ):
+            saved = await store.upsert_token(
+                user_id="user-1",
+                mcp_name="oauth-mcp",
+                access_token="access-secret",
+                refresh_token="refresh-secret",
+                expires_at=expires_at,
+                scopes=["read", "write"],
+            )
+            loaded = await store.get_token("user-1", "oauth-mcp")
+
+        assert saved.access_token == "access-secret"
+        assert saved.refresh_token == "refresh-secret"
+        assert saved.scopes == ["read", "write"]
+        assert loaded is not None
+        assert loaded.access_token == "access-secret"
+        assert loaded.refresh_token == "refresh-secret"
+        assert loaded.expires_at == expires_at
+        assert loaded.scopes == ["read", "write"]
+
+        payload = json.loads(stored_payload["value"])
+        assert payload["access_token"] != "access-secret"
+        assert payload["refresh_token"] != "refresh-secret"
+
+    async def test_get_token_returns_none_on_miss(self, store):
+        with patch("deep_agent.aegra.mcp_token_store.cache_get", return_value=None):
+            assert await store.get_token("user-1", "oauth-mcp") is None
+
+    async def test_upsert_token_raises_when_redis_unavailable(self, store, fernet_key):
+        with patch(
+            "deep_agent.aegra.mcp_token_store.cache_set_persistent", return_value=False
+        ):
+            with pytest.raises(RuntimeError, match="Failed to persist MCP OAuth token"):
+                await store.upsert_token(
+                    user_id="user-1",
+                    mcp_name="oauth-mcp",
+                    access_token="access-secret",
+                )
+
+    async def test_delete_token(self, store):
+        deleted_keys: list[str] = []
+
+        def fake_delete(key: str) -> bool:
+            deleted_keys.append(key)
+            return True
+
+        with patch("deep_agent.aegra.mcp_token_store.cache_delete", fake_delete):
+            assert await store.delete_token("user-1", "oauth-mcp") is True
+
+        assert deleted_keys == ["mcp_oauth_token:user-1:oauth-mcp"]

--- a/tests/unit/aegra/test_oauth_client_secret.py
+++ b/tests/unit/aegra/test_oauth_client_secret.py
@@ -1,0 +1,84 @@
+"""Unit tests for OAuth client secret resolution from environment variables."""
+
+from __future__ import annotations
+
+import pytest
+
+from deep_agent.aegra.mcp_auth import resolve_oauth_client_secret
+from deep_agent.src.agent.config.loader import AgentConfig
+
+
+class TestResolveOauthClientSecret:
+    def test_reads_from_env_var(self, monkeypatch):
+        monkeypatch.setenv("TEST_MCP_CLIENT_SECRET", "from-env")
+        secret = resolve_oauth_client_secret(
+            {"client_secret_env": "TEST_MCP_CLIENT_SECRET"},
+            "oauth-mcp",
+        )
+        assert secret == "from-env"
+
+    def test_env_var_takes_precedence_over_inline(self, monkeypatch):
+        monkeypatch.setenv("TEST_MCP_CLIENT_SECRET", "from-env")
+        secret = resolve_oauth_client_secret(
+            {
+                "client_secret_env": "TEST_MCP_CLIENT_SECRET",
+                "client_secret": "inline-value",
+            },
+            "oauth-mcp",
+        )
+        assert secret == "from-env"
+
+    def test_warns_on_inline_value(self, monkeypatch, caplog):
+        monkeypatch.delenv("TEST_MCP_CLIENT_SECRET", raising=False)
+        with caplog.at_level("WARNING"):
+            secret = resolve_oauth_client_secret(
+                {"client_secret": "inline-value"},
+                "oauth-mcp",
+            )
+        assert secret == "inline-value"
+        assert any(
+            "client_secret in mcp.json is insecure" in r.message for r in caplog.records
+        )
+
+
+class TestMcpConfigInlineSecretWarning:
+    def setup_method(self):
+        AgentConfig._instance = None
+
+    @staticmethod
+    def _write_minimal_config_dir(tmp_path):
+        (tmp_path / "PROMPT.md").write_text(
+            """---
+name: test-orchestrator
+model: gemini-2.5-flash
+---
+Test prompt.
+"""
+        )
+
+    def test_warns_on_inline_secret_in_mcp_json(self, tmp_path, caplog):
+        self._write_minimal_config_dir(tmp_path)
+        (tmp_path / "mcp.json").write_text(
+            """
+            {
+              "mcpServers": {
+                "oauth-mcp": {
+                  "url": "http://localhost/mcp",
+                  "enabled": true,
+                  "auth_mode": "oauth",
+                  "oauth": {
+                    "client_id": "cid",
+                    "client_secret": "inline-value",
+                    "authorization_endpoint": "https://as.example.com/authorize",
+                    "token_endpoint": "https://as.example.com/token"
+                  }
+                }
+              }
+            }
+            """
+        )
+        with caplog.at_level("WARNING"):
+            AgentConfig(tmp_path).get_mcp_servers()
+        assert any(
+            "client_secret in mcp.json is insecure" in r.message for r in caplog.records
+        )

--- a/tests/unit/aegra/test_oauth_scopes.py
+++ b/tests/unit/aegra/test_oauth_scopes.py
@@ -1,0 +1,56 @@
+"""Unit tests for OAuth scope validation."""
+
+from __future__ import annotations
+
+from deep_agent.aegra.mcp_oauth_scopes import (
+    parse_token_scopes,
+    requested_scopes,
+    validate_granted_scopes,
+)
+
+
+class TestRequestedScopes:
+    def test_parses_list(self):
+        assert requested_scopes({"scopes": ["read", "write"]}) == ["read", "write"]
+
+    def test_parses_string(self):
+        assert requested_scopes({"scopes": "read write"}) == ["read", "write"]
+
+    def test_empty_when_not_configured(self):
+        assert requested_scopes({}) == []
+
+
+class TestParseTokenScopes:
+    def test_parses_space_delimited_string(self):
+        assert parse_token_scopes({"scope": "read write"}) == ["read", "write"]
+
+    def test_parses_list(self):
+        assert parse_token_scopes({"scope": ["read", "write"]}) == ["read", "write"]
+
+    def test_returns_none_when_missing(self):
+        assert parse_token_scopes({}) is None
+
+
+class TestValidateGrantedScopes:
+    def test_accepts_when_all_requested_granted(self):
+        assert validate_granted_scopes(
+            ["read", "write", "openid"],
+            ["read", "write"],
+            "oauth-mcp",
+        ) == ["read", "write", "openid"]
+
+    def test_skips_validation_when_none_requested(self):
+        assert validate_granted_scopes(["read"], [], "oauth-mcp") == ["read"]
+
+    def test_rejects_missing_scopes(self, caplog):
+        with caplog.at_level("ERROR"):
+            assert (
+                validate_granted_scopes(["read"], ["read", "write"], "oauth-mcp")
+                is None
+            )
+        assert any("missing requested scopes" in r.message for r in caplog.records)
+
+    def test_rejects_empty_granted_when_scopes_requested(self, caplog):
+        with caplog.at_level("ERROR"):
+            assert validate_granted_scopes(None, ["read"], "oauth-mcp") is None
+        assert any("returned no scopes" in r.message for r in caplog.records)

--- a/tests/unit/aegra/test_redis_lock.py
+++ b/tests/unit/aegra/test_redis_lock.py
@@ -1,0 +1,56 @@
+"""Unit tests for Redis distributed locks."""
+
+from unittest.mock import MagicMock, patch
+
+import deep_agent.aegra.redis as redis_mod
+from deep_agent.aegra.redis import (
+    acquire_distributed_lock,
+    distributed_lock,
+    release_distributed_lock,
+)
+
+
+class TestDistributedLock:
+    def test_acquire_and_release(self):
+        mock_client = MagicMock()
+        mock_client.set.return_value = True
+        mock_client.eval.return_value = 1
+        redis_mod._client = mock_client
+
+        token = acquire_distributed_lock(
+            "refresh:user:mcp", ttl_seconds=30, wait_seconds=1
+        )
+        assert token is not None
+        assert release_distributed_lock("refresh:user:mcp", token) is True
+        mock_client.set.assert_called_once()
+        mock_client.eval.assert_called_once()
+
+    def test_acquire_returns_none_when_redis_unavailable(self):
+        with patch("deep_agent.aegra.redis.get_redis_client", return_value=None):
+            assert acquire_distributed_lock("refresh:user:mcp") is None
+
+
+class TestDistributedLockAsync:
+    async def test_yields_no_redis_when_client_missing(self):
+        with patch("deep_agent.aegra.redis.get_redis_client", return_value=None):
+            async with distributed_lock("refresh:user:mcp") as state:
+                assert state == "no_redis"
+
+    async def test_yields_held_when_lock_acquired(self):
+        with (
+            patch(
+                "deep_agent.aegra.redis.acquire_distributed_lock",
+                return_value="lock-token",
+            ),
+            patch(
+                "deep_agent.aegra.redis.release_distributed_lock",
+                return_value=True,
+            ) as release,
+            patch(
+                "deep_agent.aegra.redis.get_redis_client",
+                return_value=MagicMock(),
+            ),
+        ):
+            async with distributed_lock("refresh:user:mcp") as state:
+                assert state == "held"
+            release.assert_called_once_with("refresh:user:mcp", "lock-token")

--- a/tests/unit/aegra/test_shutdown.py
+++ b/tests/unit/aegra/test_shutdown.py
@@ -129,9 +129,7 @@ class TestRunShutdown:
                 return_value="ok",
             ) as mock_sched,
             patch.object(shutdown_mod, "_clear_graph_cache", return_value="ok"),
-            patch.object(
-                shutdown_mod, "_close_redis", return_value="ok"
-            ) as mock_redis,
+            patch.object(shutdown_mod, "_close_redis", return_value="ok") as mock_redis,
         ):
             result = await run_shutdown()
 
@@ -177,9 +175,7 @@ class TestShutdownLangfuse:
         mock_client.flush.assert_called_once()
 
     async def test_skips_when_not_configured(self):
-        with patch(
-            "deep_agent.aegra.telemetry.get_langfuse_client", return_value=None
-        ):
+        with patch("deep_agent.aegra.telemetry.get_langfuse_client", return_value=None):
             result = await _shutdown_langfuse()
         assert "skipped" in result
 

--- a/tests/unit/agent/test_provider_factory.py
+++ b/tests/unit/agent/test_provider_factory.py
@@ -73,9 +73,7 @@ class TestParseModelConfig:
         assert spec3.provider == Provider.MAAS  # Inferred
 
     def test_parses_object_form(self):
-        spec = parse_model_config(
-            {"provider": "vertex", "name": "gemini-2.5-pro"}
-        )
+        spec = parse_model_config({"provider": "vertex", "name": "gemini-2.5-pro"})
         assert spec.provider == Provider.VERTEX
         assert spec.name == "gemini-2.5-pro"
 
@@ -256,7 +254,10 @@ class TestCreateByProvider:
             return_value=mock_model,
         ) as mock_vertex:
             result = _create_by_provider(
-                Provider.VERTEX, "gemini-2.5-pro", temperature=0.0, max_output_tokens=8192
+                Provider.VERTEX,
+                "gemini-2.5-pro",
+                temperature=0.0,
+                max_output_tokens=8192,
             )
         assert result is mock_model
         mock_vertex.assert_called_once_with("gemini-2.5-pro", 0.0, 8192)

--- a/tests/unit/infrastructure/test_mcp.py
+++ b/tests/unit/infrastructure/test_mcp.py
@@ -9,6 +9,7 @@ from deep_agent.aegra.mcp import (
     _connect_single_server,
     _get_server_configs,
     get_mcp_tools,
+    mcp_httpx_verify,
 )
 
 
@@ -50,6 +51,19 @@ class TestGetServerConfigs:
             assert result == {}
 
 
+class TestMcpHttpxVerify:
+    """Tests for mcp_httpx_verify helper."""
+
+    def test_defaults_to_true(self):
+        assert mcp_httpx_verify({}) is True
+
+    def test_respects_ssl_verify_false(self):
+        assert mcp_httpx_verify({"ssl_verify": False}) is False
+
+    def test_respects_ssl_verify_true(self):
+        assert mcp_httpx_verify({"ssl_verify": True}) is True
+
+
 class TestBuildServerConfig:
     """Tests for _build_server_config function."""
 
@@ -61,7 +75,7 @@ class TestBuildServerConfig:
             "auth": True,
             "ssl_verify": True,
         }
-        config = _build_server_config(entry, sso_token=None)
+        config = _build_server_config(entry, None)
 
         assert config["url"] == "http://localhost:8000/mcp/"
         assert config["transport"] == "http"
@@ -76,7 +90,7 @@ class TestBuildServerConfig:
             "auth": True,
             "ssl_verify": True,
         }
-        config = _build_server_config(entry, sso_token="test_token_123")
+        config = _build_server_config(entry, "test_token_123")
 
         assert config["url"] == "https://api.example.com/mcp/"
         assert config["transport"] == "https"
@@ -91,7 +105,7 @@ class TestBuildServerConfig:
             "auth": True,
             "ssl_verify": False,
         }
-        config = _build_server_config(entry, sso_token=None)
+        config = _build_server_config(entry, None)
 
         assert "httpx_client_factory" in config
         assert callable(config["httpx_client_factory"])
@@ -107,14 +121,14 @@ class TestBuildServerConfig:
             "auth": False,
             "ssl_verify": True,
         }
-        config = _build_server_config(entry, sso_token="should_be_ignored")
+        config = _build_server_config(entry, "should_be_ignored")
 
         assert config["headers"] == {}
 
     def test_config_defaults(self):
         """Test that missing optional fields use sensible defaults."""
         entry = {"url": "http://localhost:8000/mcp/"}
-        config = _build_server_config(entry, sso_token="tok")
+        config = _build_server_config(entry, "tok")
 
         assert config["transport"] == "streamable_http"
         assert config["headers"] == {"Authorization": "Bearer tok"}
@@ -139,7 +153,7 @@ class TestConnectSingleServer:
             "deep_agent.aegra.mcp.MultiServerMCPClient",
             return_value=mock_client,
         ):
-            tools = await _connect_single_server("test_server", config, timeout=5)
+            tools = await _connect_single_server("test_server", config, {}, timeout=5)
 
             assert len(tools) == 1
             assert tools[0].name == "test_tool"
@@ -158,7 +172,7 @@ class TestConnectSingleServer:
             "deep_agent.aegra.mcp.MultiServerMCPClient",
             return_value=mock_client,
         ):
-            tools = await _connect_single_server("slow_server", config, timeout=1)
+            tools = await _connect_single_server("slow_server", config, {}, timeout=1)
 
             assert tools == []
 
@@ -176,7 +190,7 @@ class TestConnectSingleServer:
             "deep_agent.aegra.mcp.MultiServerMCPClient",
             return_value=mock_client,
         ):
-            tools = await _connect_single_server("broken_server", config, timeout=5)
+            tools = await _connect_single_server("broken_server", config, {}, timeout=5)
 
             assert tools == []
 
@@ -192,7 +206,7 @@ class TestConnectSingleServer:
             "deep_agent.aegra.mcp.MultiServerMCPClient",
             return_value=mock_client,
         ):
-            tools = await _connect_single_server("faulty_server", config, timeout=5)
+            tools = await _connect_single_server("faulty_server", config, {}, timeout=5)
 
             assert tools == []
 
@@ -227,12 +241,8 @@ class TestGetMCPTools:
         mock_tool.name = "tool1"
 
         with (
-            patch(
-                "deep_agent.aegra.mcp._get_server_configs"
-            ) as mock_get_configs,
-            patch(
-                "deep_agent.aegra.mcp._connect_single_server"
-            ) as mock_connect,
+            patch("deep_agent.aegra.mcp._get_server_configs") as mock_get_configs,
+            patch("deep_agent.aegra.mcp._connect_single_server") as mock_connect,
         ):
             mock_get_configs.return_value = mock_servers
             mock_connect.return_value = [mock_tool]
@@ -273,12 +283,8 @@ class TestGetMCPTools:
         tool_b2.name = "unique_b"
 
         with (
-            patch(
-                "deep_agent.aegra.mcp._get_server_configs"
-            ) as mock_get_configs,
-            patch(
-                "deep_agent.aegra.mcp._connect_single_server"
-            ) as mock_connect,
+            patch("deep_agent.aegra.mcp._get_server_configs") as mock_get_configs,
+            patch("deep_agent.aegra.mcp._connect_single_server") as mock_connect,
         ):
             mock_get_configs.return_value = mock_servers
             mock_connect.side_effect = [[tool_a1, tool_a2], [tool_b1, tool_b2]]
@@ -303,9 +309,7 @@ class TestGetMCPTools:
             }
         }
 
-        with patch(
-            "deep_agent.aegra.mcp._get_server_configs"
-        ) as mock_get_configs:
+        with patch("deep_agent.aegra.mcp._get_server_configs") as mock_get_configs:
             mock_get_configs.return_value = mock_servers
 
             tools = await get_mcp_tools()
@@ -316,9 +320,7 @@ class TestGetMCPTools:
     async def test_no_servers_configured_returns_empty_list(self):
         """Test that no MCP servers configured returns empty list."""
         _reset_mcp_cache()
-        with patch(
-            "deep_agent.aegra.mcp._get_server_configs"
-        ) as mock_get_configs:
+        with patch("deep_agent.aegra.mcp._get_server_configs") as mock_get_configs:
             mock_get_configs.return_value = {}
 
             tools = await get_mcp_tools()
@@ -343,12 +345,8 @@ class TestGetMCPTools:
         }
 
         with (
-            patch(
-                "deep_agent.aegra.mcp._get_server_configs"
-            ) as mock_get_configs,
-            patch(
-                "deep_agent.aegra.mcp._connect_single_server"
-            ) as mock_connect,
+            patch("deep_agent.aegra.mcp._get_server_configs") as mock_get_configs,
+            patch("deep_agent.aegra.mcp._connect_single_server") as mock_connect,
         ):
             mock_get_configs.return_value = mock_servers
             mock_connect.return_value = []
@@ -374,21 +372,15 @@ class TestGetMCPTools:
         mock_tool.name = "tool1"
 
         with (
-            patch(
-                "deep_agent.aegra.mcp._get_server_configs"
-            ) as mock_get_configs,
-            patch(
-                "deep_agent.aegra.mcp._build_server_config"
-            ) as mock_build_config,
-            patch(
-                "deep_agent.aegra.mcp._connect_single_server"
-            ) as mock_connect,
+            patch("deep_agent.aegra.mcp._get_server_configs") as mock_get_configs,
+            patch("deep_agent.aegra.mcp._build_server_config") as mock_build_config,
+            patch("deep_agent.aegra.mcp._connect_single_server") as mock_connect,
         ):
             mock_get_configs.return_value = mock_servers
             mock_build_config.return_value = {"url": "http://localhost/mcp/"}
             mock_connect.return_value = [mock_tool]
 
-            await get_mcp_tools(sso_token="test_token_123")
+            await get_mcp_tools("test_token_123")
 
             # Verify _build_server_config was called with the token
             mock_build_config.assert_called_once()
@@ -413,12 +405,8 @@ class TestGetMCPTools:
         tool3.name = "tool3"
 
         with (
-            patch(
-                "deep_agent.aegra.mcp._get_server_configs"
-            ) as mock_get_configs,
-            patch(
-                "deep_agent.aegra.mcp._connect_single_server"
-            ) as mock_connect,
+            patch("deep_agent.aegra.mcp._get_server_configs") as mock_get_configs,
+            patch("deep_agent.aegra.mcp._connect_single_server") as mock_connect,
         ):
             mock_get_configs.return_value = mock_servers
             mock_connect.side_effect = [[tool1], [tool2], [tool3]]
@@ -442,12 +430,8 @@ class TestGetMCPTools:
         tool_w.name = "wanted_tool"
 
         with (
-            patch(
-                "deep_agent.aegra.mcp._get_server_configs"
-            ) as mock_get_configs,
-            patch(
-                "deep_agent.aegra.mcp._connect_single_server"
-            ) as mock_connect,
+            patch("deep_agent.aegra.mcp._get_server_configs") as mock_get_configs,
+            patch("deep_agent.aegra.mcp._connect_single_server") as mock_connect,
         ):
             mock_get_configs.return_value = mock_servers
             mock_connect.return_value = [tool_w]

--- a/tests/unit/infrastructure/test_subagents.py
+++ b/tests/unit/infrastructure/test_subagents.py
@@ -39,7 +39,10 @@ class TestLoadSubagents:
                 "deep_agent.src.infrastructure.subagents.get_or_create_model_from_spec",
                 return_value=mock_model,
             ),
-            patch("deep_agent.src.infrastructure.subagents.SubAgent", return_value=MagicMock()),
+            patch(
+                "deep_agent.src.infrastructure.subagents.SubAgent",
+                return_value=MagicMock(),
+            ),
         ):
             mock_get_configs.return_value = {
                 "analyst": {
@@ -409,9 +412,7 @@ class TestAgentTypeSystem:
             patch(
                 "deep_agent.src.infrastructure.subagents.get_or_create_model_from_spec"
             ) as mock_create_model,
-            patch(
-                "deepagents.create_deep_agent"
-            ) as mock_create_agent,
+            patch("deepagents.create_deep_agent") as mock_create_agent,
             patch(
                 "deep_agent.src.infrastructure.backend.get_configured_backend"
             ) as mock_get_backend,
@@ -494,7 +495,9 @@ class TestAgentTypeSystem:
                     # No graph_id
                 }
             }
-            with pytest.raises(SubAgentError, match="requires deepagents with async support"):
+            with pytest.raises(
+                SubAgentError, match="requires deepagents with async support"
+            ):
                 load_subagents(tools=[])
 
 
@@ -516,7 +519,10 @@ class TestSubagentProviderConfig:
                 "deep_agent.src.infrastructure.subagents.get_or_create_model_from_spec",
                 return_value=mock_model,
             ) as mock_from_spec,
-            patch("deep_agent.src.infrastructure.subagents.SubAgent", return_value=MagicMock()),
+            patch(
+                "deep_agent.src.infrastructure.subagents.SubAgent",
+                return_value=MagicMock(),
+            ),
         ):
             mock_get_configs.return_value = {
                 "analyst": {
@@ -547,8 +553,13 @@ class TestSubagentProviderConfig:
                 "deep_agent.src.infrastructure.subagents.get_or_create_model_from_spec",
                 return_value=mock_model,
             ) as mock_from_spec,
-            patch("langchain.agents.middleware.ModelFallbackMiddleware") as mock_middleware,
-            patch("deep_agent.src.infrastructure.subagents.SubAgent", return_value=MagicMock()) as mock_sa,
+            patch(
+                "langchain.agents.middleware.ModelFallbackMiddleware"
+            ) as mock_middleware,
+            patch(
+                "deep_agent.src.infrastructure.subagents.SubAgent",
+                return_value=MagicMock(),
+            ) as mock_sa,
         ):
             mock_get_configs.return_value = {
                 "analyst": {
@@ -583,8 +594,13 @@ class TestSubagentProviderConfig:
                 "deep_agent.src.infrastructure.subagents.get_or_create_model_from_spec",
                 return_value=mock_model,
             ) as mock_from_spec,
-            patch("langchain.agents.middleware.ModelFallbackMiddleware") as mock_middleware,
-            patch("deep_agent.src.infrastructure.subagents.SubAgent", return_value=MagicMock()) as mock_sa,
+            patch(
+                "langchain.agents.middleware.ModelFallbackMiddleware"
+            ) as mock_middleware,
+            patch(
+                "deep_agent.src.infrastructure.subagents.SubAgent",
+                return_value=MagicMock(),
+            ) as mock_sa,
         ):
             mock_get_configs.return_value = {
                 "analyst": {
@@ -619,8 +635,13 @@ class TestSubagentProviderConfig:
                 "deep_agent.src.infrastructure.subagents.get_or_create_model_from_spec",
                 return_value=mock_model,
             ) as mock_from_spec,
-            patch("langchain.agents.middleware.ModelFallbackMiddleware") as mock_middleware,
-            patch("deep_agent.src.infrastructure.subagents.SubAgent", return_value=MagicMock()) as mock_sa,
+            patch(
+                "langchain.agents.middleware.ModelFallbackMiddleware"
+            ) as mock_middleware,
+            patch(
+                "deep_agent.src.infrastructure.subagents.SubAgent",
+                return_value=MagicMock(),
+            ) as mock_sa,
         ):
             mock_get_configs.return_value = {
                 "analyst": {
@@ -659,7 +680,10 @@ class TestSubagentProviderConfig:
                 "deep_agent.src.infrastructure.subagents.get_or_create_model_from_spec",
                 return_value=mock_model,
             ) as mock_from_spec,
-            patch("deep_agent.src.infrastructure.subagents.SubAgent", return_value=MagicMock()),
+            patch(
+                "deep_agent.src.infrastructure.subagents.SubAgent",
+                return_value=MagicMock(),
+            ),
         ):
             mock_get_configs.return_value = {
                 "analyst": {
@@ -699,8 +723,13 @@ class TestSubagentProviderConfig:
                 "deep_agent.src.infrastructure.subagents.get_or_create_model_from_spec",
                 return_value=mock_model,
             ) as mock_from_spec,
-            patch("langchain.agents.middleware.ModelFallbackMiddleware") as mock_middleware,
-            patch("deep_agent.src.infrastructure.subagents.SubAgent", return_value=MagicMock()) as mock_sa,
+            patch(
+                "langchain.agents.middleware.ModelFallbackMiddleware"
+            ) as mock_middleware,
+            patch(
+                "deep_agent.src.infrastructure.subagents.SubAgent",
+                return_value=MagicMock(),
+            ) as mock_sa,
         ):
             mock_get_configs.return_value = {
                 "analyst": {

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -98,3 +98,27 @@ class TestValidateConfig:
     def test_port_boundary_high(self):
         s = Settings(AGENT_PORT=65535)
         validate_config(s)
+
+
+class TestValidateConfigPublicBaseUrl:
+    def test_allows_localhost_http_base_url(self):
+        validate_config(
+            Settings(AGENT_PUBLIC_BASE_URL="http://localhost:5002", AGENT_PORT=5002)
+        )
+
+    def test_requires_https_for_production_base_url(self):
+        with pytest.raises(
+            AppException, match="AGENT_PUBLIC_BASE_URL must use https://"
+        ):
+            validate_config(Settings(AGENT_PUBLIC_BASE_URL="http://agent.example.com"))
+
+    def test_allows_https_production_base_url(self):
+        validate_config(Settings(AGENT_PUBLIC_BASE_URL="https://agent.example.com"))
+
+    def test_oauth_callback_url_derived_from_public_base_url(self):
+        s = Settings(AGENT_PUBLIC_BASE_URL="https://agent.example.com")
+        assert s.oauth_callback_url == "https://agent.example.com/mcp/oauth/callback"
+
+    def test_oauth_callback_url_defaults_to_localhost(self):
+        s = Settings(AGENT_PORT=5002)
+        assert s.oauth_callback_url == "http://localhost:5002/mcp/oauth/callback"


### PR DESCRIPTION
Introduces MCP OAuth connect/callback/status endpoints, encrypted Postgres token persistence, LangGraph auth interrupts, and http_app consolidation.

## Summary

Adds per-MCP authentication so each MCP server in `mcp.json` can use its own auth strategy: SSO (existing behavior), OAuth (pre-registered client), or DCR (dynamic client registration). OAuth/DCR tokens are stored per user in Postgres (encrypted) and injected at MCP tool-call time.

## What changed

### MCP config (`config/agent/mcp.json`)

- Extended schema with `auth_mode` (`sso` | `oauth` | `dcr`) and optional `oauth` block.
- Default/exmple dev config includes:
  - `template-mcp-server` — SSO, enabled
  - `template-mcp-server-dcr` — DCR example, disabled

### New HTTP surface (`deep_agent/aegra/http_app.py`)

Consolidates feedback + MCP OAuth routes behind the Aegra custom app entry (`aegra.json`):

- `POST /mcp/{name}/connect` — start OAuth/DCR flow
- `GET /mcp/oauth/callback` — handle redirect and token exchange
- `GET /mcp/{name}/status` — check whether the current user has a valid token
- `GET /info` — agent metadata + list of enabled OAuth/DCR MCPs (drives UI precheck)

### Auth & token lifecycle

- `mcp_auth.py` / `mcp_tool_auth.py` — resolve credentials per MCP at runtime; raise LangGraph `mcp_auth_required` interrupt when a token is missing
- `mcp_oauth_handlers.py` — connect/callback/status orchestration
- `mcp_token_store.py` — Postgres tables (`mcp_oauth_clients`, `mcp_oauth_tokens`), created at startup
- `mcp_crypto.py` — Fernet encryption for stored tokens

### Config & docs

- `loader.py` / `model.py` — validate `auth_mode` and required `oauth` fields per mode
- `settings.py` — `MCP_TOKEN_ENCRYPTION_KEY`, `AGENT_PUBLIC_BASE_URL`
- `README.md` — MCP auth modes, schema, endpoints, and env var setup
- `.env.example` — documents new OAuth-related vars

### Tests

- New unit tests in `tests/unit/aegra/test_mcp_auth.py`
- Updated MCP/subagent/shutdown tests for the new auth paths

### New env vars (OAuth/DCR MCPs)

- `MCP_TOKEN_ENCRYPTION_KEY` — Fernet key for encrypting OAuth/DCR tokens at rest in Postgres
- `AGENT_PUBLIC_BASE_URL` — Public agent URL used to build the OAuth redirect URI (`{AGENT_PUBLIC_BASE_URL}/mcp/oauth/callback`); defaults to `http://localhost:{AGENT_PORT}` in dev