### PR TITLE
chore: allow workflow to trigger on any tag pattern

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -3,7 +3,7 @@ name: Build and Push Base Image
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - '*'
     branches:
       - main
       - deep-agent


### PR DESCRIPTION
Changed tag trigger from 'v*.*.*' to '*' to support any tag format.