### PR TITLE
FEAT: Add api_key authentication method for mcp

### DIFF
--- a/config/agent/mcp.json
+++ b/config/agent/mcp.json
@@ -23,6 +23,16 @@
                 "registration_endpoint": "http://localhost:5001/auth/register",
                 "scopes": ["email", "openid", "profile", "session:role-any"]
             }
+        },
+        "template-mcp-server-api-key": {
+            "url": "http://localhost:5001/mcp",
+            "transport": "streamable_http",
+            "enabled": false,
+            "auth": true,
+            "auth_mode": "api_key",
+            "auth_env_var": "template_mcp_api_key",
+            "ssl_verify": false,
+            "timeout": 30
         }
     }
 }

--- a/deep_agent/aegra/mcp.py
+++ b/deep_agent/aegra/mcp.py
@@ -86,6 +86,9 @@ class _TokenInjectorInterceptor:
         user_id = _current_user_id.get()
         auth_mode = self._server_cfg.get("auth_mode", "sso")
 
+        if auth_mode == "api_key":
+            return await handler(request)
+
         try:
             if auth_mode in ("oauth", "dcr"):
                 if not user_id:
@@ -245,6 +248,13 @@ async def _resolve_connection_token(
     auth_mode = entry.get("auth_mode", "sso")
     if auth_mode == "sso":
         return sso_token
+
+    if auth_mode == "api_key":
+        env_var = entry.get("auth_env_var", "")
+        api_key = os.environ.get(env_var, "").strip().strip('"')
+        if not api_key:
+            logger.warning("MCP auth_mode=api_key but %s is not set", env_var)
+        return api_key or None
 
     if not user_id:
         return None

--- a/deep_agent/src/agent/config/loader.py
+++ b/deep_agent/src/agent/config/loader.py
@@ -314,9 +314,9 @@ class AgentConfig:
         auth_mode = cfg.get("auth_mode", "sso")
         cfg["auth_mode"] = auth_mode
 
-        if auth_mode not in ("sso", "oauth", "dcr"):
+        if auth_mode not in ("sso", "oauth", "dcr", "api_key"):
             logger.error(
-                "MCP server '%s': invalid auth_mode '%s' (expected sso, oauth, or dcr)",
+                "MCP server '%s': invalid auth_mode '%s' (expected sso, oauth, dcr, or api_key)",
                 name,
                 auth_mode,
             )


### PR DESCRIPTION
### Add API key authentication mode for MCP servers

**Summary**
Introduces api_key as a new auth_mode for MCP server connections, alongside existing sso, oauth, and dcr modes.
The API key is read from a configurable environment variable (auth_env_var field in mcp.json) at connection time.
Adds a sample template-mcp-server-api-key entry to the MCP config for reference/testing.

**Changes**
config/agent/mcp.json: Added template-mcp-server-api-key server entry with auth_mode: "api_key"
deep_agent/aegra/mcp.py: Added api_key handling in _TokenInjectorInterceptor (bypass per-call token refresh) and _resolve_connection_token (resolve key from env var)
deep_agent/src/agent/config/loader.py: Added "api_key" to the allowed auth_mode set in config validation

**Motivation**
Some MCP servers authenticate via static API keys rather than SSO/OAuth flows. This change enables connecting to such servers without requiring a full OAuth handshake or user-scoped SSO token.

**How it works**
Config: declare "auth_mode": "api_key" and "auth_env_var": "<ENV_VAR_NAME>" in mcp.json.
Connection: at tool-discovery time, _resolve_connection_token reads the key from the environment and passes it as a Bearer token in the initial connection headers.
Tool calls: the _TokenInjectorInterceptor skips per-call token resolution for api_key servers (static key, no refresh needed).

**Backward compatibility**
All existing sso, oauth, and dcr code paths are untouched.
The new api_key branch is additive — only activates when explicitly configured.
Config validation simply adds "api_key" to the allowed set; no existing configs are invalidated.
