### PR TITLE
fix: resolve pre-commit failures (ruff, mypy, pydocstyle, formatting)

### DIFF
--- a/deep_agent/aegra/graph.py
+++ b/deep_agent/aegra/graph.py
@@ -283,11 +283,6 @@ async def agent(runtime: ServerRuntime) -> Any:
     subagents = load_subagents(tools=mcp_tools)
     backend = get_configured_backend()
 
-    from deep_agent.src.infrastructure.middleware import (
-        build_middleware_list,
-        resolve_memory_param,
-    )
-
     middleware_overrides = orchestrator_cfg.get("middleware")
     resolved_mw = agent_config.resolve_agent_middleware(
         model_name, middleware_overrides

--- a/deep_agent/src/audit/emitter.py
+++ b/deep_agent/src/audit/emitter.py
@@ -18,11 +18,26 @@ from deep_agent.utils.pylogger import SERVICE_NAME, get_python_logger
 logger = get_python_logger()
 
 # Sensitive keys to redact from audit details
-SENSITIVE_KEYS = frozenset({
-    "password", "token", "apikey", "api_key", "secret", "authorization",
-    "cookie", "session", "auth", "credentials", "privatekey", "private_key",
-    "accesstoken", "access_token", "refreshtoken", "refresh_token"
-})
+SENSITIVE_KEYS = frozenset(
+    {
+        "password",
+        "token",
+        "apikey",
+        "api_key",
+        "secret",
+        "authorization",
+        "cookie",
+        "session",
+        "auth",
+        "credentials",
+        "privatekey",
+        "private_key",
+        "accesstoken",
+        "access_token",
+        "refreshtoken",
+        "refresh_token",
+    }
+)
 
 
 def _is_sensitive_key(key: str) -> bool:
@@ -42,7 +57,7 @@ def _scrub_details(details: dict[str, Any], depth: int = 0) -> dict[str, Any]:
     if depth > MAX_DEPTH:
         return {"error": "max_depth_exceeded"}
 
-    scrubbed = {}
+    scrubbed: dict[str, Any] = {}
     for key, value in details.items():
         if _is_sensitive_key(key):
             scrubbed[key] = "[REDACTED]"
@@ -106,7 +121,7 @@ def _safe_json_default(obj: Any) -> str:
     if isinstance(obj, datetime):
         return obj.isoformat()
     if hasattr(obj, "isoformat"):  # date, time, etc.
-        return obj.isoformat()
+        return str(obj.isoformat())
     # Allow Path and UUID
     if isinstance(obj, (Path, UUID)):
         return str(obj)
@@ -119,23 +134,23 @@ def _emit_envelope(envelope: dict[str, Any]) -> None:
 
     try:
         line = json.dumps(
-            _format_record(envelope),
-            default=_safe_json_default,
-            ensure_ascii=False
+            _format_record(envelope), default=_safe_json_default, ensure_ascii=False
         )
 
         if len(line) > MAX_SIZE:
             logger.warning(
                 "audit_event_too_large",
                 size=len(line),
-                event_type=envelope.get("audit_event_type")
+                event_type=envelope.get("audit_event_type"),
             )
             # Emit a truncated error event instead
             error_envelope = {
                 **envelope,
-                "details": {"error": "event_too_large", "size": len(line)}
+                "details": {"error": "event_too_large", "size": len(line)},
             }
-            line = json.dumps(_format_record(error_envelope), default=_safe_json_default)
+            line = json.dumps(
+                _format_record(error_envelope), default=_safe_json_default
+            )
 
         sys.stdout.write(f"{line}\n")
         sys.stdout.flush()
@@ -144,7 +159,7 @@ def _emit_envelope(envelope: dict[str, Any]) -> None:
             "audit_emit_failed",
             error=str(exc),
             error_type=type(exc).__name__,
-            event_type=envelope.get("audit_event_type")
+            event_type=envelope.get("audit_event_type"),
         )
         enqueue(envelope)
 
@@ -155,18 +170,12 @@ def _flush_buffer() -> None:
     for envelope in pending:
         try:
             line = json.dumps(
-                _format_record(envelope),
-                default=_safe_json_default,
-                ensure_ascii=False
+                _format_record(envelope), default=_safe_json_default, ensure_ascii=False
             )
             sys.stdout.write(f"{line}\n")
             sys.stdout.flush()
         except Exception as exc:
-            logger.debug(
-                "audit_flush_failed",
-                error=str(exc),
-                remaining=len(pending)
-            )
+            logger.debug("audit_flush_failed", error=str(exc), remaining=len(pending))
             # Re-enqueue this event and stop (preserves order)
             enqueue(envelope)
             break

--- a/deep_agent/src/audit/middleware.py
+++ b/deep_agent/src/audit/middleware.py
@@ -54,7 +54,9 @@ def _model_name(request: ModelRequest[Any]) -> str:
     model = request.model
     if isinstance(model, str):
         return model
-    return getattr(model, "model_name", None) or getattr(model, "model", None) or "unknown"
+    return (
+        getattr(model, "model_name", None) or getattr(model, "model", None) or "unknown"
+    )
 
 
 def classify_tool_call(
@@ -83,6 +85,7 @@ class AuditMiddleware(AgentMiddleware):
         subagent: str | None = None,
         agent: str | None = None,
     ) -> None:
+        """Initialize with optional MCP tool filter and agent identity."""
         self._mcp_tool_names = mcp_tool_names or frozenset()
         self._agent = agent or subagent or _ORCHESTRATOR_AGENT
 
@@ -166,6 +169,7 @@ class AuditMiddleware(AgentMiddleware):
         request: ModelRequest[Any],
         handler: Callable[[ModelRequest[Any]], Awaitable[ModelResponse[Any]]],
     ) -> ModelResponse[Any]:
+        """Async wrapper that audits LLM model invocations."""
         if not is_audit_enabled():
             return await handler(request)
 
@@ -201,9 +205,7 @@ class AuditMiddleware(AgentMiddleware):
         return response
 
     def _classify_tool(self, tool_name: str, args: dict[str, Any]) -> str:
-        return classify_tool_call(
-            tool_name, args, mcp_tool_names=self._mcp_tool_names
-        )
+        return classify_tool_call(tool_name, args, mcp_tool_names=self._mcp_tool_names)
 
     def _emit_tool_event(
         self,
@@ -228,8 +230,8 @@ class AuditMiddleware(AgentMiddleware):
             details["error"] = error
 
         if audit_type == AuditEventType.SUBAGENT_DELEGATION:
-            details["delegated_subagent"] = (
-                tool_args.get("subagent") or tool_args.get("name")
+            details["delegated_subagent"] = tool_args.get("subagent") or tool_args.get(
+                "name"
             )
         elif audit_type == AuditEventType.MEMORY_WRITE:
             details["path"] = _tool_path(tool_args)
@@ -294,6 +296,7 @@ class AuditMiddleware(AgentMiddleware):
         request: ToolCallRequest,
         handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]],
     ) -> ToolMessage | Command[Any]:
+        """Async wrapper that audits tool invocations."""
         if not is_audit_enabled():
             return await handler(request)
 

--- a/deep_agent/src/infrastructure/subagents.py
+++ b/deep_agent/src/infrastructure/subagents.py
@@ -392,7 +392,6 @@ def _build_default_subagent(
 
     # Build fallback middleware if spec has fallback configured
     fallback_mw = _build_fallback_middleware(spec)
-    subagent_middleware = [*fallback_mw]
 
     subagent_params: dict[str, Any] = {
         "name": name,
@@ -459,7 +458,6 @@ def _build_compiled_subagent(
 
     # Build fallback middleware if spec has fallback configured
     fallback_mw = _build_fallback_middleware(spec)
-    compiled_middleware = [*fallback_mw]
 
     create_kwargs = {
         "name": name,

--- a/tests/unit/aegra/test_graph.py
+++ b/tests/unit/aegra/test_graph.py
@@ -327,9 +327,13 @@ class TestAgentFactory:
 
         assert result is mock_compiled
         call_kwargs = mock_create.call_args.kwargs
-        assert "interrupt_on" in call_kwargs, "interrupt_on was not passed to create_deep_agent"
+        assert "interrupt_on" in call_kwargs, (
+            "interrupt_on was not passed to create_deep_agent"
+        )
         assert isinstance(call_kwargs["interrupt_on"], dict)
-        assert len(call_kwargs["interrupt_on"]) > 0, "interrupt_on dict must not be empty"
+        assert len(call_kwargs["interrupt_on"]) > 0, (
+            "interrupt_on dict must not be empty"
+        )
         assert all(v is True for v in call_kwargs["interrupt_on"].values())
 
     @pytest.mark.asyncio

--- a/tests/unit/audit/test_emitter.py
+++ b/tests/unit/audit/test_emitter.py
@@ -20,7 +20,9 @@ def _clear_context():
 class TestEmitAuditEventDisabled:
     def test_noop_when_disabled(self):
         with patch("deep_agent.src.audit.emitter.is_audit_enabled", return_value=False):
-            with patch("deep_agent.src.audit.emitter.sys.stdout", new_callable=StringIO) as out:
+            with patch(
+                "deep_agent.src.audit.emitter.sys.stdout", new_callable=StringIO
+            ) as out:
                 emit_audit_event("llm_call", model="test")
                 assert out.getvalue() == ""
 
@@ -29,7 +31,9 @@ class TestEmitAuditEventEnabled:
     def test_emits_envelope(self):
         bind_audit_context(user="alice@example.com", org="acme", trace_id="trace-1")
         with patch("deep_agent.src.audit.emitter.is_audit_enabled", return_value=True):
-            with patch("deep_agent.src.audit.emitter.sys.stdout", new_callable=StringIO) as out:
+            with patch(
+                "deep_agent.src.audit.emitter.sys.stdout", new_callable=StringIO
+            ) as out:
                 emit_audit_event("llm_call", model="gemini", phase="start")
                 record = json.loads(out.getvalue().strip())
                 assert record["event"] == "platform.audit"

--- a/tests/unit/audit/test_middleware.py
+++ b/tests/unit/audit/test_middleware.py
@@ -32,7 +32,12 @@ class TestClassifyToolCallParity:
         ("tool", "args", "mcp_names", "expected"),
         [
             ("task", {"subagent": "researcher"}, frozenset(), "subagent_delegation"),
-            ("gitlab_search", {"q": "x"}, frozenset({"gitlab_search"}), "mcp_tool_call"),
+            (
+                "gitlab_search",
+                {"q": "x"},
+                frozenset({"gitlab_search"}),
+                "mcp_tool_call",
+            ),
             ("edit_file", {"path": "/memories/x.md"}, frozenset(), "memory_write"),
             ("calculate_bmi", {}, frozenset(), ""),
         ],
@@ -49,7 +54,9 @@ class TestAuditMiddlewareClassification:
         request.messages = []
         handler = MagicMock(return_value=MagicMock())
 
-        with patch("deep_agent.src.audit.middleware.is_audit_enabled", return_value=True):
+        with patch(
+            "deep_agent.src.audit.middleware.is_audit_enabled", return_value=True
+        ):
             with patch("deep_agent.src.audit.middleware.emit_audit_event") as emit:
                 mw.wrap_model_call(request, handler)
                 assert emit.call_count == 2
@@ -64,7 +71,9 @@ class TestAuditMiddlewareClassification:
         request.messages = []
         handler = MagicMock(return_value=MagicMock())
 
-        with patch("deep_agent.src.audit.middleware.is_audit_enabled", return_value=True):
+        with patch(
+            "deep_agent.src.audit.middleware.is_audit_enabled", return_value=True
+        ):
             with patch("deep_agent.src.audit.middleware.emit_audit_event") as emit:
                 mw.wrap_model_call(request, handler)
                 assert emit.call_args_list[0].kwargs["agent"] == "orchestrator"
@@ -80,7 +89,9 @@ class TestAuditMiddlewareClassification:
         }
         handler = AsyncMock(return_value=MagicMock())
 
-        with patch("deep_agent.src.audit.middleware.is_audit_enabled", return_value=True):
+        with patch(
+            "deep_agent.src.audit.middleware.is_audit_enabled", return_value=True
+        ):
             with patch("deep_agent.src.audit.middleware.emit_audit_event") as emit:
                 await mw.awrap_tool_call(request, handler)
                 emit.assert_called_once()
@@ -98,7 +109,9 @@ class TestAuditMiddlewareClassification:
         request.tool_call = {"name": "gitlab_search", "args": {"q": "x"}, "id": "1"}
         handler = AsyncMock(return_value=MagicMock())
 
-        with patch("deep_agent.src.audit.middleware.is_audit_enabled", return_value=True):
+        with patch(
+            "deep_agent.src.audit.middleware.is_audit_enabled", return_value=True
+        ):
             with patch("deep_agent.src.audit.middleware.emit_audit_event") as emit:
                 await mw.awrap_tool_call(request, handler)
                 emit.assert_called_once()
@@ -112,7 +125,9 @@ class TestAuditMiddlewareClassification:
         request.tool_call = {"name": "calculate_bmi", "args": {}, "id": "1"}
         handler = AsyncMock(return_value=MagicMock())
 
-        with patch("deep_agent.src.audit.middleware.is_audit_enabled", return_value=True):
+        with patch(
+            "deep_agent.src.audit.middleware.is_audit_enabled", return_value=True
+        ):
             with patch("deep_agent.src.audit.middleware.emit_audit_event") as emit:
                 await mw.awrap_tool_call(request, handler)
                 emit.assert_not_called()
@@ -124,7 +139,9 @@ class TestAuditMiddlewareClassification:
         request.tool_call = {"name": "calculate_bmi", "args": {}, "id": "1"}
         handler = AsyncMock(return_value=MagicMock())
 
-        with patch("deep_agent.src.audit.middleware.is_audit_enabled", return_value=True):
+        with patch(
+            "deep_agent.src.audit.middleware.is_audit_enabled", return_value=True
+        ):
             with patch("deep_agent.src.audit.middleware.emit_audit_event") as emit:
                 await mw.awrap_tool_call(request, handler)
                 emit.assert_not_called()

--- a/tests/unit/test_hitl.py
+++ b/tests/unit/test_hitl.py
@@ -20,7 +20,9 @@ def _tool(name: str) -> MagicMock:
 class TestBuildInterruptOn:
     def test_disabled_returns_empty(self):
         config = HumanApprovalConfig(enabled=False, mode="all")
-        result = build_interrupt_on(config, [_tool("send_email"), _tool("delete_record")])
+        result = build_interrupt_on(
+            config, [_tool("send_email"), _tool("delete_record")]
+        )
         assert result == {}
 
     def test_mode_none_returns_empty(self):
@@ -41,7 +43,9 @@ class TestBuildInterruptOn:
         config = HumanApprovalConfig(enabled=True, mode="all")
         result = build_interrupt_on(config, [])
         for builtin in _DEEPAGENTS_BUILTIN_TOOLS:
-            assert builtin in result, f"built-in tool '{builtin}' missing from interrupt_on"
+            assert builtin in result, (
+                f"built-in tool '{builtin}' missing from interrupt_on"
+            )
 
     def test_empty_tool_list_still_covers_builtins(self):
         """An agent with no MCP tools still gets HITL for built-in filesystem tools."""
@@ -53,7 +57,9 @@ class TestBuildInterruptOn:
     def test_exclude_removes_listed_tools(self):
         tools = [_tool("send_email"), _tool("search_web"), _tool("health_check")]
         config = HumanApprovalConfig(
-            enabled=True, mode="all", exclude=["health_check", "search_web", "ls", "read_file"]
+            enabled=True,
+            mode="all",
+            exclude=["health_check", "search_web", "ls", "read_file"],
         )
         result = build_interrupt_on(config, tools)
         assert result.get("send_email") is True


### PR DESCRIPTION
- Remove unused variables in subagents.py (ruff F841)
- Add explicit type annotation for scrubbed dict in emitter.py (mypy)
- Wrap isoformat() return with str() to satisfy mypy no-any-return
- Add missing docstrings to AuditMiddleware methods (pydocstyle D102/D107)
- Apply ruff format auto-fixes across 7 files