### PR TITLE
feat(agent): mcp oauth dcr agent

### DIFF
--- a/deep_agent/aegra/mcp_auth.py
+++ b/deep_agent/aegra/mcp_auth.py
@@ -23,7 +23,6 @@ from deep_agent.aegra.mcp_oauth_scopes import (
 )
 from deep_agent.aegra.mcp_token_store import McpOAuthToken, McpTokenStore
 from deep_agent.aegra.redis import distributed_lock
-from deep_agent.src.agent.config import agent_config
 from deep_agent.src.settings import settings
 from deep_agent.utils.pylogger import get_python_logger
 
@@ -114,7 +113,8 @@ class McpCredentialResolver:
             access = _current_access_token.get()
             return bool(access)
 
-        stored = await self._store.get_token(user_id, mcp_name)
+        current_agent_name = settings.agent_deployment_id
+        stored = await self._store.get_token(current_agent_name, user_id, mcp_name)
         if stored is None:
             return False
         if self._token_valid(stored):
@@ -142,7 +142,8 @@ class McpCredentialResolver:
         mcp_name: str,
         server_cfg: dict[str, Any],
     ) -> str:
-        stored = await self._store.get_token(user_id, mcp_name)
+        current_agent_name = settings.agent_deployment_id
+        stored = await self._store.get_token(current_agent_name, user_id, mcp_name)
         if stored is None:
             raise NeedsAuthorization(mcp_name, self.connect_url(mcp_name))
 
@@ -152,13 +153,13 @@ class McpCredentialResolver:
         if not stored.refresh_token:
             raise NeedsAuthorization(mcp_name, self.connect_url(mcp_name))
 
-        lock_name = f"mcp_token_refresh:{user_id}:{mcp_name}"
+        lock_name = f"mcp_token_refresh:{current_agent_name}:{user_id}:{mcp_name}"
         async with distributed_lock(
             lock_name,
             ttl_seconds=_TOKEN_REFRESH_LOCK_TTL_SECONDS,
             wait_seconds=_TOKEN_REFRESH_LOCK_WAIT_SECONDS,
         ) as lock_state:
-            stored = await self._store.get_token(user_id, mcp_name)
+            stored = await self._store.get_token(current_agent_name, user_id, mcp_name)
             if stored is None:
                 raise NeedsAuthorization(mcp_name, self.connect_url(mcp_name))
             if self._token_valid(stored):
@@ -168,7 +169,7 @@ class McpCredentialResolver:
 
             if lock_state == "timeout":
                 refreshed_by_peer = await self._wait_for_refreshed_token(
-                    user_id, mcp_name
+                    current_agent_name, user_id, mcp_name
                 )
                 if refreshed_by_peer:
                     return refreshed_by_peer
@@ -188,12 +189,12 @@ class McpCredentialResolver:
         raise NeedsAuthorization(mcp_name, self.connect_url(mcp_name))
 
     async def _wait_for_refreshed_token(
-        self, user_id: str, mcp_name: str
+        self, agent_name: str, user_id: str, mcp_name: str
     ) -> str | None:
         """Poll storage while another request holds the refresh lock."""
         for _ in range(_TOKEN_REFRESH_WAIT_ATTEMPTS):
             await asyncio.sleep(_TOKEN_REFRESH_WAIT_POLL_SECONDS)
-            stored = await self._store.get_token(user_id, mcp_name)
+            stored = await self._store.get_token(agent_name, user_id, mcp_name)
             if stored is not None and self._token_valid(stored):
                 return stored.access_token
         logger.error(
@@ -281,6 +282,7 @@ class McpCredentialResolver:
             scopes = stored.scopes
 
         await self._store.upsert_token(
+            agent_name=stored.agent_name,
             user_id=stored.user_id,
             mcp_name=stored.mcp_name,
             access_token=new_access,
@@ -303,7 +305,7 @@ class McpCredentialResolver:
             )
 
         if auth_mode == "dcr":
-            current_agent_name = agent_config.get_name()
+            current_agent_name = settings.agent_deployment_id
             client = await self._store.get_client(current_agent_name, mcp_name)
             if client is None:
                 return None, None

--- a/deep_agent/aegra/mcp_oauth_handlers.py
+++ b/deep_agent/aegra/mcp_oauth_handlers.py
@@ -24,7 +24,7 @@ from deep_agent.aegra.mcp_oauth_scopes import (
     validate_granted_scopes,
 )
 from deep_agent.aegra.mcp_token_store import McpTokenStore
-from deep_agent.aegra.redis import cache_get, cache_set
+from deep_agent.aegra.redis import cache_delete, cache_get, cache_set
 from deep_agent.src.agent.config import agent_config
 from deep_agent.src.settings import settings
 from deep_agent.utils.pylogger import get_python_logger
@@ -80,6 +80,7 @@ async def _register_dcr_client(
         "grant_types": ["authorization_code", "refresh_token"],
         "response_types": ["code"],
         "scope": scope_str or "read write",
+        "token_endpoint_auth_method": "client_secret_post",
     }
 
     async with httpx.AsyncClient(verify=mcp_httpx_verify(server_cfg)) as client:
@@ -205,6 +206,8 @@ async def handle_mcp_oauth_callback(
             status_code=400,
         )
 
+    cache_delete(f"mcp_oauth_state:{state}")
+
     server_cfg = _get_mcp_server_config(mcp_name)
     oauth_cfg = server_cfg.get("oauth") or {}
     token_endpoint = oauth_cfg.get("token_endpoint")
@@ -217,15 +220,11 @@ async def handle_mcp_oauth_callback(
 
     callback_uri = _callback_redirect_uri(request)
     if callback_uri != redirect_uri:
-        logger.warning(
-            "OAuth callback redirect_uri mismatch for '%s': expected %r, got %r",
-            mcp_name,
+        logger.debug(
+            "OAuth callback redirect_uri differs (expected %r, got %r) — "
+            "expected behind a reverse proxy; using configured redirect_uri for token exchange",
             redirect_uri,
             callback_uri,
-        )
-        return HTMLResponse(
-            _callback_html(error="OAuth redirect URI mismatch"),
-            status_code=400,
         )
 
     store = McpTokenStore(settings.database_uri)
@@ -335,7 +334,7 @@ def _callback_html(
 <p>Connected. You can close this window.</p>
 <script>
   if (window.opener) {{
-    window.opener.postMessage({{ type: "mcp_oauth_done", mcp_name: {safe_name} }}, window.location.origin);
+    window.opener.postMessage({{ type: "mcp_oauth_done", mcp_name: {safe_name} }}, "*");
   }}
   window.close();
 </script>

--- a/deep_agent/aegra/mcp_oauth_handlers.py
+++ b/deep_agent/aegra/mcp_oauth_handlers.py
@@ -24,7 +24,7 @@ from deep_agent.aegra.mcp_oauth_scopes import (
     validate_granted_scopes,
 )
 from deep_agent.aegra.mcp_token_store import McpTokenStore
-from deep_agent.aegra.redis import cache_delete, cache_get, cache_set
+from deep_agent.aegra.redis import cache_get, cache_set
 from deep_agent.src.agent.config import agent_config
 from deep_agent.src.settings import settings
 from deep_agent.utils.pylogger import get_python_logger
@@ -80,7 +80,6 @@ async def _register_dcr_client(
         "grant_types": ["authorization_code", "refresh_token"],
         "response_types": ["code"],
         "scope": scope_str or "read write",
-        "token_endpoint_auth_method": "client_secret_post",
     }
 
     async with httpx.AsyncClient(verify=mcp_httpx_verify(server_cfg)) as client:
@@ -206,8 +205,6 @@ async def handle_mcp_oauth_callback(
             status_code=400,
         )
 
-    cache_delete(f"mcp_oauth_state:{state}")
-
     server_cfg = _get_mcp_server_config(mcp_name)
     oauth_cfg = server_cfg.get("oauth") or {}
     token_endpoint = oauth_cfg.get("token_endpoint")
@@ -220,11 +217,15 @@ async def handle_mcp_oauth_callback(
 
     callback_uri = _callback_redirect_uri(request)
     if callback_uri != redirect_uri:
-        logger.debug(
-            "OAuth callback redirect_uri differs (expected %r, got %r) — "
-            "expected behind a reverse proxy; using configured redirect_uri for token exchange",
+        logger.warning(
+            "OAuth callback redirect_uri mismatch for '%s': expected %r, got %r",
+            mcp_name,
             redirect_uri,
             callback_uri,
+        )
+        return HTMLResponse(
+            _callback_html(error="OAuth redirect URI mismatch"),
+            status_code=400,
         )
 
     store = McpTokenStore(settings.database_uri)

--- a/deep_agent/aegra/mcp_oauth_handlers.py
+++ b/deep_agent/aegra/mcp_oauth_handlers.py
@@ -35,9 +35,14 @@ _OAUTH_STATE_TTL_SECONDS = 300
 
 
 def _callback_redirect_uri(request: Request) -> str:
-    """Reconstruct the OAuth callback URL (scheme + host + path, no query)."""
-    url = request.url
-    return f"{url.scheme}://{url.netloc}{url.path}"
+    """Reconstruct the OAuth callback URL using the canonical public base URL.
+
+    Behind a reverse proxy (e.g. MCP ingress with nginx rewrite-target),
+    request.url.path is the rewritten pod-local path, not the original
+    public path.  Use AGENT_PUBLIC_BASE_URL so the URI matches what was
+    registered during DCR / authorization.
+    """
+    return settings.oauth_callback_url
 
 
 def _pkce_pair() -> tuple[str, str]:

--- a/deep_agent/aegra/mcp_oauth_handlers.py
+++ b/deep_agent/aegra/mcp_oauth_handlers.py
@@ -138,7 +138,7 @@ async def handle_mcp_connect(user_id: str, mcp_name: str) -> dict[str, str]:
             )
 
     redirect_uri = settings.oauth_callback_url
-    current_agent_name = agent_config.get_name()
+    current_agent_name = settings.agent_deployment_id
 
     store = McpTokenStore(settings.database_uri)
     if auth_mode == "dcr":
@@ -235,7 +235,7 @@ async def handle_mcp_oauth_callback(
 
     store = McpTokenStore(settings.database_uri)
     auth_mode = server_cfg.get("auth_mode", "sso")
-    current_agent_name = agent_config.get_name()
+    current_agent_name = settings.agent_deployment_id
     if auth_mode == "oauth":
         client_id = oauth_cfg.get("client_id")
         client_secret = resolve_oauth_client_secret(oauth_cfg, mcp_name)
@@ -295,6 +295,7 @@ async def handle_mcp_oauth_callback(
         )
 
     await store.upsert_token(
+        agent_name=current_agent_name,
         user_id=user_id,
         mcp_name=mcp_name,
         access_token=access_token,

--- a/deep_agent/aegra/mcp_oauth_handlers.py
+++ b/deep_agent/aegra/mcp_oauth_handlers.py
@@ -334,7 +334,7 @@ def _callback_html(
 <p>Connected. You can close this window.</p>
 <script>
   if (window.opener) {{
-    window.opener.postMessage({{ type: "mcp_oauth_done", mcp_name: {safe_name} }}, "*");
+    window.opener.postMessage({{ type: "mcp_oauth_done", mcp_name: {safe_name} }}, window.location.origin);
   }}
   window.close();
 </script>

--- a/deep_agent/aegra/mcp_token_store.py
+++ b/deep_agent/aegra/mcp_token_store.py
@@ -85,8 +85,9 @@ class McpOAuthClient:
 
 @dataclass
 class McpOAuthToken:
-    """Stored OAuth tokens for a (user, MCP) pair."""
+    """Stored OAuth tokens for a (agent, user, MCP) tuple."""
 
+    agent_name: str
     user_id: str
     mcp_name: str
     access_token: str
@@ -104,8 +105,8 @@ class McpTokenStore:
         self._uri = database_uri
 
     @staticmethod
-    def _token_key(user_id: str, mcp_name: str) -> str:
-        return f"{_TOKEN_KEY_PREFIX}{user_id}:{mcp_name}"
+    def _token_key(agent_name: str, user_id: str, mcp_name: str) -> str:
+        return f"{_TOKEN_KEY_PREFIX}{agent_name}:{user_id}:{mcp_name}"
 
     @staticmethod
     def _serialize_datetime(value: datetime | None) -> str | None:
@@ -141,9 +142,10 @@ class McpTokenStore:
         }
 
     def _payload_to_token(
-        self, user_id: str, mcp_name: str, payload: dict[str, Any]
+        self, agent_name: str, user_id: str, mcp_name: str, payload: dict[str, Any]
     ) -> McpOAuthToken:
         return McpOAuthToken(
+            agent_name=agent_name,
             user_id=user_id,
             mcp_name=mcp_name,
             access_token=decrypt_secret(payload.get("access_token")) or "",
@@ -227,31 +229,34 @@ class McpTokenStore:
             registration_data=registration_data,
         )
 
-    async def get_token(self, user_id: str, mcp_name: str) -> McpOAuthToken | None:
-        """Return stored OAuth tokens for *(user_id, mcp_name)* from Redis."""
-        raw = await asyncio.to_thread(cache_get, self._token_key(user_id, mcp_name))
+    async def get_token(self, agent_name: str, user_id: str, mcp_name: str) -> McpOAuthToken | None:
+        """Return stored OAuth tokens for *(agent_name, user_id, mcp_name)* from Redis."""
+        raw = await asyncio.to_thread(cache_get, self._token_key(agent_name, user_id, mcp_name))
         if raw is None:
             return None
         try:
             payload = json.loads(raw)
         except json.JSONDecodeError:
             logger.error(
-                "Corrupt MCP OAuth token payload for user '%s' MCP '%s'",
+                "Corrupt MCP OAuth token payload for agent '%s' user '%s' MCP '%s'",
+                agent_name,
                 user_id,
                 mcp_name,
             )
             return None
         if not isinstance(payload, dict):
             logger.error(
-                "Invalid MCP OAuth token payload type for user '%s' MCP '%s'",
+                "Invalid MCP OAuth token payload type for agent '%s' user '%s' MCP '%s'",
+                agent_name,
                 user_id,
                 mcp_name,
             )
             return None
-        return self._payload_to_token(user_id, mcp_name, payload)
+        return self._payload_to_token(agent_name, user_id, mcp_name, payload)
 
     async def upsert_token(
         self,
+        agent_name: str,
         user_id: str,
         mcp_name: str,
         access_token: str,
@@ -259,17 +264,18 @@ class McpTokenStore:
         expires_at: datetime | None = None,
         scopes: list[str] | None = None,
     ) -> McpOAuthToken:
-        """Insert or update OAuth tokens for *(user_id, mcp_name)* in Redis."""
+        """Insert or update OAuth tokens for *(agent_name, user_id, mcp_name)* in Redis."""
         payload = self._token_to_payload(
             access_token, refresh_token, expires_at, scopes
         )
-        key = self._token_key(user_id, mcp_name)
+        key = self._token_key(agent_name, user_id, mcp_name)
         stored = await asyncio.to_thread(cache_set_persistent, key, json.dumps(payload))
         if not stored:
             raise RuntimeError(
-                f"Failed to persist MCP OAuth token for user '{user_id}' MCP '{mcp_name}'"
+                f"Failed to persist MCP OAuth token for agent '{agent_name}' user '{user_id}' MCP '{mcp_name}'"
             )
         return McpOAuthToken(
+            agent_name=agent_name,
             user_id=user_id,
             mcp_name=mcp_name,
             access_token=access_token,
@@ -279,9 +285,9 @@ class McpTokenStore:
             updated_at=self._deserialize_datetime(payload["updated_at"]),
         )
 
-    async def delete_token(self, user_id: str, mcp_name: str) -> bool:
-        """Delete stored OAuth tokens for *(user_id, mcp_name)* from Redis."""
-        return await asyncio.to_thread(cache_delete, self._token_key(user_id, mcp_name))
+    async def delete_token(self, agent_name: str, user_id: str, mcp_name: str) -> bool:
+        """Delete stored OAuth tokens for *(agent_name, user_id, mcp_name)* from Redis."""
+        return await asyncio.to_thread(cache_delete, self._token_key(agent_name, user_id, mcp_name))
 
     @staticmethod
     def expires_at_from_token_response(data: dict[str, Any]) -> datetime | None:

--- a/deep_agent/src/settings.py
+++ b/deep_agent/src/settings.py
@@ -138,8 +138,8 @@ class Settings(BaseSettings):
     ENABLE_CLI: bool = Field(default=True)
 
     # ── Platform ──────────────────────────────────────────────────────
-    AI_PLATFORM_AGENT_NAME: str = Field(default="")
-    AI_PLATFORM_AGENT_ORG: str = Field(default="")
+    DEPLOYED_AGENT_NAME: str = Field(default="")
+    DEPLOYED_AGENT_ORG: str = Field(default="")
     PLATFORM_AUDIT_ENABLED: bool = Field(default=True)
     PLATFORM_AUDIT_BUFFER_MAX: int = Field(default=1000, ge=1, le=100_000)
 
@@ -160,10 +160,10 @@ class Settings(BaseSettings):
         Combines org + agent name when deployed via agent-engine.
         Falls back to the generic config name for local dev.
         """
-        if self.AI_PLATFORM_AGENT_ORG and self.AI_PLATFORM_AGENT_NAME:
-            return f"{self.AI_PLATFORM_AGENT_ORG}/{self.AI_PLATFORM_AGENT_NAME}"
-        if self.AI_PLATFORM_AGENT_NAME:
-            return self.AI_PLATFORM_AGENT_NAME
+        if self.DEPLOYED_AGENT_ORG and self.DEPLOYED_AGENT_NAME:
+            return f"{self.DEPLOYED_AGENT_ORG}/{self.DEPLOYED_AGENT_NAME}"
+        if self.DEPLOYED_AGENT_NAME:
+            return self.DEPLOYED_AGENT_NAME
         from deep_agent.src.agent.config import agent_config
         return agent_config.get_name()
 

--- a/deep_agent/src/settings.py
+++ b/deep_agent/src/settings.py
@@ -138,6 +138,7 @@ class Settings(BaseSettings):
     ENABLE_CLI: bool = Field(default=True)
 
     # ── Platform ──────────────────────────────────────────────────────
+    AI_PLATFORM_AGENT_NAME: str = Field(default="")
     AI_PLATFORM_AGENT_ORG: str = Field(default="")
     PLATFORM_AUDIT_ENABLED: bool = Field(default=True)
     PLATFORM_AUDIT_BUFFER_MAX: int = Field(default=1000, ge=1, le=100_000)
@@ -151,6 +152,20 @@ class Settings(BaseSettings):
     AGENT_PUBLIC_BASE_URL: Optional[str] = Field(default=None)
 
     # ── Derived ───────────────────────────────────────────────────────
+
+    @property
+    def agent_deployment_id(self) -> str:
+        """Unique identity for this agent deployment, used as DCR/token key.
+
+        Combines org + agent name when deployed via agent-engine.
+        Falls back to the generic config name for local dev.
+        """
+        if self.AI_PLATFORM_AGENT_ORG and self.AI_PLATFORM_AGENT_NAME:
+            return f"{self.AI_PLATFORM_AGENT_ORG}/{self.AI_PLATFORM_AGENT_NAME}"
+        if self.AI_PLATFORM_AGENT_NAME:
+            return self.AI_PLATFORM_AGENT_NAME
+        from deep_agent.src.agent.config import agent_config
+        return agent_config.get_name()
 
     @property
     def agent_public_base_url(self) -> str:


### PR DESCRIPTION
**Summary**
  
  OAuth callbacks fail with a redirect URI mismatch when agents are accessed through the MCP ingress. The nginx
  ingress rewrites the request path from /{org}/{agent_name}/mcp/oauth/callback to /mcp/oauth/callback before
  forwarding to the agent pod. The callback handler reconstructs the redirect URI from the raw request URL,
  producing the rewritten pod-local path instead of the original public URL — causing it to never match the URI
  registered during DCR.

**Changes**
  
  Updated _callback_redirect_uri() in deep_agent/aegra/mcp_oauth_handlers.py to return
  settings.oauth_callback_url (derived from AGENT_PUBLIC_BASE_URL) instead of reconstructing from request.url.
  This ensures the callback URI matches the canonical public URL used during DCR registration and the
  authorization request, regardless of any reverse proxy path rewrites.

**User Flow**

  1. User clicks "Connect" on an MCP server with DCR/OAuth auth in the agent UI.
  2. Agent registers a client via DCR with redirect URI http://<host>/<org>/<agent>/mcp/oauth/callback.
  3. User is redirected to the OAuth provider's authorization page and grants access.
  4. OAuth provider redirects back to http://<host>/<org>/<agent>/mcp/oauth/callback?code=...&state=....
  5. MCP ingress rewrites the path to /mcp/oauth/callback and forwards to the agent pod.
  6. Agent handler validates the callback, exchanges the authorization code for tokens, and stores them.
  7. User sees "Connected" and the MCP server's tools become available.

  Previously, step 6 failed because the handler compared the rewritten path against the registered public URL,
  returning a 400 redirect URI mismatch error.