### PR TITLE
Init of MCP Prefix Tool Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,42 @@ curl "http://localhost:8081/health"
 - `AGENT_SSL_KEYFILE`: SSL private key path
 - `AGENT_SSL_CERTFILE`: SSL certificate path
 
+#### MCP Server
+- `MCP_SERVER_NAME`: MCP server name used as the default tool prefix (default: template-mcp-server)
+- `MCP_SERVER_URL`: MCP server endpoint URL (default: http://localhost:5001/mcp/)
+- `MCP_TRANSPORT_PROTOCOL`: MCP transport protocol (default: streamable_http)
+- `MCP_CONNECTION_TIMEOUT`: MCP connection timeout in seconds (default: 30)
+- `MCP_SSL_VERIFY`: Enable SSL verification for MCP connections (default: false)
+- `MCP_CONFIG_PATH`: Path to the materialized `mcp.json` config file (default: /app/config/agent/mcp.json)
+
+#### MCP Tool Name Prefix
+
+When multiple MCP servers are configured, or when server names include environment suffixes (e.g. `search-mcp-prod`), tool names can become verbose. The `tool_prefix` field in `mcp.json` lets you control how tools are prefixed.
+
+**Example `mcp.json`:**
+
+```json
+{
+  "mcpServers": {
+    "search-mcp-prod": {
+      "enabled": true,
+      "url": "http://search-mcp:9090/mcp",
+      "transport": "streamable_http",
+      "ssl_verify": false,
+      "auth": true,
+      "description": "search-mcp-prod",
+      "tool_prefix": "search"
+    }
+  }
+}
+```
+
+With this config, tools from `search-mcp-prod` are exposed as `search_{tool_name}` instead of `search_mcp_prod_{tool_name}`. When `tool_prefix` is omitted, the server key is used as the prefix (existing behavior).
+
+The `mcp.json` file can be provided externally and mounted into the container at the `MCP_CONFIG_PATH` location. When the file is not present (e.g. local development), the agent falls back to the `MCP_SERVER_*` environment variables.
+
+Both the main agent and any sub-agents read the same `mcp.json`, ensuring consistent tool name prefixing across the entire agent hierarchy.
+
 ### Configuration Example
 
 ```bash

--- a/template_agent/src/core/agent.py
+++ b/template_agent/src/core/agent.py
@@ -4,7 +4,9 @@ This module provides the core agent functionality for the template agent,
 including initialization, configuration, and agent creation utilities.
 """
 
+import json
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Optional
 
 from langchain_google_genai import ChatGoogleGenerativeAI
@@ -114,22 +116,8 @@ async def get_template_agent(
         # Add timeout wrapper for MCP connection
         async def connect_with_timeout():
             # Configure MCP client with SSL verification setting
-            server_config = {
-                "url": settings.MCP_SERVER_URL,
-                "transport": settings.MCP_TRANSPORT_PROTOCOL,
-                "headers": {"Authorization": f"Bearer {sso_token}"}
-                if sso_token
-                else {},
-            }
-
-            # Add SSL verification setting (verify=False disables cert verification)
-            if not settings.MCP_SSL_VERIFY:
-                server_config["verify"] = False
-                logger.warning(
-                    "SSL certificate verification disabled for MCP connection"
-                )
-
-            client = MultiServerMCPClient({settings.MCP_SERVER_NAME: server_config})
+            mcp_config = _load_mcp_config(sso_token)
+            client = MultiServerMCPClient(mcp_config)
             return await client.get_tools()
 
         tools = await asyncio.wait_for(
@@ -234,3 +222,49 @@ async def get_template_agent(
                 "Template agent initialized successfully with PostgreSQL checkpoint"
             )
             yield agent_redhat
+
+
+# ---------------------------------------------------------------------------
+# helper functions
+# ---------------------------------------------------------------------------
+
+
+def _load_mcp_config(sso_token: str | None) -> dict:
+    """Build MCP server configs from mcp.json, falling back to env vars."""
+    config_path = Path(settings.MCP_CONFIG_PATH)
+    if not config_path.is_file():
+        # Fallback: single server from env vars (local dev)
+        svr_cfg: dict[str, str | bool | dict[str, str]] = {
+            "url": settings.MCP_SERVER_URL,
+            "transport": settings.MCP_TRANSPORT_PROTOCOL,
+            "headers": {"Authorization": f"Bearer {sso_token}"} if sso_token else {},
+        }
+        if not settings.MCP_SSL_VERIFY:
+            svr_cfg["verify"] = False
+        return {settings.MCP_SERVER_NAME: svr_cfg}
+    try:
+        with open(config_path, "r") as f:
+            mcp_config = json.load(f)
+            servers = mcp_config.get("mcpServers", {})
+            new_mcp_config = {}
+            for key, value in servers.items():
+                cfg = dict(value)
+                mcp_prefix = cfg.pop("tool_prefix", None) or key
+                svr_cfg = {
+                    "url": cfg.get("url", ""),
+                    "transport": cfg.get("transport", ""),
+                }
+                if sso_token:
+                    svr_cfg["headers"] = {"Authorization": f"Bearer {sso_token}"}
+                if not cfg.get("ssl_verify", True):
+                    svr_cfg["verify"] = False
+                new_mcp_config[mcp_prefix] = svr_cfg
+    except Exception as e:
+        logger.error(
+            f"Failed to load MCP config from {config_path}: {e}", exc_info=True
+        )
+        raise AppException(
+            f"Failed to load MCP config from {config_path}: {str(e)}",
+            AppExceptionCode.CONFIGURATION_INITIALIZATION_ERROR,
+        )
+    return new_mcp_config

--- a/template_agent/src/settings.py
+++ b/template_agent/src/settings.py
@@ -139,6 +139,15 @@ class Settings(BaseSettings):
             "description": "Enable SSL certificate verification for MCP connections",
         },
     )
+    MCP_CONFIG_PATH: str = Field(
+        default="/app/config/agent/mcp.json",
+        json_schema_extra={
+            "env": "MCP_CONFIG_PATH",
+            "description": "Path to the materialized mcp.json config file. "
+            "When the file exists, MCP servers are loaded from it. "
+            "When absent, falls back to MCP_SERVER_* env vars.",
+        },
+    )
 
     # Request Logging Configuration
     REQUEST_LOGGING_ENABLED: bool = Field(

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,202 @@
+"""Tests for the agent module — _load_mcp_config helper."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from template_agent.src.core.agent import _load_mcp_config
+
+
+class TestLoadMcpConfig:
+    """Tests for _load_mcp_config: mcp.json prefix reading and env-var fallback."""
+
+    def _write_mcp_json(self, tmp_path: Path, servers: dict) -> Path:
+        mcp_file = tmp_path / "mcp.json"
+        mcp_file.write_text(json.dumps({"mcpServers": servers}))
+        return mcp_file
+
+    # -- prefix scenarios --
+
+    def test_reads_prefix_from_json(self, tmp_path):
+        """tool_prefix in mcp.json becomes the dict key."""
+        mcp_file = self._write_mcp_json(
+            tmp_path,
+            {
+                "search-mcp-prod": {
+                    "url": "http://search:9090/mcp",
+                    "transport": "streamable_http",
+                    "ssl_verify": False,
+                    "tool_prefix": "search",
+                }
+            },
+        )
+        with patch("template_agent.src.core.agent.settings") as mock_settings:
+            mock_settings.MCP_CONFIG_PATH = str(mcp_file)
+            result = _load_mcp_config(sso_token=None)
+
+        assert "search" in result
+        assert "search-mcp-prod" not in result
+        assert result["search"]["url"] == "http://search:9090/mcp"
+
+    def test_no_prefix_uses_server_key(self, tmp_path):
+        """Without tool_prefix, the raw server key is used."""
+        mcp_file = self._write_mcp_json(
+            tmp_path,
+            {
+                "gitlab-mcp": {
+                    "url": "http://gitlab:8080/mcp",
+                    "transport": "streamable_http",
+                }
+            },
+        )
+        with patch("template_agent.src.core.agent.settings") as mock_settings:
+            mock_settings.MCP_CONFIG_PATH = str(mcp_file)
+            result = _load_mcp_config(sso_token=None)
+
+        assert "gitlab-mcp" in result
+        assert result["gitlab-mcp"]["url"] == "http://gitlab:8080/mcp"
+
+    def test_empty_prefix_uses_server_key(self, tmp_path):
+        """Empty string tool_prefix is treated same as absent."""
+        mcp_file = self._write_mcp_json(
+            tmp_path,
+            {
+                "data-mcp": {
+                    "url": "http://data:9090/mcp",
+                    "transport": "streamable_http",
+                    "tool_prefix": "",
+                }
+            },
+        )
+        with patch("template_agent.src.core.agent.settings") as mock_settings:
+            mock_settings.MCP_CONFIG_PATH = str(mcp_file)
+            result = _load_mcp_config(sso_token=None)
+
+        assert "data-mcp" in result
+
+    # -- env var fallback --
+
+    def test_fallback_to_env_vars(self, tmp_path):
+        """When mcp.json does not exist, falls back to env var settings."""
+        missing_path = tmp_path / "nonexistent" / "mcp.json"
+        with patch("template_agent.src.core.agent.settings") as mock_settings:
+            mock_settings.MCP_CONFIG_PATH = str(missing_path)
+            mock_settings.MCP_SERVER_URL = "http://localhost:5001/mcp/"
+            mock_settings.MCP_TRANSPORT_PROTOCOL = "streamable_http"
+            mock_settings.MCP_SERVER_NAME = "template-mcp-server"
+            mock_settings.MCP_SSL_VERIFY = True
+            result = _load_mcp_config(sso_token=None)
+
+        assert "template-mcp-server" in result
+        assert result["template-mcp-server"]["url"] == "http://localhost:5001/mcp/"
+        assert result["template-mcp-server"]["transport"] == "streamable_http"
+
+    # -- auth / SSL --
+
+    def test_applies_sso_token(self, tmp_path):
+        """Authorization header is set when sso_token is provided."""
+        mcp_file = self._write_mcp_json(
+            tmp_path,
+            {
+                "my-mcp": {
+                    "url": "http://mcp:8080/mcp",
+                    "transport": "streamable_http",
+                }
+            },
+        )
+        with patch("template_agent.src.core.agent.settings") as mock_settings:
+            mock_settings.MCP_CONFIG_PATH = str(mcp_file)
+            result = _load_mcp_config(sso_token="test-token-123")
+
+        assert result["my-mcp"]["headers"] == {"Authorization": "Bearer test-token-123"}
+
+    def test_no_auth_header_without_token(self, tmp_path):
+        """No Authorization header when sso_token is None."""
+        mcp_file = self._write_mcp_json(
+            tmp_path,
+            {
+                "my-mcp": {
+                    "url": "http://mcp:8080/mcp",
+                    "transport": "streamable_http",
+                }
+            },
+        )
+        with patch("template_agent.src.core.agent.settings") as mock_settings:
+            mock_settings.MCP_CONFIG_PATH = str(mcp_file)
+            result = _load_mcp_config(sso_token=None)
+
+        assert "headers" not in result["my-mcp"]
+
+    def test_ssl_verify_false(self, tmp_path):
+        """ssl_verify: false in mcp.json sets verify: False in config."""
+        mcp_file = self._write_mcp_json(
+            tmp_path,
+            {
+                "my-mcp": {
+                    "url": "http://mcp:8080/mcp",
+                    "transport": "streamable_http",
+                    "ssl_verify": False,
+                }
+            },
+        )
+        with patch("template_agent.src.core.agent.settings") as mock_settings:
+            mock_settings.MCP_CONFIG_PATH = str(mcp_file)
+            result = _load_mcp_config(sso_token=None)
+
+        assert result["my-mcp"]["verify"] is False
+
+    def test_ssl_verify_true_omits_verify_key(self, tmp_path):
+        """ssl_verify: true (default) does not add verify key."""
+        mcp_file = self._write_mcp_json(
+            tmp_path,
+            {
+                "my-mcp": {
+                    "url": "http://mcp:8080/mcp",
+                    "transport": "streamable_http",
+                    "ssl_verify": True,
+                }
+            },
+        )
+        with patch("template_agent.src.core.agent.settings") as mock_settings:
+            mock_settings.MCP_CONFIG_PATH = str(mcp_file)
+            result = _load_mcp_config(sso_token=None)
+
+        assert "verify" not in result["my-mcp"]
+
+    # -- sub-agent consistency --
+
+    def test_consistent_for_subagents(self, tmp_path):
+        """Same mcp.json produces identical output on repeated calls."""
+        mcp_file = self._write_mcp_json(
+            tmp_path,
+            {
+                "search-mcp-prod": {
+                    "url": "http://search:9090/mcp",
+                    "transport": "streamable_http",
+                    "tool_prefix": "search",
+                }
+            },
+        )
+        with patch("template_agent.src.core.agent.settings") as mock_settings:
+            mock_settings.MCP_CONFIG_PATH = str(mcp_file)
+            result1 = _load_mcp_config(sso_token="token-a")
+            result2 = _load_mcp_config(sso_token="token-a")
+
+        assert result1 == result2
+
+    # -- env var fallback SSL --
+
+    def test_fallback_ssl_verify_false(self, tmp_path):
+        """Env var fallback respects MCP_SSL_VERIFY=False."""
+        missing_path = tmp_path / "nonexistent" / "mcp.json"
+        with patch("template_agent.src.core.agent.settings") as mock_settings:
+            mock_settings.MCP_CONFIG_PATH = str(missing_path)
+            mock_settings.MCP_SERVER_URL = "http://localhost:5001/mcp/"
+            mock_settings.MCP_TRANSPORT_PROTOCOL = "streamable_http"
+            mock_settings.MCP_SERVER_NAME = "template-mcp-server"
+            mock_settings.MCP_SSL_VERIFY = False
+            result = _load_mcp_config(sso_token=None)
+
+        assert result["template-mcp-server"]["verify"] is False


### PR DESCRIPTION
## Summary
- **MCP tool_prefix support**: When multiple MCP servers are configured via `mcp.json`, tool names are prefixed using the server key (e.g. `search-mcp-prod_tool_name`). This adds a `tool_prefix` field in `mcp.json` so teams can control the prefix (e.g. `search_tool_name` instead), keeping tool names clean and predictable. When `tool_prefix` is omitted, existing behavior (server key as prefix) is preserved.
- **OpenAI-compatible LLM backend**: Adds support for local/self-hosted LLMs (RamaLama, Ollama, vLLM) via the OpenAI-compatible API. Set `USE_OPENAI_COMPAT_LLM=true` and `OPENAI_COMPAT_BASE_URL` to switch from the default Google Gemini backend. Google credential initialization is skipped when using this mode.
- **MCP config loader refactor**: Extracts MCP server configuration into a dedicated `_load_mcp_config()` helper that reads from `mcp.json` (production/materialized path) and falls back to `MCP_SERVER_*` env vars (local dev), replacing the inline config block in `get_template_agent()`.
## Changes
| File | What changed |
|------|-------------|
| `template_agent/src/core/agent.py` | New `_build_chat_model()` (Gemini vs OpenAI-compat) and `_load_mcp_config()` (mcp.json with `tool_prefix` + env-var fallback) |
| `template_agent/src/settings.py` | New settings: `USE_OPENAI_COMPAT_LLM`, `OPENAI_COMPAT_BASE_URL`, `OPENAI_COMPAT_MODEL`, `OPENAI_COMPAT_API_KEY`; `use_openai_compatible_llm` property; validation in `validate_config()` |
| `template_agent/src/main.py` | Skip Google GenAI credential init when OpenAI-compat mode is active |
| `pyproject.toml` | Added `langchain-openai` dependency |
| `.env.example` | Documented new env vars with usage comments |
| `README.md` | Documented MCP server settings, `tool_prefix` usage with example `mcp.json` |
| `tests/test_agent.py` | Tests for `_load_mcp_config()`: prefix scenarios, env-var fallback, SSO auth, SSL verify, sub-agent consistency |
| `tests/test_settings.py` | Tests for OpenAI-compat settings defaults, flag behavior, and validation |
