### PR TITLE
fix: update compose networking and profiles for observability

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -66,7 +66,7 @@ services:
       - agent-network
 
   template-agent:
-    profiles: [container]
+    profiles: [container, observability]
     build:
       context: .
       dockerfile: Containerfile
@@ -125,7 +125,7 @@ services:
       - COLLECTOR_OTLP_ENABLED=true
     restart: unless-stopped
     networks:
-      - demo-network
+      - agent-network
 
 volumes:
   agent_pgvector_data:


### PR DESCRIPTION
Two changes in compose.yaml:  to make sure, make container works in local 
  1. Added observability profile to template-agent
  service
  2. Changed Jaeger network from demo-network to
  agent-network