### PR TITLE
fix: bump pytest-asyncio from 1.0.0 to 1.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest==9.1.1",
-    "pytest-asyncio==1.0.0",
+    "pytest-asyncio==1.4.0",
     "pytest-cov==6.2.1",
     "pytest-mock>=3.14.0",
     "ruff==0.12.2",


### PR DESCRIPTION
Upgrades pytest-asyncio from 1.0.0 to 1.4.0 to pick up compatibility improvements in async test handling. This dependency is due to the version upgrade in pytest. No functional changes to production code.