### PR TITLE
feat: human in the loop

### DIFF
--- a/config/agent/runtime/agent.yaml
+++ b/config/agent/runtime/agent.yaml
@@ -105,6 +105,10 @@ harness_profiles:
 # Controls which deepagents middleware is active and how it behaves.
 # Resolution order: defaults → profile (matched from model: field) → per-agent overrides
 middleware:
+  human_approval:
+    enabled: true    # set to false to disable human-in-the-loop tool approval
+    mode: all        # 'all' = every tool; 'none' = disabled
+    exclude: []      # tool names to never interrupt (e.g. ls, read_file, glob, grep)
   summarization_tool:
     enabled: true
   memory:

--- a/deep_agent/aegra/graph.py
+++ b/deep_agent/aegra/graph.py
@@ -61,9 +61,17 @@ def _graph_fingerprint(
     model_name: str,
     system_prompt: str,
     tool_names: list[str],
+    hitl_enabled: bool = False,
+    hitl_mode: str = "all",
+    hitl_exclude: list[str] | None = None,
 ) -> str:
     """Stable fingerprint for graph cache keying."""
-    raw = f"{model_name}\0{system_prompt}\0{','.join(sorted(tool_names))}"
+    hitl_flag = (
+        f"hitl={int(hitl_enabled)}"
+        f",mode={hitl_mode}"
+        f",exclude={','.join(sorted(hitl_exclude or []))}"
+    )
+    raw = f"{model_name}\0{system_prompt}\0{','.join(sorted(tool_names))}\0{hitl_flag}"
     return hashlib.sha256(raw.encode()).hexdigest()[:16]
 
 
@@ -210,10 +218,23 @@ async def agent(runtime: ServerRuntime) -> Any:
         )
         tools = mcp_tools
 
+    from deep_agent.src.infrastructure.middleware import (
+        build_middleware_list,
+        resolve_memory_param,
+    )
+
+    middleware_overrides = orchestrator_cfg.get("middleware")
+    resolved_mw = agent_config.resolve_agent_middleware(
+        model_name, middleware_overrides
+    )
+
     cache_key = _graph_fingerprint(
         model_name,
         system_prompt,
         [t.name for t in tools],
+        hitl_enabled=resolved_mw.human_approval.enabled,
+        hitl_mode=resolved_mw.human_approval.mode,
+        hitl_exclude=resolved_mw.human_approval.exclude,
     )
     now = time.time()
     graph_ttl = float(agent_config.get_cache_config().graph.ttl)
@@ -228,15 +249,6 @@ async def agent(runtime: ServerRuntime) -> Any:
     subagents = load_subagents(tools=mcp_tools)
     backend = get_configured_backend()
 
-    from deep_agent.src.infrastructure.middleware import (
-        build_middleware_list,
-        resolve_memory_param,
-    )
-
-    middleware_overrides = orchestrator_cfg.get("middleware")
-    resolved_mw = agent_config.resolve_agent_middleware(
-        model_name, middleware_overrides
-    )
     middleware = build_middleware_list(resolved_mw, model=model, backend=backend)
     memory = resolve_memory_param(resolved_mw)
     skills_param = skill_paths if resolved_mw.skills_enabled else None
@@ -269,6 +281,23 @@ async def agent(runtime: ServerRuntime) -> Any:
                 create_kwargs["permissions"] = permissions
         except (ImportError, TypeError):
             pass
+
+    if "interrupt_on" in create_sig.parameters:
+        from deep_agent.src.agent.config.hitl import build_interrupt_on
+
+        interrupt_on = build_interrupt_on(resolved_mw.human_approval, tools)
+        if interrupt_on:
+            create_kwargs["interrupt_on"] = interrupt_on
+        elif resolved_mw.human_approval.enabled:
+            logger.warning(
+                "HITL is enabled but interrupt_on is empty — "
+                "no tool calls will be interrupted (all tools may be excluded)"
+            )
+    elif resolved_mw.human_approval.enabled:
+        logger.warning(
+            "HITL is enabled but create_deep_agent does not support interrupt_on — "
+            "upgrade deepagents to activate human-in-the-loop approval"
+        )
 
     compiled = create_deep_agent(**create_kwargs)
 

--- a/deep_agent/src/agent/config/hitl.py
+++ b/deep_agent/src/agent/config/hitl.py
@@ -1,0 +1,108 @@
+"""Human-in-the-loop interrupt configuration builder.
+
+Converts the ``human_approval`` section of ``agent.yaml`` into the
+``interrupt_on`` dict expected by ``create_deep_agent()``.
+
+The dict maps each tool name to ``True`` (use deepagents default
+decisions: approve / edit / reject / respond).  When the feature is
+disabled the function returns an empty dict, which signals to
+``graph.py`` not to pass ``interrupt_on`` at all.
+
+For ``mode: all``, both the caller-supplied tools (MCP / explicit) and
+the deepagents built-in tools are included so that every tool call —
+regardless of origin — pauses for human approval.
+
+Example YAML config::
+
+    middleware:
+      human_approval:
+        enabled: true
+        mode: all
+        exclude:
+          - ls
+          - read_file
+          - glob
+          - grep
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from deep_agent.src.agent.config.middleware import HumanApprovalConfig
+from deep_agent.utils.pylogger import get_python_logger
+
+logger = get_python_logger()
+
+# Built-in tool names added by deepagents internally (FilesystemMiddleware,
+# TodoListMiddleware, SubAgentMiddleware).  These are never present in the
+# caller-supplied ``tools`` list, so they must be enumerated explicitly for
+# ``interrupt_on`` to cover them.
+_DEEPAGENTS_BUILTIN_TOOLS: frozenset[str] = frozenset(
+    {
+        # filesystem (FilesystemMiddleware)
+        "ls",
+        "read_file",
+        "write_file",
+        "edit_file",
+        "glob",
+        "grep",
+        "execute",
+        # todo list (TodoListMiddleware)
+        "write_todos",
+        # subagents (SubAgentMiddleware)
+        "task",
+        # conversation management
+        "compact_conversation",
+    }
+)
+
+
+def build_interrupt_on(
+    config: HumanApprovalConfig,
+    tools: list[Any],
+) -> dict[str, Any]:
+    """Build the ``interrupt_on`` dict for ``create_deep_agent()``.
+
+    Args:
+        config: Resolved ``human_approval`` config from ``agent.yaml``.
+        tools: List of resolved tool objects (must have a ``.name`` attr).
+            Typically MCP tools + any explicitly declared tools.  Built-in
+            deepagents tools are added automatically when ``mode`` is ``"all"``.
+
+    Returns:
+        Dict mapping tool name → ``True`` for every tool that should
+        trigger a human approval interrupt.  Returns ``{}`` when the
+        feature is disabled or ``mode`` is ``"none"``.
+    """
+    if not config.enabled or config.mode == "none":
+        logger.debug("HITL disabled (enabled=%s, mode=%s)", config.enabled, config.mode)
+        return {}
+
+    exclude = set(config.exclude)
+
+    # Explicit / MCP tools passed by the caller
+    explicit_names = {t.name for t in tools}
+
+    # For mode=all, also cover the deepagents built-in tools so that
+    # filesystem and todo calls are intercepted even when no MCP tools exist.
+    all_names = explicit_names | _DEEPAGENTS_BUILTIN_TOOLS
+
+    interrupt_on = {name: True for name in all_names if name not in exclude}
+
+    if interrupt_on:
+        excluded = (explicit_names | _DEEPAGENTS_BUILTIN_TOOLS) - set(interrupt_on)
+        logger.info(
+            "HITL enabled: %d tool(s) will require approval%s",
+            len(interrupt_on),
+            f" ({len(excluded)} excluded: {sorted(excluded)})" if excluded else "",
+        )
+    else:
+        logger.debug(
+            "HITL enabled but all tools excluded (explicit=%d, builtins=%d, exclude=%s)",
+            len(explicit_names),
+            len(_DEEPAGENTS_BUILTIN_TOOLS),
+            exclude,
+        )
+
+    return interrupt_on

--- a/deep_agent/src/agent/config/middleware.py
+++ b/deep_agent/src/agent/config/middleware.py
@@ -13,7 +13,7 @@ declarative config into the parameters needed by the middleware builder.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import yaml
 from pydantic import BaseModel, Field
@@ -27,6 +27,19 @@ class SummarizationToolConfig(BaseModel):
     """Config for SummarizationToolMiddleware."""
 
     enabled: bool = True
+
+
+class HumanApprovalConfig(BaseModel):
+    """Config for human-in-the-loop tool approval.
+
+    When enabled, the agent pauses before executing any tool call and
+    waits for the user to approve, reject, or always-allow it.
+    Backed by deepagents HumanInTheLoopMiddleware via interrupt_on.
+    """
+
+    enabled: bool = False
+    mode: Literal["all", "none"] = "all"
+    exclude: list[str] = Field(default_factory=list)
 
 
 class MemoryConfig(BaseModel):
@@ -106,6 +119,7 @@ class MiddlewareDefaults(BaseModel):
     summarization_tool: SummarizationToolConfig = Field(
         default_factory=SummarizationToolConfig
     )
+    human_approval: HumanApprovalConfig = Field(default_factory=HumanApprovalConfig)
     memory: MemoryConfig = Field(default_factory=MemoryConfig)
     patch_tool_calls: PatchToolCallsConfig = Field(default_factory=PatchToolCallsConfig)
     skills: SkillsConfig = Field(default_factory=SkillsConfig)
@@ -138,6 +152,7 @@ class ResolvedMiddlewareConfig(BaseModel):
     """Final resolved config for a single agent after merge."""
 
     summarization_tool_enabled: bool = True
+    human_approval: HumanApprovalConfig = Field(default_factory=HumanApprovalConfig)
     memory_enabled: bool = True
     memory_namespaces: list[str] = Field(default_factory=lambda: ["memories"])
     patch_tool_calls_enabled: bool = True
@@ -224,8 +239,15 @@ def resolve_middleware(
     if "patch_tool_calls" in profile.excluded_middleware:
         patch_enabled = False
 
+    human_approval = defaults.human_approval
+    if isinstance(overrides.get("human_approval"), dict):
+        human_approval = HumanApprovalConfig.model_validate(overrides["human_approval"])
+    elif isinstance(overrides.get("human_approval"), bool):
+        human_approval = HumanApprovalConfig(enabled=overrides["human_approval"])
+
     return ResolvedMiddlewareConfig(
         summarization_tool_enabled=summarization_enabled,
+        human_approval=human_approval,
         memory_enabled=memory_enabled,
         memory_namespaces=memory_namespaces,
         patch_tool_calls_enabled=patch_enabled,

--- a/tests/unit/aegra/test_graph.py
+++ b/tests/unit/aegra/test_graph.py
@@ -1,5 +1,6 @@
 """Unit tests for aegra graph factory."""
 
+import inspect
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -245,4 +246,165 @@ class TestAgentFactory:
         assert mock_create.call_args.kwargs["tools"] == [mock_tool]
         mock_get_mcp.assert_awaited_once_with(
             sso_token=None, server_names=["dataverse-mcp-prod1"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_hitl_passes_interrupt_on_when_enabled(self):
+        """create_deep_agent must receive a non-empty interrupt_on dict when HITL is enabled."""
+        from deep_agent.src.agent.config.middleware import HumanApprovalConfig
+
+        mock_compiled = MagicMock()
+        mock_config = MagicMock()
+        mock_config.get_orchestrator_config.return_value = {
+            "name": "orchestrator",
+            "model": "gemini-2.5-flash",
+            "body": "test prompt",
+            "skill_paths": [],
+            "tools": [],
+        }
+        mock_config.resolve_tools.return_value = []
+
+        hitl_config = HumanApprovalConfig(enabled=True, mode="all", exclude=[])
+        mock_mw = MagicMock(skills_enabled=True)
+        mock_mw.human_approval = hitl_config
+        mock_config.resolve_agent_middleware.return_value = mock_mw
+
+        mock_runtime = MagicMock()
+        mock_runtime.user = None
+
+        # Give the mock a real signature that includes interrupt_on so that the
+        # inspect.signature() check inside agent() sees the parameter.
+        def _stub(*, interrupt_on=None, **kw): ...
+
+        mock_create = MagicMock(return_value=mock_compiled)
+        mock_create.__signature__ = inspect.signature(_stub)
+
+        _reset_graph_state()
+
+        with (
+            patch("deep_agent.src.agent.config.agent_config", mock_config),
+            patch(
+                "deep_agent.src.infrastructure.providers.register_profiles_from_config",
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.src.infrastructure.providers.resolve_model_from_config",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.aegra.mcp.get_mcp_tools",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.load_subagents",
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.src.infrastructure.backend.get_configured_backend",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.async_tasks.build_async_middleware",
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.src.infrastructure.middleware.build_middleware_list",
+                return_value=[],
+            ),
+            patch(
+                "deep_agent.src.infrastructure.middleware.resolve_memory_param",
+                return_value=None,
+            ),
+            patch("deep_agent.aegra.graph._ensure_startup", new_callable=AsyncMock),
+            patch("deepagents.create_deep_agent", new=mock_create),
+        ):
+            from deep_agent.aegra.graph import agent
+
+            result = await agent(mock_runtime)
+
+        assert result is mock_compiled
+        call_kwargs = mock_create.call_args.kwargs
+        assert "interrupt_on" in call_kwargs, "interrupt_on was not passed to create_deep_agent"
+        assert isinstance(call_kwargs["interrupt_on"], dict)
+        assert len(call_kwargs["interrupt_on"]) > 0, "interrupt_on dict must not be empty"
+        assert all(v is True for v in call_kwargs["interrupt_on"].values())
+
+    @pytest.mark.asyncio
+    async def test_hitl_omits_interrupt_on_when_disabled(self):
+        """create_deep_agent must NOT receive interrupt_on when HITL is disabled."""
+        from deep_agent.src.agent.config.middleware import HumanApprovalConfig
+
+        mock_compiled = MagicMock()
+        mock_config = MagicMock()
+        mock_config.get_orchestrator_config.return_value = {
+            "name": "orchestrator",
+            "model": "gemini-2.5-flash",
+            "body": "test prompt",
+            "skill_paths": [],
+            "tools": [],
+        }
+        mock_config.resolve_tools.return_value = []
+
+        hitl_config = HumanApprovalConfig(enabled=False)
+        mock_mw = MagicMock(skills_enabled=True)
+        mock_mw.human_approval = hitl_config
+        mock_config.resolve_agent_middleware.return_value = mock_mw
+
+        mock_runtime = MagicMock()
+        mock_runtime.user = None
+
+        def _stub(*, interrupt_on=None, **kw): ...
+
+        mock_create = MagicMock(return_value=mock_compiled)
+        mock_create.__signature__ = inspect.signature(_stub)
+
+        _reset_graph_state()
+
+        with (
+            patch("deep_agent.src.agent.config.agent_config", mock_config),
+            patch(
+                "deep_agent.src.infrastructure.providers.register_profiles_from_config",
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.src.infrastructure.providers.resolve_model_from_config",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.aegra.mcp.get_mcp_tools",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.load_subagents",
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.src.infrastructure.backend.get_configured_backend",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.async_tasks.build_async_middleware",
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.src.infrastructure.middleware.build_middleware_list",
+                return_value=[],
+            ),
+            patch(
+                "deep_agent.src.infrastructure.middleware.resolve_memory_param",
+                return_value=None,
+            ),
+            patch("deep_agent.aegra.graph._ensure_startup", new_callable=AsyncMock),
+            patch("deepagents.create_deep_agent", new=mock_create),
+        ):
+            from deep_agent.aegra.graph import agent
+
+            result = await agent(mock_runtime)
+
+        assert result is mock_compiled
+        call_kwargs = mock_create.call_args.kwargs
+        assert "interrupt_on" not in call_kwargs, (
+            "interrupt_on must not be passed when HITL is disabled"
         )

--- a/tests/unit/test_hitl.py
+++ b/tests/unit/test_hitl.py
@@ -1,0 +1,84 @@
+"""Unit tests for the HITL interrupt_on builder."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from deep_agent.src.agent.config.hitl import (
+    _DEEPAGENTS_BUILTIN_TOOLS,
+    build_interrupt_on,
+)
+from deep_agent.src.agent.config.middleware import HumanApprovalConfig
+
+
+def _tool(name: str) -> MagicMock:
+    t = MagicMock()
+    t.name = name
+    return t
+
+
+class TestBuildInterruptOn:
+    def test_disabled_returns_empty(self):
+        config = HumanApprovalConfig(enabled=False, mode="all")
+        result = build_interrupt_on(config, [_tool("send_email"), _tool("delete_record")])
+        assert result == {}
+
+    def test_mode_none_returns_empty(self):
+        config = HumanApprovalConfig(enabled=True, mode="none")
+        result = build_interrupt_on(config, [_tool("send_email")])
+        assert result == {}
+
+    def test_mode_all_includes_explicit_tools(self):
+        tools = [_tool("send_email"), _tool("search_web"), _tool("delete_record")]
+        config = HumanApprovalConfig(enabled=True, mode="all")
+        result = build_interrupt_on(config, tools)
+        assert result["send_email"] is True
+        assert result["search_web"] is True
+        assert result["delete_record"] is True
+
+    def test_mode_all_always_includes_builtins(self):
+        """Built-in deepagents tools must be interrupted even with no explicit tools."""
+        config = HumanApprovalConfig(enabled=True, mode="all")
+        result = build_interrupt_on(config, [])
+        for builtin in _DEEPAGENTS_BUILTIN_TOOLS:
+            assert builtin in result, f"built-in tool '{builtin}' missing from interrupt_on"
+
+    def test_empty_tool_list_still_covers_builtins(self):
+        """An agent with no MCP tools still gets HITL for built-in filesystem tools."""
+        config = HumanApprovalConfig(enabled=True, mode="all")
+        result = build_interrupt_on(config, [])
+        assert len(result) == len(_DEEPAGENTS_BUILTIN_TOOLS)
+        assert result == {name: True for name in _DEEPAGENTS_BUILTIN_TOOLS}
+
+    def test_exclude_removes_listed_tools(self):
+        tools = [_tool("send_email"), _tool("search_web"), _tool("health_check")]
+        config = HumanApprovalConfig(
+            enabled=True, mode="all", exclude=["health_check", "search_web", "ls", "read_file"]
+        )
+        result = build_interrupt_on(config, tools)
+        assert result.get("send_email") is True
+        assert "health_check" not in result
+        assert "search_web" not in result
+        assert "ls" not in result
+        assert "read_file" not in result
+
+    def test_exclude_nonexistent_tool_is_harmless(self):
+        tools = [_tool("send_email")]
+        config = HumanApprovalConfig(enabled=True, mode="all", exclude=["nonexistent"])
+        result = build_interrupt_on(config, tools)
+        assert result["send_email"] is True
+        # builtins still present
+        assert "ls" in result
+
+    def test_all_tools_excluded_returns_empty(self):
+        all_names = list(_DEEPAGENTS_BUILTIN_TOOLS) + ["send_email"]
+        tools = [_tool("send_email")]
+        config = HumanApprovalConfig(enabled=True, mode="all", exclude=all_names)
+        result = build_interrupt_on(config, tools)
+        assert result == {}
+
+    def test_default_config_disabled(self):
+        """Default HumanApprovalConfig should produce no interrupts."""
+        config = HumanApprovalConfig()
+        result = build_interrupt_on(config, [_tool("send_email")])
+        assert result == {}


### PR DESCRIPTION
## Description

<!-- What does this MR do and why? Jira: DVRS-XXXX -->

Adds a **human-in-the-loop (HITL) tool approval gate** to the template-agent. When enabled, the agent pauses before executing any tool call and waits for the user to approve, reject, or always-allow it. The feature is driven by a new `human_approval` middleware config block in `agent.yaml` and is wired into the LangGraph graph factory via `create_deep_agent`'s `interrupt_on` parameter. HITL state is fully reflected in the graph cache key so config changes always trigger a graph rebuild.

## Changes

- `config/agent/runtime/agent.yaml` — added `human_approval` middleware block with `enabled`, `mode`, and `exclude` fields; default ships with `enabled: true, mode: all`
- `deep_agent/src/agent/config/middleware.py` — new `HumanApprovalConfig` Pydantic model; wired into `MiddlewareDefaults`, `ResolvedMiddlewareConfig`, and `resolve_middleware()` with bool-shorthand override support
- `deep_agent/src/agent/config/hitl.py` — new `build_interrupt_on()` helper that converts resolved config into the `interrupt_on` dict expected by `create_deep_agent()`; covers both caller-supplied MCP tools and deepagents built-in tools (`_DEEPAGENTS_BUILTIN_TOOLS`)
- `deep_agent/aegra/graph.py` — moved middleware resolution before cache-key computation; extended `_graph_fingerprint()` to include `mode` and `exclude` (not just the enabled bool); injected `interrupt_on` into `create_kwargs` with warnings when HITL is enabled but silently not applied (older deepagents or all-tools-excluded)
- `tests/unit/test_hitl.py` — 8-case unit test suite for `build_interrupt_on()` covering disabled, mode=none, builtins, exclusions, and edge cases
- `tests/unit/aegra/test_graph.py` — 2 new graph-level integration tests asserting `create_deep_agent` receives (or omits) `interrupt_on` based on HITL config

## AI Disclosure

<!-- Helps reviewers calibrate: AI-generated code has different failure modes than hand-written code. -->

- **AI used**: Yes
- **Tool(s)**: Claude Code
- **Scope**: Initial bootstrap implementation. Code review of the full feature branch; fixes for cache key incompleteness (`mode`/`exclude` missing from fingerprint), silent HITL skip without warning log, and missing graph-level integration tests — all three fix commits generated by Claude Code
- **Human verification**: Ran full test suite locally; reviewed diff for correctness of middleware resolution order and inspect.signature mock pattern

## Checklist

- [x] I have reviewed my own diff
- [x] Tests pass with adequate coverage
- [x] Docs and config updated if needed
- [x] AI output verified for correctness and hallucinated dependencies

## Deployment & Security Impact

<!--
Deployment: new env vars, config changes, migrations, resource scaling, downtime risk, rollback steps.
Security: auth/token changes, new endpoints exposed, input validation, secrets handling, RBAC changes.
-->

- **Config change**: `agent.yaml` ships with `human_approval.enabled: true` — existing deployed agents that pick up the new template config will have HITL turned on by default. Set `enabled: false` to preserve previous behaviour.
- **No new env vars, migrations, or endpoints.**
- **Security note**: HITL intercepts tool calls before execution; no new attack surface introduced. The `exclude` list should be reviewed to avoid inadvertently bypassing approval on sensitive tools.

## Reviewer Notes

<!-- What to focus on. -->

- The two high-severity Bugbot findings are **not addressed in this PR**: (1) subagent MCP tools bypass HITL because they run in separate graphs that never receive `interrupt_on`; (2) the shipped default `enabled: true` may break existing agents. Recommend follow-up ticket.
- `_DEEPAGENTS_BUILTIN_TOOLS` in `hitl.py` is a hardcoded frozenset — will drift if deepagents adds new built-in tools. Check against the pinned deepagents version in `pyproject.toml` on each upgrade.
- `profile.excluded_middleware` does not yet honour `human_approval` — other middleware (e.g. `patch_tool_calls`) has this guard, HITL does not.
