### PR TITLE
feat: add custom CA certificate support at container startup

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
       - deep-agent
+      - pull_107
   workflow_dispatch:  # Allow manual trigger for testing
 
 permissions:

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - main
       - deep-agent
-      - pull_107
   workflow_dispatch:  # Allow manual trigger for testing
 
 permissions:

--- a/Containerfile
+++ b/Containerfile
@@ -24,6 +24,7 @@ USER 65532
 
 COPY --chown=65532:root deep_agent /app/deep_agent
 COPY --chown=65532:root aegra.json /app/aegra.json
+COPY --chown=65532:root entrypoint.sh /app/entrypoint.sh
 
 ENV PYTHONPATH=/app
 ENV AGENT_HOST=0.0.0.0
@@ -33,4 +34,5 @@ ENV CONFIG_PATH=/app/config/agent
 
 EXPOSE 5002
 
-CMD ["/bin/sh", "-c", "exec /app/.venv/bin/python -m deep_agent.aegra.entrypoint"]
+ENTRYPOINT ["/app/entrypoint.sh"]
+CMD ["/app/.venv/bin/python", "-m", "deep_agent.aegra.entrypoint"]

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Configuration is split between **secrets/endpoints** (`.env`) and **operational 
 | `MCP_TOKEN_ENCRYPTION_KEY` | — | Fernet key for OAuth/DCR token encryption |
 | `MCP_TOKEN_ENCRYPTION_KEY_PREVIOUS` | — | Previous key during rotation (decrypt-only) |
 | `AGENT_PUBLIC_BASE_URL` | `http://localhost:5002` | Public agent URL for OAuth callbacks |
+| `CUSTOM_CA_FILE` | — | Host path to a PEM file with custom CA certs (compose only) |
 | `SSL_KEYFILE` | — | TLS private key path (optional) |
 | `SSL_CERTFILE` | — | TLS certificate path (optional) |
 
@@ -204,6 +205,41 @@ Skills evals auto-discover from `config/agent/skills/*/evals/evals.json`. See [`
 ruff check . && ruff format .
 pre-commit run --all-files
 ```
+
+## Custom CA Certificates
+
+If your environment uses a corporate or internal certificate authority, the container can trust it at startup without rebuilding the image.
+
+**Compose** — set `CUSTOM_CA_FILE` in `.env` to the host path of your PEM bundle:
+
+```bash
+# .env
+CUSTOM_CA_FILE=./certs/ca.pem
+```
+
+**Kubernetes** — create a Secret and mount it, then set `CUSTOM_CA_PATH`:
+
+```yaml
+env:
+  - name: CUSTOM_CA_PATH
+    value: /etc/custom-ca/ca.pem
+volumeMounts:
+  - name: custom-ca
+    mountPath: /etc/custom-ca
+    readOnly: true
+volumes:
+  - name: custom-ca
+    secret:
+      secretName: custom-ca
+```
+
+**Fallback URL** — for non-orchestrated environments (e.g. `podman run`), set `CUSTOM_CA_URL` to download the PEM at startup:
+
+```bash
+podman run -e CUSTOM_CA_URL=https://certs.example.com/ca.pem ...
+```
+
+If neither variable is set, or the download fails, the container starts normally with default system certs.
 
 ## Deployment
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -86,6 +86,8 @@ services:
       - POSTGRES_PASSWORD=postgres
       - REDIS_URL=redis://redis:6379/0
       - REDIS_BROKER_ENABLED=true
+      # Custom CA — mount a PEM at ./certs/ca.pem to trust corporate CAs
+      - CUSTOM_CA_PATH=${CUSTOM_CA_PATH:-/etc/custom-ca/ca.pem}
       # OTEL (enable via env — make container sets these when Jaeger profile is active)
       - ENABLE_OTEL=${ENABLE_OTEL:-false}
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://jaeger:4317}
@@ -106,6 +108,7 @@ services:
     volumes:
       - ./deep_agent:/app/deep_agent:ro
       - ./config:/app/config:ro
+      - ${CUSTOM_CA_FILE:-/dev/null}:/etc/custom-ca/ca.pem:ro
     networks:
       - agent-network
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,31 +30,34 @@ elif [ -n "$CUSTOM_CA_URL" ]; then
 fi
 
 if [ ${#CA_PEMS[@]} -gt 0 ]; then
+  # Use /app (user-writable) instead of /tmp to avoid permission issues with shell redirection
+  BUNDLE_PATH="/app/.ca-bundle.pem"
+
   # Start with system CA bundle
   if command -v python3 &>/dev/null && python3 -m certifi &>/dev/null; then
-    cp "$(python3 -m certifi)" /tmp/ca-bundle.pem
+    cp "$(python3 -m certifi)" "$BUNDLE_PATH"
   elif [ -f /etc/ssl/certs/ca-certificates.crt ]; then
-    cp /etc/ssl/certs/ca-certificates.crt /tmp/ca-bundle.pem
+    cp /etc/ssl/certs/ca-certificates.crt "$BUNDLE_PATH"
   elif [ -f /etc/pki/tls/certs/ca-bundle.crt ]; then
-    cp /etc/pki/tls/certs/ca-bundle.crt /tmp/ca-bundle.pem
+    cp /etc/pki/tls/certs/ca-bundle.crt "$BUNDLE_PATH"
   else
-    cp /dev/null /tmp/ca-bundle.pem
+    touch "$BUNDLE_PATH"
   fi
 
-  # Append all custom CA certificates to the bundle
+  # Append all custom CA certificates to the bundle using cat (not shell redirection)
   for ca_pem in "${CA_PEMS[@]}"; do
-    cat "$ca_pem" >> /tmp/ca-bundle.pem
+    cat "$ca_pem" >> "$BUNDLE_PATH" 2>/dev/null || cat "$ca_pem" | cat >> "$BUNDLE_PATH"
     # Clean up temporary downloads
     [[ "$ca_pem" == /tmp/custom-ca-*.pem ]] && rm -f "$ca_pem"
   done
 
-  export REQUESTS_CA_BUNDLE=/tmp/ca-bundle.pem
-  export SSL_CERT_FILE=/tmp/ca-bundle.pem
-  export CURL_CA_BUNDLE=/tmp/ca-bundle.pem
-  export PIP_CERT=/tmp/ca-bundle.pem
-  export NODE_EXTRA_CA_CERTS=/tmp/ca-bundle.pem
+  export REQUESTS_CA_BUNDLE="$BUNDLE_PATH"
+  export SSL_CERT_FILE="$BUNDLE_PATH"
+  export CURL_CA_BUNDLE="$BUNDLE_PATH"
+  export PIP_CERT="$BUNDLE_PATH"
+  export NODE_EXTRA_CA_CERTS="$BUNDLE_PATH"
 
-  echo "INFO: Custom CA bundle configured with ${#CA_PEMS[@]} certificate(s)" >&2
+  echo "INFO: Custom CA bundle configured with ${#CA_PEMS[@]} certificate(s) at $BUNDLE_PATH" >&2
 fi
 
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,35 +1,22 @@
 #!/bin/bash
 
-# Custom CA support: mount a PEM file or provide URL(s).
+# Custom CA support: mount a PEM file or provide a URL.
 #   CUSTOM_CA_PATH — path to a mounted PEM file (preferred, no network call)
-#   CUSTOM_CA_URL  — URL(s) to download PEM from (comma-separated for multiple certs)
-#                    Examples:
-#                      Single:   CUSTOM_CA_URL="https://example.com/cert.pem"
-#                      Multiple: CUSTOM_CA_URL="https://example.com/cert1.pem,https://example.com/cert2.pem"
-CA_PEMS=()
+#   CUSTOM_CA_URL  — URL to download PEM from (fallback, hits network per pod)
+CA_PEM=""
 
 if [ -n "$CUSTOM_CA_PATH" ] && [ -f "$CUSTOM_CA_PATH" ]; then
-  CA_PEMS=("$CUSTOM_CA_PATH")
+  CA_PEM="$CUSTOM_CA_PATH"
 elif [ -n "$CUSTOM_CA_URL" ]; then
-  # Split CUSTOM_CA_URL by comma and download each certificate
-  IFS=',' read -ra URLS <<< "$CUSTOM_CA_URL"
-  for i in "${!URLS[@]}"; do
-    url="${URLS[$i]}"
-    # Trim whitespace
-    url=$(echo "$url" | xargs)
-    if [ -n "$url" ]; then
-      tmp_ca="/tmp/custom-ca-$i.pem"
-      if curl -so "$tmp_ca" "$url"; then
-        CA_PEMS+=("$tmp_ca")
-        echo "INFO: Successfully fetched CA from $url" >&2
-      else
-        echo "WARN: Failed to fetch CA from $url, skipping" >&2
-      fi
-    fi
-  done
+  if curl -so /tmp/custom-ca.pem "$CUSTOM_CA_URL"; then
+    CA_PEM="/tmp/custom-ca.pem"
+    echo "INFO: Successfully fetched CA from $CUSTOM_CA_URL" >&2
+  else
+    echo "WARN: Failed to fetch CA from $CUSTOM_CA_URL, continuing with defaults" >&2
+  fi
 fi
 
-if [ ${#CA_PEMS[@]} -gt 0 ]; then
+if [ -n "$CA_PEM" ]; then
   # Use /app (user-writable) instead of /tmp to avoid permission issues with shell redirection
   BUNDLE_PATH="/app/.ca-bundle.pem"
 
@@ -44,12 +31,9 @@ if [ ${#CA_PEMS[@]} -gt 0 ]; then
     touch "$BUNDLE_PATH"
   fi
 
-  # Append all custom CA certificates to the bundle using cat (not shell redirection)
-  for ca_pem in "${CA_PEMS[@]}"; do
-    cat "$ca_pem" >> "$BUNDLE_PATH" 2>/dev/null || cat "$ca_pem" | cat >> "$BUNDLE_PATH"
-    # Clean up temporary downloads
-    [[ "$ca_pem" == /tmp/custom-ca-*.pem ]] && rm -f "$ca_pem"
-  done
+  # Append custom CA certificate to the bundle
+  cat "$CA_PEM" >> "$BUNDLE_PATH" 2>/dev/null || cat "$CA_PEM" | cat >> "$BUNDLE_PATH"
+  [ "$CA_PEM" = "/tmp/custom-ca.pem" ] && rm -f /tmp/custom-ca.pem
 
   export REQUESTS_CA_BUNDLE="$BUNDLE_PATH"
   export SSL_CERT_FILE="$BUNDLE_PATH"
@@ -57,7 +41,7 @@ if [ ${#CA_PEMS[@]} -gt 0 ]; then
   export PIP_CERT="$BUNDLE_PATH"
   export NODE_EXTRA_CA_CERTS="$BUNDLE_PATH"
 
-  echo "INFO: Custom CA bundle configured with ${#CA_PEMS[@]} certificate(s) at $BUNDLE_PATH" >&2
+  echo "INFO: Custom CA bundle configured at $BUNDLE_PATH" >&2
 fi
 
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,21 +1,36 @@
 #!/bin/bash
 
-# Custom CA support: mount a PEM file or provide a URL.
+# Custom CA support: mount a PEM file or provide URL(s).
 #   CUSTOM_CA_PATH — path to a mounted PEM file (preferred, no network call)
-#   CUSTOM_CA_URL  — URL to download PEM from (fallback, hits network per pod)
-CA_PEM=""
+#   CUSTOM_CA_URL  — URL(s) to download PEM from (comma-separated for multiple certs)
+#                    Examples:
+#                      Single:   CUSTOM_CA_URL="https://example.com/cert.pem"
+#                      Multiple: CUSTOM_CA_URL="https://example.com/cert1.pem,https://example.com/cert2.pem"
+CA_PEMS=()
 
 if [ -n "$CUSTOM_CA_PATH" ] && [ -f "$CUSTOM_CA_PATH" ]; then
-  CA_PEM="$CUSTOM_CA_PATH"
+  CA_PEMS=("$CUSTOM_CA_PATH")
 elif [ -n "$CUSTOM_CA_URL" ]; then
-  if curl -so /tmp/custom-ca.pem "$CUSTOM_CA_URL"; then
-    CA_PEM="/tmp/custom-ca.pem"
-  else
-    echo "WARN: Failed to fetch CA from $CUSTOM_CA_URL, continuing with defaults" >&2
-  fi
+  # Split CUSTOM_CA_URL by comma and download each certificate
+  IFS=',' read -ra URLS <<< "$CUSTOM_CA_URL"
+  for i in "${!URLS[@]}"; do
+    url="${URLS[$i]}"
+    # Trim whitespace
+    url=$(echo "$url" | xargs)
+    if [ -n "$url" ]; then
+      tmp_ca="/tmp/custom-ca-$i.pem"
+      if curl -so "$tmp_ca" "$url"; then
+        CA_PEMS+=("$tmp_ca")
+        echo "INFO: Successfully fetched CA from $url" >&2
+      else
+        echo "WARN: Failed to fetch CA from $url, skipping" >&2
+      fi
+    fi
+  done
 fi
 
-if [ -n "$CA_PEM" ]; then
+if [ ${#CA_PEMS[@]} -gt 0 ]; then
+  # Start with system CA bundle
   if command -v python3 &>/dev/null && python3 -m certifi &>/dev/null; then
     cp "$(python3 -m certifi)" /tmp/ca-bundle.pem
   elif [ -f /etc/ssl/certs/ca-certificates.crt ]; then
@@ -26,14 +41,20 @@ if [ -n "$CA_PEM" ]; then
     cp /dev/null /tmp/ca-bundle.pem
   fi
 
-  cat "$CA_PEM" >> /tmp/ca-bundle.pem
-  [ "$CA_PEM" = "/tmp/custom-ca.pem" ] && rm /tmp/custom-ca.pem
+  # Append all custom CA certificates to the bundle
+  for ca_pem in "${CA_PEMS[@]}"; do
+    cat "$ca_pem" >> /tmp/ca-bundle.pem
+    # Clean up temporary downloads
+    [[ "$ca_pem" == /tmp/custom-ca-*.pem ]] && rm -f "$ca_pem"
+  done
 
   export REQUESTS_CA_BUNDLE=/tmp/ca-bundle.pem
   export SSL_CERT_FILE=/tmp/ca-bundle.pem
   export CURL_CA_BUNDLE=/tmp/ca-bundle.pem
   export PIP_CERT=/tmp/ca-bundle.pem
   export NODE_EXTRA_CA_CERTS=/tmp/ca-bundle.pem
+
+  echo "INFO: Custom CA bundle configured with ${#CA_PEMS[@]} certificate(s)" >&2
 fi
 
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,6 +31,9 @@ if [ -n "$CA_PEM" ]; then
     touch "$BUNDLE_PATH"
   fi
 
+  # Make bundle writable (system CA bundles are often read-only)
+  chmod u+w "$BUNDLE_PATH"
+
   # Append custom CA certificate to the bundle
   cat "$CA_PEM" >> "$BUNDLE_PATH" 2>/dev/null || cat "$CA_PEM" | cat >> "$BUNDLE_PATH"
   [ "$CA_PEM" = "/tmp/custom-ca.pem" ] && rm -f /tmp/custom-ca.pem

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Custom CA support: mount a PEM file or provide a URL.
+#   CUSTOM_CA_PATH — path to a mounted PEM file (preferred, no network call)
+#   CUSTOM_CA_URL  — URL to download PEM from (fallback, hits network per pod)
+CA_PEM=""
+
+if [ -n "$CUSTOM_CA_PATH" ] && [ -f "$CUSTOM_CA_PATH" ]; then
+  CA_PEM="$CUSTOM_CA_PATH"
+elif [ -n "$CUSTOM_CA_URL" ]; then
+  if curl -so /tmp/custom-ca.pem "$CUSTOM_CA_URL"; then
+    CA_PEM="/tmp/custom-ca.pem"
+  else
+    echo "WARN: Failed to fetch CA from $CUSTOM_CA_URL, continuing with defaults" >&2
+  fi
+fi
+
+if [ -n "$CA_PEM" ]; then
+  if command -v python3 &>/dev/null && python3 -m certifi &>/dev/null; then
+    cp "$(python3 -m certifi)" /tmp/ca-bundle.pem
+  elif [ -f /etc/ssl/certs/ca-certificates.crt ]; then
+    cp /etc/ssl/certs/ca-certificates.crt /tmp/ca-bundle.pem
+  elif [ -f /etc/pki/tls/certs/ca-bundle.crt ]; then
+    cp /etc/pki/tls/certs/ca-bundle.crt /tmp/ca-bundle.pem
+  else
+    cp /dev/null /tmp/ca-bundle.pem
+  fi
+
+  cat "$CA_PEM" >> /tmp/ca-bundle.pem
+  [ "$CA_PEM" = "/tmp/custom-ca.pem" ] && rm /tmp/custom-ca.pem
+
+  export REQUESTS_CA_BUNDLE=/tmp/ca-bundle.pem
+  export SSL_CERT_FILE=/tmp/ca-bundle.pem
+  export CURL_CA_BUNDLE=/tmp/ca-bundle.pem
+  export PIP_CERT=/tmp/ca-bundle.pem
+  export NODE_EXTRA_CA_CERTS=/tmp/ca-bundle.pem
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary
- Adds an `entrypoint.sh` that injects custom CA bundles at container startup via `CUSTOM_CA_PATH` (mount) or `CUSTOM_CA_URL` (download), without requiring an image rebuild.
- Appends the custom PEM to the system CA bundle and exports standard env vars (`REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`, `CURL_CA_BUNDLE`, `PIP_CERT`, `NODE_EXTRA_CA_CERTS`) so all HTTP clients trust it.
- Updates `Containerfile` to use the new entrypoint, `compose.yaml` to mount a CA PEM volume, and README with usage instructions for Compose, Kubernetes, and standalone `podman run`.

## Test plan
- [x] Build image and run with `CUSTOM_CA_PATH` pointing to a mounted PEM; verify HTTPS to an internal-CA endpoint succeeds
- [x] Run with `CUSTOM_CA_URL` pointing to a downloadable PEM; verify it fetches and trusts the CA
- [x] Run without either variable set; verify container starts normally with default certs
- [x] Verify `docker compose up` mounts the CA volume correctly when `CUSTOM_CA_FILE` is set in `.env`