### PR TITLE
feat: add Langfuse mock for graceful degradation

### DIFF
--- a/template_agent/__init__.py
+++ b/template_agent/__init__.py
@@ -2,3 +2,16 @@
 
 This package provides a template-based agent system for MCP (Model Context Protocol) servers.
 """
+
+from template_agent.src.settings import settings
+from template_agent.utils.langfuse_mock import (
+    install_langfuse_mock,
+    is_langfuse_configured,
+)
+
+if not is_langfuse_configured(
+    settings.LANGFUSE_PUBLIC_KEY,
+    settings.LANGFUSE_SECRET_KEY,
+    settings.LANGFUSE_BASE_URL,
+):
+    install_langfuse_mock()

--- a/template_agent/utils/langfuse_mock.py
+++ b/template_agent/utils/langfuse_mock.py
@@ -1,0 +1,65 @@
+"""No-op Langfuse stand-ins when credentials are not configured."""
+
+import sys
+import types
+from typing import Any, Optional
+
+from langchain_core.callbacks import BaseCallbackHandler
+
+from template_agent.utils.pylogger import get_python_logger
+
+logger = get_python_logger()
+
+
+def is_langfuse_configured(
+    public_key: Optional[str],
+    secret_key: Optional[str],
+    base_url: Optional[str],
+) -> bool:
+    """Return True when all Langfuse credential values are non-empty."""
+    return all((value or "").strip() for value in (public_key, secret_key, base_url))
+
+
+class NoOpLangfuse:
+    """Langfuse client stub that accepts calls without sending observability data."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Accept Langfuse client initialization arguments without side effects."""
+        pass
+
+    def score(self, *args: Any, **kwargs: Any) -> None:
+        """No-op score call."""
+        return None
+
+    def flush(self, *args: Any, **kwargs: Any) -> None:
+        """No-op flush call."""
+        return None
+
+    def shutdown(self, *args: Any, **kwargs: Any) -> None:
+        """No-op shutdown call."""
+        return None
+
+
+class NoOpCallbackHandler(BaseCallbackHandler):
+    """LangChain callback stub with default no-op handler methods."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Accept callback handler initialization arguments without side effects."""
+        super().__init__()
+
+
+def install_langfuse_mock() -> None:
+    """Register mock Langfuse modules so the real SDK is never imported."""
+    if "langfuse" in sys.modules:
+        return
+
+    langfuse_module = types.ModuleType("langfuse")
+    langfuse_module.Langfuse = NoOpLangfuse  # type: ignore[attr-defined]
+
+    callback_module = types.ModuleType("langfuse.callback")
+    callback_module.CallbackHandler = NoOpCallbackHandler  # type: ignore[attr-defined]
+
+    sys.modules["langfuse"] = langfuse_module
+    sys.modules["langfuse.callback"] = callback_module
+
+    logger.info("Langfuse credentials not configured; using no-op mock implementations")

--- a/tests/test_langfuse_mock.py
+++ b/tests/test_langfuse_mock.py
@@ -1,0 +1,140 @@
+"""Tests for Langfuse mock graceful degradation."""
+
+import os
+import subprocess
+import sys
+
+from template_agent.utils.langfuse_mock import (
+    NoOpCallbackHandler,
+    NoOpLangfuse,
+    install_langfuse_mock,
+    is_langfuse_configured,
+)
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(__file__))
+
+
+class TestIsLangfuseConfigured:
+    """Tests for Langfuse credential detection."""
+
+    def test_returns_false_when_all_missing(self):
+        assert not is_langfuse_configured(None, None, None)
+
+    def test_returns_false_when_any_empty(self):
+        assert not is_langfuse_configured("pk-test", "sk-test", "")
+        assert not is_langfuse_configured("pk-test", "", "https://cloud.langfuse.com")
+        assert not is_langfuse_configured("", "sk-test", "https://cloud.langfuse.com")
+
+    def test_returns_false_when_partially_configured(self):
+        assert not is_langfuse_configured("pk-test", None, None)
+        assert not is_langfuse_configured("pk-test", "sk-test", None)
+
+    def test_returns_true_when_all_configured(self):
+        assert is_langfuse_configured(
+            "pk-test", "sk-test", "https://cloud.langfuse.com"
+        )
+
+
+class TestNoOpImplementations:
+    """Tests for no-op Langfuse stand-ins."""
+
+    def test_noop_langfuse_score_is_safe(self):
+        client = NoOpLangfuse(environment="development")
+        assert client.score(trace_id="run-1", name="quality", value=4.5) is None
+
+    def test_noop_callback_handler_is_base_callback_handler(self):
+        handler = NoOpCallbackHandler(trace_name="template-agent")
+        assert isinstance(handler, NoOpCallbackHandler)
+
+
+class TestInstallLangfuseMock:
+    """Tests for sys.modules injection."""
+
+    def test_install_registers_mock_modules(self):
+        modules_snapshot = {
+            name: sys.modules.get(name) for name in ("langfuse", "langfuse.callback")
+        }
+        for name in ("langfuse", "langfuse.callback"):
+            sys.modules.pop(name, None)
+
+        try:
+            install_langfuse_mock()
+
+            from langfuse import Langfuse
+            from langfuse.callback import CallbackHandler
+
+            assert Langfuse is NoOpLangfuse
+            assert CallbackHandler is NoOpCallbackHandler
+        finally:
+            for name, module in modules_snapshot.items():
+                if module is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = module
+
+
+class TestPackageBootstrap:
+    """Integration tests for package-level mock installation."""
+
+    def test_feedback_import_uses_mock_without_credentials(self):
+        env = os.environ.copy()
+        env.update(
+            {
+                "LANGFUSE_PUBLIC_KEY": "",
+                "LANGFUSE_SECRET_KEY": "",
+                "LANGFUSE_BASE_URL": "",
+            }
+        )
+        script = """
+import template_agent
+from langfuse import Langfuse
+from template_agent.src.routes.feedback import client
+from template_agent.src.core.manager import langfuse_handler
+assert isinstance(client, Langfuse)
+assert client.score(trace_id="run-1", name="quality", value=1.0) is None
+print("mock-ok")
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=PROJECT_ROOT,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "mock-ok" in result.stdout
+
+    def test_package_does_not_install_mock_when_configured(self):
+        env = os.environ.copy()
+        env.update(
+            {
+                "LANGFUSE_PUBLIC_KEY": "pk-test",
+                "LANGFUSE_SECRET_KEY": "sk-test",
+                "LANGFUSE_BASE_URL": "https://cloud.langfuse.com",
+            }
+        )
+        script = """
+import importlib
+import sys
+
+for module_name in list(sys.modules):
+    if module_name == "template_agent" or module_name.startswith("template_agent."):
+        del sys.modules[module_name]
+for module_name in ("langfuse", "langfuse.callback"):
+    sys.modules.pop(module_name, None)
+
+import template_agent
+from langfuse import Langfuse
+from template_agent.utils.langfuse_mock import NoOpLangfuse
+assert Langfuse is not NoOpLangfuse
+print("real-ok")
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=PROJECT_ROOT,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "real-ok" in result.stdout


### PR DESCRIPTION
Issue #33

## Summary
- Add `template_agent/utils/langfuse_mock.py` with no-op `Langfuse` and `CallbackHandler` implementations
- Auto-detect missing credentials and install mocks in `template_agent/__init__.py` before real SDK import
- Add tests in `tests/test_langfuse_mock.py`

## Test plan
- [x] `pytest` — 87 passed
- [x] App starts without `LANGFUSE_*` env vars
- [x] `POST /v1/feedback` returns 200 without Langfuse errors