### PR TITLE
feat: add /version endpoint and bump to 0.2.0

### DIFF
--- a/deep_agent/aegra/__init__.py
+++ b/deep_agent/aegra/__init__.py
@@ -17,4 +17,4 @@ Modules:
     shutdown: Graceful SIGTERM shutdown orchestrator
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/deep_agent/aegra/__init__.py
+++ b/deep_agent/aegra/__init__.py
@@ -17,4 +17,6 @@ Modules:
     shutdown: Graceful SIGTERM shutdown orchestrator
 """
 
-__version__ = "0.2.0"
+import os as _os
+
+__version__ = _os.environ.get("APPLICATION_VERSION", "").strip() or "0.2.0"

--- a/deep_agent/aegra/health.py
+++ b/deep_agent/aegra/health.py
@@ -8,7 +8,7 @@ Response format::
 
     {
       "status": "healthy" | "degraded" | "unhealthy",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "uptime_seconds": 1234.5,
       "checks": {
         "database": {"status": "ok", "latency_ms": 5.2},
@@ -25,6 +25,7 @@ import asyncio
 import time
 from typing import Any
 
+from deep_agent.aegra import __version__
 from deep_agent.utils.pylogger import get_python_logger
 
 logger = get_python_logger()
@@ -122,7 +123,7 @@ async def get_health_status() -> dict[str, Any]:
 
     return {
         "status": overall,
-        "version": "0.1.0",
+        "version": __version__,
         "uptime_seconds": round(time.monotonic() - _start_time, 1),
         "checks": checks,
     }
@@ -135,7 +136,7 @@ async def health_response() -> tuple[int, dict[str, Any]]:
     if is_shutting_down():
         return 503, {
             "status": "shutting_down",
-            "version": "0.1.0",
+            "version": __version__,
             "uptime_seconds": round(time.monotonic() - _start_time, 1),
         }
 

--- a/deep_agent/aegra/http_app.py
+++ b/deep_agent/aegra/http_app.py
@@ -101,3 +101,11 @@ class TraceIDMiddleware(BaseHTTPMiddleware):
 app.add_middleware(TraceIDMiddleware)
 app.include_router(mcp_router)
 app.include_router(feedback_router)
+
+
+@app.get("/version")
+def version() -> dict[str, str]:
+    """Return service name and version."""
+    from deep_agent.aegra import __version__
+
+    return {"service": "template-agent", "version": __version__}

--- a/deep_agent/aegra/state.py
+++ b/deep_agent/aegra/state.py
@@ -12,6 +12,8 @@ concerns that don't belong in the agent itself.
 
 from typing import Any, TypedDict
 
+from deep_agent.aegra import __version__
+
 
 class AegraMetadata(TypedDict, total=False):
     """Platform-level metadata tracked alongside agent state."""
@@ -49,7 +51,7 @@ def make_health_status(
     """Build a health status dict from agent configuration."""
     return HealthStatus(
         status="healthy",
-        version="0.1.0",
+        version=__version__,
         agent_name=agent_name,
         model=model,
         mcp_tools_loaded=mcp_tools_count,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["deep_agent"]
 
 [project]
 name = "template-agent"
-version = "0.1.0"
+version = "0.2.0"
 description = "A template for Model Context Protocol (MCP) server development"
 readme = "README.md"
 keywords = ["mcp", "template", "server"]


### PR DESCRIPTION
## Summary
- Adds `/version` endpoint returning `{"service": "template-agent", "version": "0.2.0"}`
- Bumps version from 0.1.0 to 0.2.0 in `pyproject.toml` and `__init__.py`
- Replaces hardcoded version strings in health and state modules with `__version__` for single-source versioning

## Test plan
- [x] All 18 health/state tests pass
- [x] Pre-commit hooks pass (ruff, mypy, bandit, pydocstyle)
- [ ] Verify `/version` endpoint returns correct JSON on running service
- [ ] Verify `/health` response includes updated version field