### PR TITLE
feat: MCP Prefix Tool Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,26 @@ tools:
 
 See `config/agent/mcp.json` for working SSO and DCR examples.
 
+### Tool name prefix
+
+When multiple MCP servers are configured, tool names are prefixed with the
+server key (e.g. `search_mcp_prod_search_web`). Add `tool_prefix` to use a
+shorter prefix:
+
+```json
+{
+    "mcpServers": {
+        "search-mcp-prod": {
+            "url": "http://search:9090/mcp",
+            "transport": "streamable_http",
+            "enabled": true,
+            "auth": true,
+            "tool_prefix": "search"
+        }
+    }
+}
+```
+
 ## Project Structure
 
 ```

--- a/config/agent/mcp.json
+++ b/config/agent/mcp.json
@@ -8,7 +8,8 @@
             "auth": true,
             "auth_mode": "sso",
             "ssl_verify": false,
-            "timeout": 30
+            "timeout": 30,
+            "tool_prefix": "template"
         },
         "template-mcp-server-dcr": {
             "url": "http://localhost:5001/mcp",
@@ -19,6 +20,7 @@
             "auth_mode": "dcr",
             "ssl_verify": false,
             "timeout": 30,
+            "tool_prefix": "template-dcr",
             "oauth": {
                 "authorization_endpoint": "http://localhost:5001/auth/authorize",
                 // "authorization_endpoint": "http://host.containers.internal:5001/auth/authorize",
@@ -37,7 +39,8 @@
             "auth_mode": "api_key",
             "auth_env_var": "template_mcp_api_key",
             "ssl_verify": false,
-            "timeout": 30
+            "timeout": 30,
+            "tool_prefix": "template-api-key"
         }
     }
 }

--- a/deep_agent/aegra/mcp.py
+++ b/deep_agent/aegra/mcp.py
@@ -614,19 +614,20 @@ async def get_mcp_tools(
         connect_jobs = []
         placeholder_tools: list[list[Any]] = []
         for name, entry in enabled.items():
+            mcp_prefix_name = entry.get("tool_prefix") or name
             bearer = await _resolve_connection_token(name, entry, sso_token, user_id)
             auth_mode = entry.get("auth_mode", "sso")
             if auth_mode in ("oauth", "dcr") and bearer is None:
                 logger.info(
                     "[%s] No OAuth token for %s server — using auth placeholder",
-                    name,
+                    mcp_prefix_name,
                     auth_mode,
                 )
                 placeholder_tools.append([_create_auth_placeholder_tool(name)])
                 continue
             connect_jobs.append(
                 _connect_single_server(
-                    name=name,
+                    name=mcp_prefix_name,
                     config=_build_server_config(entry, bearer),
                     server_cfg=entry,
                     timeout=entry.get("timeout", 30),

--- a/tests/unit/infrastructure/test_mcp.py
+++ b/tests/unit/infrastructure/test_mcp.py
@@ -441,3 +441,98 @@ class TestGetMCPTools:
             mock_connect.assert_called_once()
             assert len(tools) == 1
             assert tools[0].name == "wanted_tool"
+
+    @pytest.mark.asyncio
+    async def test_tool_prefix_as_connection_name(self):
+        """Test that tool_prefix overrides server key for MultiServerMCPClient."""
+        _reset_mcp_cache()
+        mock_servers = {
+            "jira-mcp-prod": {
+                "url": "http://jira:9090/mcp",
+                "enabled": True,
+                "auth": False,
+                "timeout": 5,
+                "tool_prefix": "jira",
+            }
+        }
+
+        mock_tool = MagicMock()
+        mock_tool.name = "jira_search_issues"
+        mock_tool.description = "Search for JIRA issues"
+        mock_tool.parameters = {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "The search query"},
+            },
+            "required": ["query"],
+        }
+
+        with (
+            patch("deep_agent.aegra.mcp._get_server_configs") as mock_get_configs,
+            patch("deep_agent.aegra.mcp._connect_single_server") as mock_connect,
+        ):
+            mock_get_configs.return_value = mock_servers
+            mock_connect.return_value = [mock_tool]
+
+            tools = await get_mcp_tools()
+
+            assert len(tools) == 1
+            assert tools[0].name == "jira_search_issues"
+            call_kwargs = mock_connect.call_args
+            assert call_kwargs[1]["name"] == "jira"
+
+    @pytest.mark.asyncio
+    async def test_no_tool_prefix_uses_server_key(self):
+        """Test that without tool_prefix, server key is used as name."""
+        _reset_mcp_cache()
+        mock_servers = {
+            "gitlab-mcp": {
+                "url": "http://gitlab:8080/mcp",
+                "enabled": True,
+                "auth": False,
+                "timeout": 5,
+            }
+        }
+        mock_tool = MagicMock()
+        mock_tool.name = "create_issue"
+        with (
+            patch("deep_agent.aegra.mcp._get_server_configs") as mock_get_configs,
+            patch("deep_agent.aegra.mcp._connect_single_server") as mock_connect,
+        ):
+            mock_get_configs.return_value = mock_servers
+            mock_connect.return_value = [mock_tool]
+
+            await get_mcp_tools()
+
+            call_kwargs = mock_connect.call_args
+            assert call_kwargs[1]["name"] == "gitlab-mcp"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("auth_mode", ["oauth", "dcr"])
+    async def test_auth_placeholder_uses_server_key_not_prefix(self, auth_mode):
+        """OAuth/DCR server with tool_prefix should use original server key for auth."""
+        _reset_mcp_cache()
+        mock_servers = {
+            "jira-mcp-prod": {
+                "url": "http://jira:9090/mcp",
+                "enabled": True,
+                "auth": True,
+                "auth_mode": auth_mode,
+                "timeout": 5,
+                "tool_prefix": "jira",
+            }
+        }
+        with (
+            patch("deep_agent.aegra.mcp._get_server_configs") as mock_get_configs,
+            patch("deep_agent.aegra.mcp._resolve_connection_token") as mock_resolve,
+            patch(
+                "deep_agent.aegra.mcp._create_auth_placeholder_tool"
+            ) as mock_placeholder,
+        ):
+            mock_get_configs.return_value = mock_servers
+            mock_resolve.return_value = None  # no token — triggers placeholder path
+            mock_tool = MagicMock()
+            mock_tool.name = "mcp__jira_mcp_prod"
+            mock_placeholder.return_value = mock_tool
+            await get_mcp_tools()
+            mock_placeholder.assert_called_once_with("jira-mcp-prod")


### PR DESCRIPTION
## Description
<!-- What does this MR do and why? Jira: DVRS-XXXX -->
Closes #129 
Add `tool_prefix` support to the deep-agent MCP runtime. When multiple MCP servers are configured in `mcp.json`, tool names are prefixed with the server key (e.g. `search_mcp_prod_search_web`), which can be verbose. The `tool_prefix` field lets teams specify a shorter alias (e.g. `search`) so tools are exposed as `search_search_web` instead. When `tool_prefix` is omitted, existing behavior (server key as prefix) is preserved.
Companion PR: agent-engine side writes `tool_prefix` into `mcp.json` during materialization.

## Changes
- `deep_agent/aegra/mcp.py`: Read `tool_prefix` from server entry in `get_mcp_tools()` and use it as the key passed to `MultiServerMCPClient`
- `config/agent/mcp.json`: Added `tool_prefix` to all three example server entries
- `README.md`: Documented `tool_prefix` usage with example in the MCP Server Configuration section
- `tests/unit/infrastructure/test_mcp.py`: Added tests verifying prefix override and fallback behavior

## Checklist
- [x] I have reviewed my own diff
- [x] Tests pass with adequate coverage
- [x] Docs and config updated if needed
- [x] AI output verified for correctness and hallucinated dependencies