### PR TITLE
fix: bump mcp to 1.28.1 to fix CVE-2026-59950

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "langchain-google-vertexai==3.2.2",
     "langchain-openai>=0.3.0",
     "langchain-mcp-adapters==0.2.2",
-    "mcp==1.27.2",
+    "mcp>=1.28.1",
     "langfuse==4.6.1",
     "langgraph-checkpoint-postgres==3.0.5",
     "langgraph-sdk>=0.1.51",


### PR DESCRIPTION
The build-and-push image tag CI is failing due to CVE-2026-59950 being a HIGH vulnerability