### PR TITLE
fix: prevent blocking for human-in-loop feature for subagent tools

### DIFF
--- a/config/agent/runtime/agent.yaml
+++ b/config/agent/runtime/agent.yaml
@@ -108,7 +108,9 @@ middleware:
   human_approval:
     enabled: true    # set to false to disable human-in-the-loop tool approval
     mode: all        # 'all' = every tool; 'none' = disabled
-    exclude: []      # tool names to never interrupt (e.g. ls, read_file, glob, grep)
+    exclude:
+      - write_todos         # internal task tracking — no user approval needed
+      - compact_conversation  # internal memory management — no user approval needed
   summarization_tool:
     enabled: true
   memory:


### PR DESCRIPTION
## Description

<!-- What does this MR do and why? Jira: DVRS-XXXX -->

Prevents unnecessary human-in-the-loop approval prompts for internal subagent tools that operate silently without user-facing side effects. `write_todos` (task tracking) and `compact_conversation` (memory management) were triggering approval interrupts even though they are infrastructure-level tools that users should never need to approve. This fix adds them to the HITL `exclude` list in the agent runtime config.

## Changes

- Added `write_todos` to `middleware.human_approval.exclude` in `config/agent/runtime/agent.yaml` with explanatory inline comment
- Added `compact_conversation` to `middleware.human_approval.exclude` in `config/agent/runtime/agent.yaml` with explanatory inline comment

## AI Disclosure

<!-- Helps reviewers calibrate: AI-generated code has different failure modes than hand-written code. -->

- **AI used**: Yes
- **Tool(s)**: Claude Code
- **Scope**: Config change — added two tools to the HITL exclusion list in `agent.yaml`
- **Human verification**: Reviewed which tools are internal-only, confirmed no user-facing side effects for `write_todos` and `compact_conversation`, verified YAML syntax and comment accuracy

## Checklist

- [x] I have reviewed my own diff
- [x] Tests pass with adequate coverage
- [x] Docs and config updated if needed
- [x] AI output verified for correctness and hallucinated dependencies

## Deployment & Security Impact

<!--
Deployment: new env vars, config changes, migrations, resource scaling, downtime risk, rollback steps.
Security: auth/token changes, new endpoints exposed, input validation, secrets handling, RBAC changes.
-->

None — config-only change. No new env vars, no migrations. The excluded tools are read/write only to internal agent state and have no external side effects.

## Reviewer Notes

<!-- What to focus on. -->

Verify the two excluded tools (`write_todos`, `compact_conversation`) are indeed internal-only subagent tools with no user-visible or destructive side effects. If any additional internal tools are causing spurious HITL interrupts, they should be added to this list following the same pattern.