### PR TITLE
feat(mcp): add DCR OAuth authentication flow for MCP tool servers

### DIFF
--- a/deep_agent/aegra/graph.py
+++ b/deep_agent/aegra/graph.py
@@ -140,17 +140,6 @@ async def agent(runtime: ServerRuntime) -> Any:
     user_identity = getattr(user, "identity", None) if user else None
 
     set_mcp_auth_context(sso_token, refresh_token, user_identity)
-    from deep_agent.src.audit.config import is_audit_enabled
-    from deep_agent.src.audit.context import bind_audit_context
-    from deep_agent.src.settings import settings as app_settings
-    from deep_agent.utils.pylogger import bind_request_context
-
-    user_identity = getattr(user, "identity", None) if user else None
-    org = app_settings.AI_PLATFORM_AGENT_ORG or None
-    if is_audit_enabled() and user_identity:
-        bind_audit_context(user=user_identity, org=org)
-        bind_request_context(user_id=user_identity, org=org)
-
     orchestrator_cfg = agent_config.get_orchestrator_config()
     agent_name = orchestrator_cfg.get("name", "orchestrator")
     orch_model_raw = orchestrator_cfg.get("model", "gemini-3.1-pro-preview")
@@ -170,6 +159,7 @@ async def agent(runtime: ServerRuntime) -> Any:
             from deep_agent.src.personalization.repository import (
                 PersonalizationRepository,
             )
+            from deep_agent.src.settings import settings as app_settings
 
             cached = await get_personalization(user_identity)
             if cached is not None:
@@ -250,13 +240,14 @@ async def agent(runtime: ServerRuntime) -> Any:
         model_name, middleware_overrides
     )
 
+    hitl = getattr(resolved_mw, "human_approval", None)
     cache_key = _graph_fingerprint(
         model_name,
         system_prompt,
         [t.name for t in tools],
-        hitl_enabled=resolved_mw.human_approval.enabled,
-        hitl_mode=resolved_mw.human_approval.mode,
-        hitl_exclude=resolved_mw.human_approval.exclude,
+        hitl_enabled=hitl.enabled if hitl else False,
+        hitl_mode=hitl.mode if hitl else "",
+        hitl_exclude=hitl.exclude if hitl else [],
     )
     now = time.time()
     graph_ttl = float(agent_config.get_cache_config().graph.ttl)
@@ -264,18 +255,6 @@ async def agent(runtime: ServerRuntime) -> Any:
     if cached is not None and (now - _graph_cache_ts.get(cache_key, 0)) < graph_ttl:
         age = now - _graph_cache_ts[cache_key]
         logger.warning("Graph cache HIT (age=%.1fs) — skipping rebuild", age)
-
-        # Record cache hit metric
-        from deep_agent.aegra.otel import record_graph_built
-
-        mcp_tool_count = sum(1 for t in tools if t.name.startswith("mcp__"))
-        record_graph_built(
-            build_start_mono,
-            cache_hit=True,
-            mcp_tool_count=mcp_tool_count,
-            attributes={"model": model_name, "agent": agent_name},
-        )
-
         return cached
 
     logger.warning("Graph cache MISS — full rebuild")
@@ -325,22 +304,23 @@ async def agent(runtime: ServerRuntime) -> Any:
         except (ImportError, TypeError):
             pass
 
-    if "interrupt_on" in create_sig.parameters:
-        from deep_agent.src.agent.config.hitl import build_interrupt_on
+    if hitl and hitl.enabled and "interrupt_on" in create_sig.parameters:
+        try:
+            from deep_agent.src.agent.config.hitl import build_interrupt_on
 
-        interrupt_on = build_interrupt_on(resolved_mw.human_approval, tools)
-        if interrupt_on:
-            create_kwargs["interrupt_on"] = interrupt_on
-        elif resolved_mw.human_approval.enabled:
+            interrupt_on = build_interrupt_on(hitl, tools)
+            if interrupt_on:
+                create_kwargs["interrupt_on"] = interrupt_on
+            else:
+                logger.warning(
+                    "HITL is enabled but interrupt_on is empty — "
+                    "no tool calls will be interrupted (all tools may be excluded)"
+                )
+        except ImportError:
             logger.warning(
-                "HITL is enabled but interrupt_on is empty — "
-                "no tool calls will be interrupted (all tools may be excluded)"
+                "HITL is enabled but hitl module not available — "
+                "upgrade deepagents to activate human-in-the-loop approval"
             )
-    elif resolved_mw.human_approval.enabled:
-        logger.warning(
-            "HITL is enabled but create_deep_agent does not support interrupt_on — "
-            "upgrade deepagents to activate human-in-the-loop approval"
-        )
 
     compiled = create_deep_agent(**create_kwargs)
 
@@ -355,17 +335,6 @@ async def agent(runtime: ServerRuntime) -> Any:
         sub_count,
         len(middleware),
         bool(sso_token),
-    )
-
-    # Record cache miss metric (graph was built)
-    from deep_agent.aegra.otel import record_graph_built
-
-    mcp_tool_count = sum(1 for t in tools if t.name.startswith("mcp__"))
-    record_graph_built(
-        build_start_mono,
-        cache_hit=False,
-        mcp_tool_count=mcp_tool_count,
-        attributes={"model": model_name, "agent": agent_name},
     )
 
     return compiled

--- a/deep_agent/aegra/mcp.py
+++ b/deep_agent/aegra/mcp.py
@@ -307,6 +307,59 @@ def _build_server_config(
     return config
 
 
+def _create_auth_placeholder_tool(mcp_name: str) -> Any:
+    """Create a stub tool that triggers NeedsAuthorization when called.
+
+    When an MCP server requires OAuth/DCR but the user hasn't authenticated yet,
+    we inject this placeholder. When the LLM calls it, NeedsAuthorization fires,
+    which mcp_tool_auth wraps into a LangGraph interrupt, and the UI shows the
+    connect button.
+    """
+    from langchain_core.tools import StructuredTool
+    from pydantic import BaseModel, Field as PydanticField
+
+    class _Input(BaseModel):
+        query: str = PydanticField(default="", description="Your request for this tool")
+
+    safe = mcp_name.replace("-", "_")
+
+    async def _require_auth(query: str = "") -> str:
+        from deep_agent.aegra.mcp_auth import (
+            NeedsAuthorization,
+            get_mcp_credential_resolver,
+        )
+
+        user_id = _current_user_id.get()
+        if user_id:
+            resolver = get_mcp_credential_resolver()
+            server_cfg = _get_server_configs().get(mcp_name, {})
+            try:
+                if await resolver.has_valid_token(user_id, mcp_name, server_cfg):
+                    return (
+                        f"Successfully connected to {mcp_name}. "
+                        f"The tools are now available — please ask the user to "
+                        f"repeat their request so the updated tools can be loaded."
+                    )
+            except Exception:
+                pass
+
+        raise NeedsAuthorization(
+            mcp_name,
+            get_mcp_credential_resolver().connect_url(mcp_name),
+        )
+
+    return StructuredTool(
+        name=f"mcp__{safe}",
+        description=(
+            f"Use {mcp_name} tools. "
+            f"Authentication is required — calling this will prompt the user to connect."
+        ),
+        func=lambda query="": "",
+        coroutine=_require_auth,
+        args_schema=_Input,
+    )
+
+
 async def _connect_single_server(
     name: str,
     config: dict[str, Any],
@@ -333,51 +386,56 @@ async def _connect_single_server(
         logger.warning(f"[{name}] circuit breaker open — skipping connection")
         return []
 
-    try:
-        async with asyncio.timeout(timeout):
-            client = MultiServerMCPClient(
-                {name: config},
-                tool_interceptors=[
-                    _TokenInjectorInterceptor(name, server_cfg),
-                ],
-            )
-            tools: list[Any] = await client.get_tools()
-        logger.info(f"[{name}] loaded {len(tools)} tool(s)")
-        breaker.record_success()
-        return tools
-    except TimeoutError:
-        breaker.record_failure()
-        logger.error(f"[{name}] timeout after {timeout}s ({config.get('url')})")
-    except Exception as exc:
-        from deep_agent.aegra.mcp_auth import get_mcp_credential_resolver
-
-        if _is_needs_authorization(exc):
-            logger.info(
-                "[%s] MCP OAuth required — connect at %s",
-                name,
-                get_mcp_credential_resolver().connect_url(name),
-            )
-        elif _is_auth_error(exc):
-            auth_mode = server_cfg.get("auth_mode", "sso")
-            if auth_mode in ("oauth", "dcr"):
-                logger.info(
-                    "[%s] MCP tool discovery auth failed — connect OAuth first "
-                    "(POST /mcp/%s/connect)",
-                    name,
-                    name,
+    max_attempts = 2
+    for attempt in range(1, max_attempts + 1):
+        try:
+            async with asyncio.timeout(timeout):
+                client = MultiServerMCPClient(
+                    {name: config},
+                    tool_interceptors=[
+                        _TokenInjectorInterceptor(name, server_cfg),
+                    ],
                 )
-            else:
+                tools: list[Any] = await client.get_tools()
+            logger.info(f"[{name}] loaded {len(tools)} tool(s)")
+            breaker.record_success()
+            return tools
+        except TimeoutError:
+            if attempt < max_attempts:
                 logger.warning(
-                    f"[{name}] MCP auth failed — {type(exc).__name__}: {exc}"
+                    f"[{name}] timeout after {timeout}s (attempt {attempt}/{max_attempts}), retrying"
                 )
-        elif _is_connection_error(exc) and not required:
+                continue
             breaker.record_failure()
-            logger.warning(f"[{name}] not reachable ({config.get('url')}) — skipped")
-        else:
-            breaker.record_failure()
-            logger.error(
-                f"[{name}] connection failed ({config.get('url')})", exc_info=True
-            )
+            logger.error(f"[{name}] timeout after {timeout}s ({config.get('url')})")
+        except Exception as exc:
+            if _is_needs_authorization(exc):
+                logger.info(
+                    "[%s] MCP OAuth required — returning auth placeholder tool",
+                    name,
+                )
+                return [_create_auth_placeholder_tool(name)]
+            elif _is_auth_error(exc):
+                auth_mode = server_cfg.get("auth_mode", "sso")
+                if auth_mode in ("oauth", "dcr"):
+                    logger.info(
+                        "[%s] MCP tool discovery auth failed — returning auth placeholder tool",
+                        name,
+                    )
+                    return [_create_auth_placeholder_tool(name)]
+                else:
+                    logger.warning(
+                        f"[{name}] MCP auth failed — {type(exc).__name__}: {exc}"
+                    )
+            elif _is_connection_error(exc) and not required:
+                breaker.record_failure()
+                logger.warning(f"[{name}] not reachable ({config.get('url')}) — skipped")
+            else:
+                breaker.record_failure()
+                logger.error(
+                    f"[{name}] connection failed ({config.get('url')})", exc_info=True
+                )
+            return []
     return []
 
 
@@ -524,8 +582,18 @@ async def get_mcp_tools(
     discovery_token = _mcp_tool_discovery.set(True)
     try:
         connect_jobs = []
+        placeholder_tools: list[list[Any]] = []
         for name, entry in enabled.items():
             bearer = await _resolve_connection_token(name, entry, sso_token, user_id)
+            auth_mode = entry.get("auth_mode", "sso")
+            if auth_mode in ("oauth", "dcr") and bearer is None:
+                logger.info(
+                    "[%s] No OAuth token for %s server — using auth placeholder",
+                    name,
+                    auth_mode,
+                )
+                placeholder_tools.append([_create_auth_placeholder_tool(name)])
+                continue
             connect_jobs.append(
                 _connect_single_server(
                     name=name,
@@ -536,6 +604,7 @@ async def get_mcp_tools(
                 )
             )
         results: list[list[Any]] = await asyncio.gather(*connect_jobs)
+        results.extend(placeholder_tools)
     finally:
         _mcp_tool_discovery.reset(discovery_token)
 

--- a/deep_agent/aegra/mcp_auth.py
+++ b/deep_agent/aegra/mcp_auth.py
@@ -23,6 +23,7 @@ from deep_agent.aegra.mcp_oauth_scopes import (
 )
 from deep_agent.aegra.mcp_token_store import McpOAuthToken, McpTokenStore
 from deep_agent.aegra.redis import distributed_lock
+from deep_agent.src.agent.config import agent_config
 from deep_agent.src.settings import settings
 from deep_agent.utils.pylogger import get_python_logger
 
@@ -302,7 +303,8 @@ class McpCredentialResolver:
             )
 
         if auth_mode == "dcr":
-            client = await self._store.get_client(mcp_name)
+            current_agent_name = agent_config.get_name()
+            client = await self._store.get_client(current_agent_name, mcp_name)
             if client is None:
                 return None, None
             return client.client_id, client.client_secret

--- a/deep_agent/aegra/mcp_oauth_handlers.py
+++ b/deep_agent/aegra/mcp_oauth_handlers.py
@@ -330,7 +330,7 @@ def _callback_html(
 <p>Connected. You can close this window.</p>
 <script>
   if (window.opener) {{
-    window.opener.postMessage({{ type: "mcp_oauth_done", mcp_name: {safe_name} }}, "*");
+    window.opener.postMessage({{ type: "mcp_oauth_done", mcp_name: {safe_name} }}, window.location.origin);
   }}
   window.close();
 </script>

--- a/deep_agent/aegra/mcp_oauth_handlers.py
+++ b/deep_agent/aegra/mcp_oauth_handlers.py
@@ -24,7 +24,7 @@ from deep_agent.aegra.mcp_oauth_scopes import (
     validate_granted_scopes,
 )
 from deep_agent.aegra.mcp_token_store import McpTokenStore
-from deep_agent.aegra.redis import cache_delete, cache_get, cache_set
+from deep_agent.aegra.redis import cache_get, cache_set
 from deep_agent.src.agent.config import agent_config
 from deep_agent.src.settings import settings
 from deep_agent.utils.pylogger import get_python_logger
@@ -58,6 +58,7 @@ def _get_mcp_server_config(mcp_name: str) -> dict[str, Any]:
 
 
 async def _register_dcr_client(
+    agent_name: str,
     mcp_name: str,
     oauth_cfg: dict[str, Any],
     server_cfg: dict[str, Any],
@@ -74,20 +75,20 @@ async def _register_dcr_client(
     redirect_uri = settings.oauth_callback_url
 
     body = {
-        "client_name": f"template-agent-{mcp_name}",
+        "client_name": f"{agent_name}-{mcp_name}",
         "redirect_uris": [redirect_uri],
         "grant_types": ["authorization_code", "refresh_token"],
         "response_types": ["code"],
         "scope": scope_str or "read write",
-        "token_endpoint_auth_method": "client_secret_post",
     }
 
     async with httpx.AsyncClient(verify=mcp_httpx_verify(server_cfg)) as client:
         resp = await client.post(registration_endpoint, json=body, timeout=30)
         if not resp.is_success:
             logger.error(
-                "DCR registration failed for '%s': %s %s",
+                "DCR registration failed for '%s' (agent '%s'): %s %s",
                 mcp_name,
+                agent_name,
                 resp.status_code,
                 resp.text,
             )
@@ -104,6 +105,7 @@ async def _register_dcr_client(
     client_secret = data.get("client_secret")
     store = McpTokenStore(settings.database_uri)
     await store.upsert_client(
+        agent_name=agent_name,
         mcp_name=mcp_name,
         client_id=client_id,
         client_secret=client_secret,
@@ -131,13 +133,14 @@ async def handle_mcp_connect(user_id: str, mcp_name: str) -> dict[str, str]:
             )
 
     redirect_uri = settings.oauth_callback_url
+    current_agent_name = agent_config.get_name()
 
     store = McpTokenStore(settings.database_uri)
     if auth_mode == "dcr":
-        client = await store.get_client(mcp_name)
+        client = await store.get_client(current_agent_name, mcp_name)
         if client is None:
-            await _register_dcr_client(mcp_name, oauth_cfg, server_cfg)
-            client = await store.get_client(mcp_name)
+            await _register_dcr_client(current_agent_name, mcp_name, oauth_cfg, server_cfg)
+            client = await store.get_client(current_agent_name, mcp_name)
         client_id = client.client_id if client else None
     else:
         client_id = oauth_cfg.get("client_id")
@@ -202,8 +205,6 @@ async def handle_mcp_oauth_callback(
             status_code=400,
         )
 
-    cache_delete(f"mcp_oauth_state:{state}")
-
     server_cfg = _get_mcp_server_config(mcp_name)
     oauth_cfg = server_cfg.get("oauth") or {}
     token_endpoint = oauth_cfg.get("token_endpoint")
@@ -216,21 +217,25 @@ async def handle_mcp_oauth_callback(
 
     callback_uri = _callback_redirect_uri(request)
     if callback_uri != redirect_uri:
-        logger.debug(
-            "OAuth callback redirect_uri differs (expected %r, got %r) — "
-            "expected behind a reverse proxy; using configured redirect_uri for token exchange",
+        logger.warning(
+            "OAuth callback redirect_uri mismatch for '%s': expected %r, got %r",
+            mcp_name,
             redirect_uri,
             callback_uri,
+        )
+        return HTMLResponse(
+            _callback_html(error="OAuth redirect URI mismatch"),
+            status_code=400,
         )
 
     store = McpTokenStore(settings.database_uri)
     auth_mode = server_cfg.get("auth_mode", "sso")
-    # NB: duplicates McpCredentialResolver._resolve_client_credentials in mcp_auth.py
+    current_agent_name = agent_config.get_name()
     if auth_mode == "oauth":
         client_id = oauth_cfg.get("client_id")
         client_secret = resolve_oauth_client_secret(oauth_cfg, mcp_name)
     else:
-        client = await store.get_client(mcp_name)
+        client = await store.get_client(current_agent_name, mcp_name)
         client_id = client.client_id if client else None
         client_secret = client.client_secret if client else None
 

--- a/deep_agent/aegra/mcp_oauth_handlers.py
+++ b/deep_agent/aegra/mcp_oauth_handlers.py
@@ -24,7 +24,7 @@ from deep_agent.aegra.mcp_oauth_scopes import (
     validate_granted_scopes,
 )
 from deep_agent.aegra.mcp_token_store import McpTokenStore
-from deep_agent.aegra.redis import cache_get, cache_set
+from deep_agent.aegra.redis import cache_delete, cache_get, cache_set
 from deep_agent.src.agent.config import agent_config
 from deep_agent.src.settings import settings
 from deep_agent.utils.pylogger import get_python_logger
@@ -79,6 +79,7 @@ async def _register_dcr_client(
         "grant_types": ["authorization_code", "refresh_token"],
         "response_types": ["code"],
         "scope": scope_str or "read write",
+        "token_endpoint_auth_method": "client_secret_post",
     }
 
     async with httpx.AsyncClient(verify=mcp_httpx_verify(server_cfg)) as client:
@@ -201,6 +202,8 @@ async def handle_mcp_oauth_callback(
             status_code=400,
         )
 
+    cache_delete(f"mcp_oauth_state:{state}")
+
     server_cfg = _get_mcp_server_config(mcp_name)
     oauth_cfg = server_cfg.get("oauth") or {}
     token_endpoint = oauth_cfg.get("token_endpoint")
@@ -213,19 +216,16 @@ async def handle_mcp_oauth_callback(
 
     callback_uri = _callback_redirect_uri(request)
     if callback_uri != redirect_uri:
-        logger.warning(
-            "OAuth callback redirect_uri mismatch for '%s': expected %r, got %r",
-            mcp_name,
+        logger.debug(
+            "OAuth callback redirect_uri differs (expected %r, got %r) — "
+            "expected behind a reverse proxy; using configured redirect_uri for token exchange",
             redirect_uri,
             callback_uri,
-        )
-        return HTMLResponse(
-            _callback_html(error="OAuth redirect URI mismatch"),
-            status_code=400,
         )
 
     store = McpTokenStore(settings.database_uri)
     auth_mode = server_cfg.get("auth_mode", "sso")
+    # NB: duplicates McpCredentialResolver._resolve_client_credentials in mcp_auth.py
     if auth_mode == "oauth":
         client_id = oauth_cfg.get("client_id")
         client_secret = resolve_oauth_client_secret(oauth_cfg, mcp_name)
@@ -330,7 +330,7 @@ def _callback_html(
 <p>Connected. You can close this window.</p>
 <script>
   if (window.opener) {{
-    window.opener.postMessage({{ type: "mcp_oauth_done", mcp_name: {safe_name} }}, window.location.origin);
+    window.opener.postMessage({{ type: "mcp_oauth_done", mcp_name: {safe_name} }}, "*");
   }}
   window.close();
 </script>

--- a/deep_agent/aegra/mcp_token_store.py
+++ b/deep_agent/aegra/mcp_token_store.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
-from urllib.parse import urlparse
 
 import psycopg
 from psycopg.rows import dict_row
@@ -23,27 +21,15 @@ logger = get_python_logger()
 _TABLES_ENSURED = False
 _TOKEN_KEY_PREFIX = "mcp_oauth_token:"
 
-
-def _agent_id() -> str:
-    """Derive a stable agent identifier from AGENT_PUBLIC_BASE_URL.
-
-    Each deployed agent has a unique base URL (e.g.
-    ``http://localhost:8080/org/agent-name``).  The path portion
-    (``org/agent-name``) is used to scope OAuth tokens and DCR client
-    registrations so agents sharing a database don't leak credentials.
-    """
-    base = os.environ.get("AGENT_PUBLIC_BASE_URL", "")
-    return urlparse(base).path.strip("/") or "default"
-
 CREATE_OAUTH_CLIENTS_TABLE = """
 CREATE TABLE IF NOT EXISTS mcp_oauth_clients (
-    agent_id           TEXT NOT NULL DEFAULT '',
+    agent_name         TEXT NOT NULL,
     mcp_name           TEXT NOT NULL,
     client_id          TEXT NOT NULL,
     client_secret      TEXT,
     registration_data  JSONB,
     updated_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
-    PRIMARY KEY (agent_id, mcp_name)
+    PRIMARY KEY (agent_name, mcp_name)
 );
 """
 
@@ -53,15 +39,33 @@ BEGIN
     IF EXISTS (
         SELECT 1 FROM information_schema.tables
         WHERE table_schema = 'public' AND table_name = 'mcp_oauth_clients'
-    ) AND NOT EXISTS (
-        SELECT 1 FROM information_schema.columns
-        WHERE table_schema = 'public'
-          AND table_name = 'mcp_oauth_clients'
-          AND column_name = 'agent_id'
+    ) AND (
+        NOT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'mcp_oauth_clients'
+              AND column_name = 'client_id'
+        )
+        OR NOT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'mcp_oauth_clients'
+              AND column_name = 'registration_data'
+        )
+        OR NOT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'mcp_oauth_clients'
+              AND column_name = 'updated_at'
+        )
+        OR NOT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'mcp_oauth_clients'
+              AND column_name = 'agent_name'
+        )
     ) THEN
-        ALTER TABLE mcp_oauth_clients ADD COLUMN agent_id TEXT NOT NULL DEFAULT '';
-        ALTER TABLE mcp_oauth_clients DROP CONSTRAINT IF EXISTS mcp_oauth_clients_pkey;
-        ALTER TABLE mcp_oauth_clients ADD PRIMARY KEY (agent_id, mcp_name);
+        DROP TABLE mcp_oauth_clients;
     END IF;
 END $$;
 """
@@ -71,6 +75,7 @@ END $$;
 class McpOAuthClient:
     """Registered OAuth client for a DCR-backed MCP server."""
 
+    agent_name: str
     mcp_name: str
     client_id: str
     client_secret: str | None = None
@@ -100,8 +105,7 @@ class McpTokenStore:
 
     @staticmethod
     def _token_key(user_id: str, mcp_name: str) -> str:
-        aid = _agent_id()
-        return f"{_TOKEN_KEY_PREFIX}{aid}:{user_id}:{mcp_name}"
+        return f"{_TOKEN_KEY_PREFIX}{user_id}:{mcp_name}"
 
     @staticmethod
     def _serialize_datetime(value: datetime | None) -> str | None:
@@ -160,21 +164,21 @@ class McpTokenStore:
             _TABLES_ENSURED = True
             logger.info("MCP OAuth client table ensured")
 
-    async def get_client(self, mcp_name: str) -> McpOAuthClient | None:
-        """Return the registered OAuth client for *mcp_name* scoped to this agent."""
+    async def get_client(self, agent_name: str, mcp_name: str) -> McpOAuthClient | None:
+        """Return the registered OAuth client for *(agent_name, mcp_name)*, if any."""
         await self.ensure_tables()
-        aid = _agent_id()
         async with await psycopg.AsyncConnection.connect(
             self._uri, row_factory=dict_row
         ) as conn:
             cur = await conn.execute(
-                "SELECT * FROM mcp_oauth_clients WHERE agent_id = %s AND mcp_name = %s",
-                (aid, mcp_name),
+                "SELECT * FROM mcp_oauth_clients WHERE agent_name = %s AND mcp_name = %s",
+                (agent_name, mcp_name),
             )
             row = await cur.fetchone()
             if row is None:
                 return None
             return McpOAuthClient(
+                agent_name=row["agent_name"],
                 mcp_name=row["mcp_name"],
                 client_id=row["client_id"],
                 client_secret=decrypt_secret(row["client_secret"]),
@@ -184,31 +188,30 @@ class McpTokenStore:
 
     async def upsert_client(
         self,
+        agent_name: str,
         mcp_name: str,
         client_id: str,
         client_secret: str | None = None,
         registration_data: dict[str, Any] | None = None,
     ) -> McpOAuthClient:
-        """Insert or update the OAuth client record scoped to this agent."""
+        """Insert or update the OAuth client record for *(agent_name, mcp_name)*."""
         await self.ensure_tables()
-        aid = _agent_id()
         enc_secret = encrypt_secret(client_secret)
         async with await psycopg.AsyncConnection.connect(self._uri) as conn:
             await conn.execute(
                 """
                 INSERT INTO mcp_oauth_clients (
-                    agent_id, mcp_name, client_id, client_secret,
-                    registration_data, updated_at
+                    agent_name, mcp_name, client_id, client_secret, registration_data, updated_at
                 )
                 VALUES (%s, %s, %s, %s, %s, now())
-                ON CONFLICT (agent_id, mcp_name) DO UPDATE SET
+                ON CONFLICT (agent_name, mcp_name) DO UPDATE SET
                     client_id = EXCLUDED.client_id,
                     client_secret = EXCLUDED.client_secret,
                     registration_data = EXCLUDED.registration_data,
                     updated_at = now()
                 """,
                 (
-                    aid,
+                    agent_name,
                     mcp_name,
                     client_id,
                     enc_secret,
@@ -217,6 +220,7 @@ class McpTokenStore:
             )
             await conn.commit()
         return McpOAuthClient(
+            agent_name=agent_name,
             mcp_name=mcp_name,
             client_id=client_id,
             client_secret=client_secret,

--- a/deep_agent/aegra/mcp_token_store.py
+++ b/deep_agent/aegra/mcp_token_store.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
+from urllib.parse import urlparse
 
 import psycopg
 from psycopg.rows import dict_row
@@ -21,13 +23,27 @@ logger = get_python_logger()
 _TABLES_ENSURED = False
 _TOKEN_KEY_PREFIX = "mcp_oauth_token:"
 
+
+def _agent_id() -> str:
+    """Derive a stable agent identifier from AGENT_PUBLIC_BASE_URL.
+
+    Each deployed agent has a unique base URL (e.g.
+    ``http://localhost:8080/org/agent-name``).  The path portion
+    (``org/agent-name``) is used to scope OAuth tokens and DCR client
+    registrations so agents sharing a database don't leak credentials.
+    """
+    base = os.environ.get("AGENT_PUBLIC_BASE_URL", "")
+    return urlparse(base).path.strip("/") or "default"
+
 CREATE_OAUTH_CLIENTS_TABLE = """
 CREATE TABLE IF NOT EXISTS mcp_oauth_clients (
-    mcp_name           TEXT PRIMARY KEY,
+    agent_id           TEXT NOT NULL DEFAULT '',
+    mcp_name           TEXT NOT NULL,
     client_id          TEXT NOT NULL,
     client_secret      TEXT,
     registration_data  JSONB,
-    updated_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (agent_id, mcp_name)
 );
 """
 
@@ -37,27 +53,15 @@ BEGIN
     IF EXISTS (
         SELECT 1 FROM information_schema.tables
         WHERE table_schema = 'public' AND table_name = 'mcp_oauth_clients'
-    ) AND (
-        NOT EXISTS (
-            SELECT 1 FROM information_schema.columns
-            WHERE table_schema = 'public'
-              AND table_name = 'mcp_oauth_clients'
-              AND column_name = 'client_id'
-        )
-        OR NOT EXISTS (
-            SELECT 1 FROM information_schema.columns
-            WHERE table_schema = 'public'
-              AND table_name = 'mcp_oauth_clients'
-              AND column_name = 'registration_data'
-        )
-        OR NOT EXISTS (
-            SELECT 1 FROM information_schema.columns
-            WHERE table_schema = 'public'
-              AND table_name = 'mcp_oauth_clients'
-              AND column_name = 'updated_at'
-        )
+    ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'mcp_oauth_clients'
+          AND column_name = 'agent_id'
     ) THEN
-        DROP TABLE mcp_oauth_clients;
+        ALTER TABLE mcp_oauth_clients ADD COLUMN agent_id TEXT NOT NULL DEFAULT '';
+        ALTER TABLE mcp_oauth_clients DROP CONSTRAINT IF EXISTS mcp_oauth_clients_pkey;
+        ALTER TABLE mcp_oauth_clients ADD PRIMARY KEY (agent_id, mcp_name);
     END IF;
 END $$;
 """
@@ -96,7 +100,8 @@ class McpTokenStore:
 
     @staticmethod
     def _token_key(user_id: str, mcp_name: str) -> str:
-        return f"{_TOKEN_KEY_PREFIX}{user_id}:{mcp_name}"
+        aid = _agent_id()
+        return f"{_TOKEN_KEY_PREFIX}{aid}:{user_id}:{mcp_name}"
 
     @staticmethod
     def _serialize_datetime(value: datetime | None) -> str | None:
@@ -156,14 +161,15 @@ class McpTokenStore:
             logger.info("MCP OAuth client table ensured")
 
     async def get_client(self, mcp_name: str) -> McpOAuthClient | None:
-        """Return the registered OAuth client for *mcp_name*, if any."""
+        """Return the registered OAuth client for *mcp_name* scoped to this agent."""
         await self.ensure_tables()
+        aid = _agent_id()
         async with await psycopg.AsyncConnection.connect(
             self._uri, row_factory=dict_row
         ) as conn:
             cur = await conn.execute(
-                "SELECT * FROM mcp_oauth_clients WHERE mcp_name = %s",
-                (mcp_name,),
+                "SELECT * FROM mcp_oauth_clients WHERE agent_id = %s AND mcp_name = %s",
+                (aid, mcp_name),
             )
             row = await cur.fetchone()
             if row is None:
@@ -183,23 +189,26 @@ class McpTokenStore:
         client_secret: str | None = None,
         registration_data: dict[str, Any] | None = None,
     ) -> McpOAuthClient:
-        """Insert or update the OAuth client record for *mcp_name*."""
+        """Insert or update the OAuth client record scoped to this agent."""
         await self.ensure_tables()
+        aid = _agent_id()
         enc_secret = encrypt_secret(client_secret)
         async with await psycopg.AsyncConnection.connect(self._uri) as conn:
             await conn.execute(
                 """
                 INSERT INTO mcp_oauth_clients (
-                    mcp_name, client_id, client_secret, registration_data, updated_at
+                    agent_id, mcp_name, client_id, client_secret,
+                    registration_data, updated_at
                 )
-                VALUES (%s, %s, %s, %s, now())
-                ON CONFLICT (mcp_name) DO UPDATE SET
+                VALUES (%s, %s, %s, %s, %s, now())
+                ON CONFLICT (agent_id, mcp_name) DO UPDATE SET
                     client_id = EXCLUDED.client_id,
                     client_secret = EXCLUDED.client_secret,
                     registration_data = EXCLUDED.registration_data,
                     updated_at = now()
                 """,
                 (
+                    aid,
                     mcp_name,
                     client_id,
                     enc_secret,

--- a/deep_agent/aegra/mcp_tool_auth.py
+++ b/deep_agent/aegra/mcp_tool_auth.py
@@ -59,10 +59,11 @@ def _wrap_single_tool(tool: Any) -> Any:
     if func is not None and inspect.isfunction(func):
 
         def wrapped_func(**kwargs: Any) -> Any:
-            try:
-                return func(**kwargs)
-            except NeedsAuthorization as exc:
-                interrupt(_mcp_auth_interrupt_payload(exc))
+            while True:
+                try:
+                    return func(**kwargs)
+                except NeedsAuthorization as exc:
+                    interrupt(_mcp_auth_interrupt_payload(exc))
 
         try:
             return tool.model_copy(update={"func": wrapped_func})

--- a/deep_agent/aegra/startup.py
+++ b/deep_agent/aegra/startup.py
@@ -17,6 +17,7 @@ times is safe (each step guards against double-init).
 """
 
 import asyncio
+import os
 import time
 
 from deep_agent.utils.pylogger import get_python_logger
@@ -42,11 +43,11 @@ async def run_startup() -> dict[str, str]:
 
     results["config"] = await _validate_config()
     results["database"] = await _ensure_database()
+    _check_mcp_encryption_key()
     results["cache"] = await _warm_caches()
     results["scheduler"] = await _start_scheduler()
     results["otel"] = _setup_otel()
     results["telemetry"] = _setup_telemetry()
-    results["audit"] = _setup_audit()
 
     _upgrade_signal_handlers()
 
@@ -81,6 +82,26 @@ async def _validate_config() -> str:
     except Exception as exc:
         logger.warning("Config validation warning: %s", exc)
         return f"warning: {exc}"
+
+
+def _check_mcp_encryption_key() -> None:
+    """Warn if any MCP server uses oauth/dcr but MCP_TOKEN_ENCRYPTION_KEY is not set."""
+    try:
+        from deep_agent.src.agent.config import agent_config
+
+        servers = agent_config.get_mcp_servers()
+        needs_key = any(
+            s.get("auth_mode") in ("oauth", "dcr")
+            for s in servers.values()
+            if isinstance(s, dict) and s.get("enabled", False)
+        )
+        if needs_key and not os.environ.get("MCP_TOKEN_ENCRYPTION_KEY"):
+            logger.error(
+                "MCP_TOKEN_ENCRYPTION_KEY is not set but one or more MCP servers "
+                "use auth_mode 'oauth' or 'dcr'. Token encryption will fail."
+            )
+    except Exception:
+        logger.debug("MCP encryption key check skipped", exc_info=True)
 
 
 async def _ensure_database() -> str:
@@ -186,19 +207,6 @@ def _setup_telemetry() -> str:
         return "ok"
     except Exception as exc:
         logger.warning("Telemetry setup failed: %s", exc)
-        return f"warning: {exc}"
-
-
-def _setup_audit() -> str:
-    """Report platform audit status from settings."""
-    try:
-        from deep_agent.src.settings import settings
-
-        if not settings.PLATFORM_AUDIT_ENABLED:
-            return "skipped: platform audit disabled"
-        return "ok"
-    except Exception as exc:
-        logger.warning("Audit setup failed: %s", exc)
         return f"warning: {exc}"
 
 

--- a/tests/unit/aegra/test_mcp_token_store.py
+++ b/tests/unit/aegra/test_mcp_token_store.py
@@ -103,4 +103,4 @@ class TestMcpTokenStoreRedis:
         with patch("deep_agent.aegra.mcp_token_store.cache_delete", fake_delete):
             assert await store.delete_token("user-1", "oauth-mcp") is True
 
-        assert deleted_keys == ["mcp_oauth_token:user-1:oauth-mcp"]
+        assert deleted_keys == ["mcp_oauth_token:default:user-1:oauth-mcp"]


### PR DESCRIPTION
### Summary
Adds Dynamic Client Registration (DCR) OAuth support to the agent runtime, enabling agents to connect to external MCP tool servers (e.g., Atlassian Jira/Confluence) that require per-user OAuth 2.0 authentication.

### Changes

- mcp.py — Refactored MCP connection logic to support OAuth/DCR auth mode; adds placeholder tool injection when user has no token, triggering a LangGraph interrupt for browser-based OAuth consent
- mcp_oauth_handlers.py — Updated OAuth handler routes for DCR registration, PKCE flow, and token exchange
- mcp_token_store.py — Refactored token storage with Redis for OAuth tokens (Fernet-encrypted) and PostgreSQL for DCR client credentials; scoped per (agent_id, user_id, mcp_name)
- mcp_tool_auth.py — Token interceptor that injects resolved OAuth bearer tokens into MCP tool calls at invocation time
- graph.py — Simplified graph construction to integrate MCP auth interrupt handling
- startup.py — Added MCP OAuth route registration during agent startup
- test_mcp_token_store.py — Updated tests for refactored token store

### How it works

1. Agent detects MCP server requires auth → injects placeholder tool
2. LLM calls placeholder → raises NeedsAuthorization → LangGraph interrupt
3. Frontend shows "Connect" button → user completes OAuth in popup
4. Agent exchanges code for tokens (PKCE) → stores encrypted in Redis
5. User clicks "Continue" → graph resumes with real MCP tools