### PR TITLE
fix: Fix langfuse tracing to prevent multiple traces due to HITL

### DIFF
--- a/deep_agent/aegra/telemetry.py
+++ b/deep_agent/aegra/telemetry.py
@@ -14,6 +14,7 @@ Environment variables (Langfuse — auto-read by v4 SDK):
 
 import contextvars
 import os
+from collections import OrderedDict
 from typing import Any
 
 from deep_agent.aegra.auth import encrypt_user_id
@@ -29,6 +30,16 @@ logger = get_python_logger()
 _langfuse_tracing_initialized = False
 _token_budget_tracing_initialized = False
 _pii_initialized = False
+
+# Cap abandoned HITL open roots (never resumed / never replaced by a new message).
+# Mirrors Langfuse's MAX_PENDING_RESUME_TRACE_CONTEXTS bound.
+_MAX_OPEN_HITL_ROOTS = 1024
+
+# Process-wide Langfuse handler so HITL interrupt→resume keeps the same trace.
+# Langfuse stores pending resume context on the handler instance; a fresh
+# CallbackHandler() per run (register_configure_hook default) drops that state.
+_shared_langfuse_handler: Any | None = None
+HitlAwareCallbackHandler: Any | None = None
 
 
 def _get_trace_name() -> str:
@@ -96,22 +107,262 @@ def setup_pii_middleware() -> None:
         logger.warning("Failed to initialise PII middleware", exc_info=True)
 
 
+def _build_hitl_aware_handler_class() -> type:
+    """Build CallbackHandler that keeps one orchestrator span across HITL resume.
+
+    LangGraph soft-interrupts end the root chain run, so upstream Langfuse opens
+    a new ``orchestrator`` root on every approve. We instead:
+
+    1. On nested ``GraphInterrupt``, remember the root observation by thread_id
+       and mark that root run to stay open.
+    2. On root ``on_chain_end`` for an interrupted run, update output but do
+       **not** call ``span.end()``.
+    3. On ``Command(resume=...)`` root ``on_chain_start``, rebind the new
+       LangChain run_id to the open observation (no new root span). Children
+       then attach under the original orchestrator.
+    """
+    from uuid import UUID
+
+    from langfuse import propagate_attributes
+    from langfuse.langchain import CallbackHandler
+
+    try:
+        from langgraph.errors import GraphInterrupt as _GraphInterrupt
+    except ImportError:  # pragma: no cover - langgraph always present in runtime
+        _GraphInterrupt = None
+
+    class _HitlAwareCallbackHandler(CallbackHandler):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+            # thread_id → still-open root observation across HITL pauses (LRU)
+            self._open_hitl_roots: OrderedDict[str, Any] = OrderedDict()
+            # root run_ids that must skip span.end() on on_chain_end
+            self._keep_open_root_run_ids: set[UUID] = set()
+
+        def _store_open_hitl_root(self, resume_key: str, root_obs: Any) -> None:
+            """Remember an open root, evicting the oldest if over the cap."""
+            previous = self._open_hitl_roots.get(resume_key)
+            if previous is not None and previous is not root_obs:
+                try:
+                    previous.end()
+                except Exception:
+                    logger.warning(
+                        "Failed to end replaced HITL open root", exc_info=True
+                    )
+            if resume_key in self._open_hitl_roots:
+                self._open_hitl_roots.move_to_end(resume_key)
+            self._open_hitl_roots[resume_key] = root_obs
+            while len(self._open_hitl_roots) > _MAX_OPEN_HITL_ROOTS:
+                _, evicted = self._open_hitl_roots.popitem(last=False)
+                try:
+                    evicted.end()
+                except Exception:
+                    logger.warning(
+                        "Failed to end evicted HITL open root", exc_info=True
+                    )
+
+        def on_chain_error(
+            self,
+            error: BaseException,
+            *,
+            run_id: UUID,
+            parent_run_id: UUID | None = None,
+            **kwargs: Any,
+        ) -> None:
+            root_run_id: UUID | None = None
+            root_obs: Any | None = None
+            resume_key: str | None = None
+            # Capture before super() — root hard errors clear resume_key upstream.
+            stale_resume_key: str | None = None
+            if parent_run_id is None:
+                root_state = self._get_root_run_state(run_id)
+                if root_state is not None:
+                    stale_resume_key = root_state.resume_key
+
+            # Only HITL GraphInterrupt — not ParentCommand / other GraphBubbleUp.
+            if (
+                parent_run_id is not None
+                and _GraphInterrupt is not None
+                and isinstance(error, _GraphInterrupt)
+            ):
+                state = self._get_run_state(run_id)
+                if state is not None:
+                    root_run_id = state.root_run_id
+                    root_obs = self._runs.get(root_run_id)
+                    root_state = self._root_run_states.get(root_run_id)
+                    if root_state is not None:
+                        resume_key = root_state.resume_key
+
+            super().on_chain_error(
+                error, run_id=run_id, parent_run_id=parent_run_id, **kwargs
+            )
+
+            if (
+                root_run_id is not None
+                and root_obs is not None
+                and resume_key is not None
+            ):
+                self._store_open_hitl_root(resume_key, root_obs)
+                self._keep_open_root_run_ids.add(root_run_id)
+            elif stale_resume_key is not None:
+                # Root hard failure: never leave a dead obs for the next resume.
+                self._open_hitl_roots.pop(stale_resume_key, None)
+
+        def on_chain_end(
+            self,
+            outputs: dict[str, Any],
+            *,
+            run_id: UUID,
+            parent_run_id: UUID | None = None,
+            **kwargs: Any,
+        ) -> Any:
+            # Interrupted root: keep the Langfuse observation open for resume.
+            if parent_run_id is None and run_id in self._keep_open_root_run_ids:
+                try:
+                    span = self._detach_observation(run_id)
+                    if span is not None:
+                        span.update(
+                            output=outputs,
+                            input=kwargs.get("inputs"),
+                        )
+                        self._deregister_langfuse_prompt(run_id)
+                    self._clear_root_run_resume_key(run_id)
+                    self._exit_propagation_context(run_id)
+                except Exception:
+                    logger.warning("HITL open-root on_chain_end failed", exc_info=True)
+                finally:
+                    self._keep_open_root_run_ids.discard(run_id)
+                    if parent_run_id is None:
+                        self._exit_propagation_context(run_id)
+                        self._reset(run_id)
+                return None
+
+            # Final (or non-HITL) root end — drop open-root bookkeeping first.
+            if parent_run_id is None:
+                root_state = self._get_root_run_state(run_id)
+                if root_state is not None and root_state.resume_key is not None:
+                    self._open_hitl_roots.pop(root_state.resume_key, None)
+                self._keep_open_root_run_ids.discard(run_id)
+
+            return super().on_chain_end(
+                outputs, run_id=run_id, parent_run_id=parent_run_id, **kwargs
+            )
+
+        def on_chain_start(
+            self,
+            serialized: dict[str, Any] | None,
+            inputs: Any,
+            *,
+            run_id: UUID,
+            parent_run_id: UUID | None = None,
+            tags: list[str] | None = None,
+            metadata: dict[str, Any] | None = None,
+            **kwargs: Any,
+        ) -> Any:
+            # New user message while a HITL root is still open → close it.
+            if parent_run_id is None and not self._is_langgraph_resume(inputs):
+                stale_key = self._get_langgraph_resume_key(metadata)
+                if stale_key is not None:
+                    stale = self._open_hitl_roots.pop(stale_key, None)
+                    if stale is not None:
+                        try:
+                            stale.end()
+                        except Exception:
+                            logger.warning(
+                                "Failed to end stale HITL open root", exc_info=True
+                            )
+
+            # Resume: reuse the open orchestrator observation (no new root span).
+            if parent_run_id is None and self._is_langgraph_resume(inputs):
+                resume_key = self._get_langgraph_resume_key(metadata)
+                open_obs = (
+                    self._open_hitl_roots.get(resume_key)
+                    if resume_key is not None
+                    else None
+                )
+                if open_obs is not None:
+                    self._track_run(
+                        run_id=run_id, parent_run_id=None, metadata=metadata
+                    )
+                    try:
+                        parsed = self._parse_langfuse_trace_attributes(
+                            metadata=metadata, tags=tags
+                        )
+                        propagation_context_manager = propagate_attributes(
+                            user_id=parsed.get("user_id", None),
+                            session_id=parsed.get("session_id", None),
+                            tags=parsed.get("tags", None),
+                            metadata=parsed.get("metadata", None),
+                            trace_name=parsed.get("trace_name", None),
+                        )
+                        root_run_state = self._get_root_run_state(run_id)
+                        if root_run_state is not None:
+                            root_run_state.propagation_context_manager = (
+                                propagation_context_manager
+                            )
+                        propagation_context_manager.__enter__()
+                        self._attach_observation(run_id, open_obs)
+                        trace_id = getattr(open_obs, "trace_id", None)
+                        if isinstance(trace_id, str):
+                            self.last_trace_id = trace_id
+                        # Ownership moves to _runs for this invoke; map stays empty
+                        # until a later nested GraphInterrupt re-stores.
+                        if resume_key is not None:
+                            self._open_hitl_roots.pop(resume_key, None)
+                        return None
+                    except Exception:
+                        self._exit_propagation_context(run_id)
+                        self._reset(run_id)
+                        if resume_key is not None:
+                            failed = self._open_hitl_roots.pop(resume_key, None)
+                            if failed is not None:
+                                try:
+                                    failed.end()
+                                except Exception:
+                                    logger.warning(
+                                        "Failed to end open root after rebind failure",
+                                        exc_info=True,
+                                    )
+                        logger.warning(
+                            "HITL open-root resume rebind failed; "
+                            "falling back to new root span",
+                            exc_info=True,
+                        )
+                        # Fall through to super().on_chain_start.
+
+            return super().on_chain_start(
+                serialized,
+                inputs,
+                run_id=run_id,
+                parent_run_id=parent_run_id,
+                tags=tags,
+                metadata=metadata,
+                **kwargs,
+            )
+
+    _HitlAwareCallbackHandler.__name__ = "HitlAwareCallbackHandler"
+    _HitlAwareCallbackHandler.__qualname__ = "HitlAwareCallbackHandler"
+    return _HitlAwareCallbackHandler
+
+
 def setup_langfuse_tracing() -> None:
     """Register Langfuse as a global LangChain callback and Aegra observability provider.
 
     Two mechanisms work together:
 
-    1. ``register_configure_hook`` — the same mechanism LangSmith uses to
-       auto-inject its tracer. Creates a fresh ``CallbackHandler()`` per run.
+    1. ``register_configure_hook`` — injects a **process-wide** HITL-aware
+       ``CallbackHandler`` so interrupt→resume keeps the same Langfuse trace.
     2. ``LangfuseObservabilityProvider`` — plugs into Aegra's
        ``ObservabilityManager`` so that ``create_run_config`` injects
-       ``langfuse_user_id``, ``langfuse_session_id``, and
+       ``langfuse_user_id``, ``langfuse_session_id``, ``thread_id``, and
        ``langfuse_trace_name`` into ``RunnableConfig.metadata``.
        The CallbackHandler reads these automatically.
 
     Must be called **once** at process startup. Subsequent calls are no-ops.
     """
     global _langfuse_tracing_initialized
+    global _shared_langfuse_handler
+    global HitlAwareCallbackHandler
     if _langfuse_tracing_initialized:
         return
     _langfuse_tracing_initialized = True
@@ -122,7 +373,6 @@ def setup_langfuse_tracing() -> None:
 
     try:
         from langchain_core.tracers.context import register_configure_hook
-        from langfuse.langchain import CallbackHandler
 
         from deep_agent.src.pii import get_scrubber as _get_scrubber
 
@@ -160,17 +410,19 @@ def setup_langfuse_tracing() -> None:
                     "Failed to register Langfuse mask_otel_spans", exc_info=True
                 )
 
+        HitlAwareCallbackHandler = _build_hitl_aware_handler_class()
+        _shared_langfuse_handler = HitlAwareCallbackHandler()
+
+        # ContextVar default makes every request context see the same handler
+        # without needing env-var-gated fresh construction.
         _langfuse_ctx_var: contextvars.ContextVar = contextvars.ContextVar(
-            "langfuse_handler", default=None
+            "langfuse_handler", default=_shared_langfuse_handler
         )
 
-        register_configure_hook(
-            _langfuse_ctx_var,
-            True,
-            CallbackHandler,
-            env_var="LANGFUSE_PUBLIC_KEY",
+        register_configure_hook(_langfuse_ctx_var, True)
+        logger.info(
+            "Langfuse auto-tracing registered (shared HITL-aware handler for interrupt/resume)"
         )
-        logger.info("Langfuse auto-tracing registered for all LangChain runs")
     except ImportError:
         logger.warning(
             "langfuse or langchain_core not available — auto-tracing disabled"
@@ -202,6 +454,7 @@ class LangfuseObservabilityProvider:
 
     - ``langfuse_user_id`` — who triggered the run
     - ``langfuse_session_id`` — groups traces by conversation (thread)
+    - ``thread_id`` — Langfuse resume-key for HITL interrupt→resume stitching
     - ``langfuse_trace_name`` — human-readable trace name in the UI
     """
 
@@ -222,6 +475,8 @@ class LangfuseObservabilityProvider:
             metadata["langfuse_user_id"] = encrypt_user_id(user_identity)
         if thread_id:
             metadata["langfuse_session_id"] = thread_id
+            # Langfuse keys pending resume context by metadata["thread_id"].
+            metadata["thread_id"] = thread_id
         trace_id = _trace_id_var.get()
         if trace_id:
             metadata["langfuse_tags"] = [f"trace_id:{trace_id}"]

--- a/tests/unit/aegra/test_telemetry_hitl_trace.py
+++ b/tests/unit/aegra/test_telemetry_hitl_trace.py
@@ -1,0 +1,415 @@
+"""Unit tests for Langfuse HITL single-flow (open-root) tracing."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from deep_agent.aegra import telemetry as telemetry_mod
+from deep_agent.aegra.telemetry import (
+    LangfuseObservabilityProvider,
+    _build_hitl_aware_handler_class,
+)
+
+
+@pytest.fixture()
+def hitl_handler_class():
+    """Build the HITL-aware handler class (requires langfuse installed)."""
+    return _build_hitl_aware_handler_class()
+
+
+def _mock_root_obs() -> MagicMock:
+    obs = MagicMock()
+    obs.trace_id = "a" * 32
+    obs.id = "b" * 16
+    obs._otel_span = MagicMock()
+    return obs
+
+
+class TestHitlAwareCallbackHandler:
+    def test_interrupt_keeps_root_span_open(self, hitl_handler_class):
+        """Nested GraphInterrupt must not end the root orchestrator observation."""
+        pytest.importorskip("langgraph")
+        from langgraph.errors import GraphInterrupt
+
+        handler = hitl_handler_class()
+        root_id, child_id = uuid4(), uuid4()
+        handler._track_run(
+            run_id=root_id, parent_run_id=None, metadata={"thread_id": "t1"}
+        )
+        handler._track_run(
+            run_id=child_id, parent_run_id=root_id, metadata={"thread_id": "t1"}
+        )
+        root_obs = _mock_root_obs()
+        handler._runs[root_id] = root_obs
+
+        handler.on_chain_error(
+            GraphInterrupt(()), run_id=child_id, parent_run_id=root_id
+        )
+        assert handler._open_hitl_roots["t1"] is root_obs
+        assert root_id in handler._keep_open_root_run_ids
+
+        handler.on_chain_end({"ok": True}, run_id=root_id, parent_run_id=None)
+
+        root_obs.end.assert_not_called()
+        assert handler._open_hitl_roots["t1"] is root_obs
+        assert root_id not in handler._runs  # detached from this invoke
+        assert root_id not in handler._keep_open_root_run_ids
+
+    def test_resume_rebinds_to_open_root_without_new_span(self, hitl_handler_class):
+        """Command(resume=...) must reuse the open observation, not start a new root."""
+        pytest.importorskip("langgraph")
+        from langgraph.errors import GraphInterrupt
+        from langgraph.types import Command
+
+        handler = hitl_handler_class()
+        root_id, child_id, resume_id = uuid4(), uuid4(), uuid4()
+        handler._track_run(
+            run_id=root_id, parent_run_id=None, metadata={"thread_id": "t1"}
+        )
+        handler._track_run(
+            run_id=child_id, parent_run_id=root_id, metadata={"thread_id": "t1"}
+        )
+        root_obs = _mock_root_obs()
+        handler._runs[root_id] = root_obs
+
+        handler.on_chain_error(
+            GraphInterrupt(()), run_id=child_id, parent_run_id=root_id
+        )
+        handler.on_chain_end({}, run_id=root_id, parent_run_id=None)
+
+        with (
+            patch.object(handler, "_attach_observation") as attach,
+            patch.object(
+                handler,
+                "_langfuse_client",
+                MagicMock(start_observation=MagicMock()),
+            ),
+        ):
+            # Make attach actually bind like production for the assertion below.
+            def _attach(run_id, observation):
+                handler._runs[run_id] = observation
+
+            attach.side_effect = _attach
+
+            handler.on_chain_start(
+                {"name": "orchestrator"},
+                Command(resume={"decisions": [{"type": "approve"}]}),
+                run_id=resume_id,
+                parent_run_id=None,
+                metadata={"thread_id": "t1"},
+            )
+
+            attach.assert_called_once()
+            assert attach.call_args.args[1] is root_obs
+            handler._langfuse_client.start_observation.assert_not_called()
+            assert handler._runs[resume_id] is root_obs
+            # Ownership moves to _runs; map must not keep a zombie handle.
+            assert "t1" not in handler._open_hitl_roots
+
+    def test_final_end_closes_open_root(self, hitl_handler_class):
+        """A completing root invoke must end the open observation and clear state."""
+        pytest.importorskip("langgraph")
+        from langgraph.errors import GraphInterrupt
+        from langgraph.types import Command
+
+        handler = hitl_handler_class()
+        root_id, child_id, resume_id = uuid4(), uuid4(), uuid4()
+        handler._track_run(
+            run_id=root_id, parent_run_id=None, metadata={"thread_id": "t1"}
+        )
+        handler._track_run(
+            run_id=child_id, parent_run_id=root_id, metadata={"thread_id": "t1"}
+        )
+        root_obs = _mock_root_obs()
+        handler._runs[root_id] = root_obs
+
+        handler.on_chain_error(
+            GraphInterrupt(()), run_id=child_id, parent_run_id=root_id
+        )
+        handler.on_chain_end({}, run_id=root_id, parent_run_id=None)
+
+        def _attach(run_id, observation):
+            handler._runs[run_id] = observation
+            handler._context_tokens[run_id] = MagicMock()
+
+        with patch.object(handler, "_attach_observation", side_effect=_attach):
+            handler.on_chain_start(
+                {"name": "orchestrator"},
+                Command(resume={"decisions": [{"type": "approve"}]}),
+                run_id=resume_id,
+                parent_run_id=None,
+                metadata={"thread_id": "t1"},
+            )
+
+        handler.on_chain_end({"done": True}, run_id=resume_id, parent_run_id=None)
+
+        root_obs.end.assert_called()
+        assert "t1" not in handler._open_hitl_roots
+
+    def test_fresh_message_ends_stale_open_root(self, hitl_handler_class):
+        """A new user message must close a leftover open HITL root for that thread."""
+        handler = hitl_handler_class()
+        stale = _mock_root_obs()
+        handler._open_hitl_roots["t1"] = stale
+
+        with patch.object(
+            handler.__class__.__bases__[0],
+            "on_chain_start",
+            return_value=None,
+        ) as super_start:
+            handler.on_chain_start(
+                {"name": "orchestrator"},
+                {"messages": [{"role": "user", "content": "hi"}]},
+                run_id=uuid4(),
+                parent_run_id=None,
+                metadata={"thread_id": "t1"},
+            )
+            super_start.assert_called_once()
+
+        stale.end.assert_called_once()
+        assert "t1" not in handler._open_hitl_roots
+
+    def test_separate_handler_instances_do_not_share_open_roots(
+        self, hitl_handler_class
+    ):
+        """Documents why setup_langfuse_tracing must reuse one handler instance."""
+        a = hitl_handler_class()
+        b = hitl_handler_class()
+        obs = _mock_root_obs()
+        a._open_hitl_roots["t"] = obs
+        assert "t" not in b._open_hitl_roots
+
+    def test_parent_command_does_not_keep_root_open(self, hitl_handler_class):
+        """Nested ParentCommand must not mark the orchestrator as an open HITL root."""
+        pytest.importorskip("langgraph")
+        from langgraph.errors import ParentCommand
+        from langgraph.types import Command
+
+        handler = hitl_handler_class()
+        root_id, child_id = uuid4(), uuid4()
+        handler._track_run(
+            run_id=root_id, parent_run_id=None, metadata={"thread_id": "t1"}
+        )
+        handler._track_run(
+            run_id=child_id, parent_run_id=root_id, metadata={"thread_id": "t1"}
+        )
+        root_obs = _mock_root_obs()
+        handler._runs[root_id] = root_obs
+
+        handler.on_chain_error(
+            ParentCommand(Command()), run_id=child_id, parent_run_id=root_id
+        )
+
+        assert "t1" not in handler._open_hitl_roots
+        assert root_id not in handler._keep_open_root_run_ids
+
+    def test_resume_rebind_failure_falls_back_to_super(self, hitl_handler_class):
+        """If open-root rebind fails, resume must still open a normal Langfuse root."""
+        pytest.importorskip("langgraph")
+        from langgraph.types import Command
+
+        handler = hitl_handler_class()
+        resume_id = uuid4()
+        open_obs = _mock_root_obs()
+        handler._open_hitl_roots["t1"] = open_obs
+
+        with (
+            patch.object(
+                handler, "_attach_observation", side_effect=RuntimeError("boom")
+            ),
+            patch.object(
+                handler.__class__.__bases__[0],
+                "on_chain_start",
+                return_value=None,
+            ) as super_start,
+        ):
+            handler.on_chain_start(
+                {"name": "orchestrator"},
+                Command(resume={"decisions": [{"type": "approve"}]}),
+                run_id=resume_id,
+                parent_run_id=None,
+                metadata={"thread_id": "t1"},
+            )
+
+            super_start.assert_called_once()
+
+        open_obs.end.assert_called_once()
+        assert "t1" not in handler._open_hitl_roots
+
+    def test_open_hitl_roots_evicts_oldest_when_over_cap(self, hitl_handler_class):
+        """Abandoned open roots must be ended once the LRU cap is exceeded."""
+        handler = hitl_handler_class()
+        oldest = _mock_root_obs()
+        middle = _mock_root_obs()
+        newest = _mock_root_obs()
+
+        with patch.object(telemetry_mod, "_MAX_OPEN_HITL_ROOTS", 2):
+            handler._store_open_hitl_root("t1", oldest)
+            handler._store_open_hitl_root("t2", middle)
+            handler._store_open_hitl_root("t3", newest)
+
+        assert "t1" not in handler._open_hitl_roots
+        assert handler._open_hitl_roots["t2"] is middle
+        assert handler._open_hitl_roots["t3"] is newest
+        oldest.end.assert_called_once()
+        middle.end.assert_not_called()
+        newest.end.assert_not_called()
+
+    def test_store_replaces_different_obs_ends_previous(self, hitl_handler_class):
+        """Overwriting the same thread key must end a different prior observation."""
+        handler = hitl_handler_class()
+        first = _mock_root_obs()
+        second = _mock_root_obs()
+        handler._store_open_hitl_root("t1", first)
+        handler._store_open_hitl_root("t1", second)
+
+        first.end.assert_called_once()
+        second.end.assert_not_called()
+        assert handler._open_hitl_roots["t1"] is second
+
+    def test_resume_hard_error_clears_open_root_for_next_resume(
+        self, hitl_handler_class
+    ):
+        """Hard error after approve must not leave a dead obs for the next resume."""
+        pytest.importorskip("langgraph")
+        from langgraph.errors import GraphInterrupt
+        from langgraph.types import Command
+
+        handler = hitl_handler_class()
+        root_id, child_id, resume_id, resume2_id = (
+            uuid4(),
+            uuid4(),
+            uuid4(),
+            uuid4(),
+        )
+        handler._track_run(
+            run_id=root_id, parent_run_id=None, metadata={"thread_id": "t1"}
+        )
+        handler._track_run(
+            run_id=child_id, parent_run_id=root_id, metadata={"thread_id": "t1"}
+        )
+        root_obs = _mock_root_obs()
+        handler._runs[root_id] = root_obs
+
+        handler.on_chain_error(
+            GraphInterrupt(()), run_id=child_id, parent_run_id=root_id
+        )
+        handler.on_chain_end({}, run_id=root_id, parent_run_id=None)
+
+        def _attach(run_id, observation):
+            handler._runs[run_id] = observation
+            handler._context_tokens[run_id] = MagicMock()
+
+        with patch.object(handler, "_attach_observation", side_effect=_attach):
+            handler.on_chain_start(
+                {"name": "orchestrator"},
+                Command(resume={"decisions": [{"type": "approve"}]}),
+                run_id=resume_id,
+                parent_run_id=None,
+                metadata={"thread_id": "t1"},
+            )
+
+        assert "t1" not in handler._open_hitl_roots
+
+        # Simulate a leftover map entry (pre-pop bug / race), then root hard error.
+        handler._open_hitl_roots["t1"] = root_obs
+        handler.on_chain_error(
+            RuntimeError("tool failed"), run_id=resume_id, parent_run_id=None
+        )
+        assert "t1" not in handler._open_hitl_roots
+
+        with (
+            patch.object(handler, "_attach_observation") as attach,
+            patch.object(
+                handler.__class__.__bases__[0],
+                "on_chain_start",
+                return_value=None,
+            ) as super_start,
+        ):
+            handler.on_chain_start(
+                {"name": "orchestrator"},
+                Command(resume={"decisions": [{"type": "approve"}]}),
+                run_id=resume2_id,
+                parent_run_id=None,
+                metadata={"thread_id": "t1"},
+            )
+            attach.assert_not_called()
+            super_start.assert_called_once()
+
+    def test_second_hitl_in_same_thread_reopens_after_rebind(self, hitl_handler_class):
+        """Pop-on-rebind must still allow a later nested GraphInterrupt to keep-open."""
+        pytest.importorskip("langgraph")
+        from langgraph.errors import GraphInterrupt
+        from langgraph.types import Command
+
+        handler = hitl_handler_class()
+        root_id, child_id, resume_id, child2_id = (
+            uuid4(),
+            uuid4(),
+            uuid4(),
+            uuid4(),
+        )
+        handler._track_run(
+            run_id=root_id, parent_run_id=None, metadata={"thread_id": "t1"}
+        )
+        handler._track_run(
+            run_id=child_id, parent_run_id=root_id, metadata={"thread_id": "t1"}
+        )
+        root_obs = _mock_root_obs()
+        handler._runs[root_id] = root_obs
+
+        handler.on_chain_error(
+            GraphInterrupt(()), run_id=child_id, parent_run_id=root_id
+        )
+        handler.on_chain_end({}, run_id=root_id, parent_run_id=None)
+
+        def _attach(run_id, observation):
+            handler._runs[run_id] = observation
+            handler._context_tokens[run_id] = MagicMock()
+
+        with patch.object(handler, "_attach_observation", side_effect=_attach):
+            handler.on_chain_start(
+                {"name": "orchestrator"},
+                Command(resume={"decisions": [{"type": "approve"}]}),
+                run_id=resume_id,
+                parent_run_id=None,
+                metadata={"thread_id": "t1"},
+            )
+
+        assert "t1" not in handler._open_hitl_roots
+        assert handler._runs[resume_id] is root_obs
+
+        handler._track_run(
+            run_id=child2_id, parent_run_id=resume_id, metadata={"thread_id": "t1"}
+        )
+        handler.on_chain_error(
+            GraphInterrupt(()), run_id=child2_id, parent_run_id=resume_id
+        )
+        assert handler._open_hitl_roots["t1"] is root_obs
+        assert resume_id in handler._keep_open_root_run_ids
+
+        handler.on_chain_end({}, run_id=resume_id, parent_run_id=None)
+        root_obs.end.assert_not_called()
+        assert handler._open_hitl_roots["t1"] is root_obs
+
+
+class TestLangfuseObservabilityProviderMetadata:
+    def test_includes_thread_id_for_resume_key(self):
+        provider = LangfuseObservabilityProvider()
+        with patch.object(
+            LangfuseObservabilityProvider,
+            "is_enabled",
+            return_value=True,
+        ):
+            metadata = provider.get_metadata(
+                run_id="run-1",
+                thread_id="thread-abc",
+                user_identity=None,
+            )
+
+        assert metadata["langfuse_session_id"] == "thread-abc"
+        assert metadata["thread_id"] == "thread-abc"
+        assert "langfuse_trace_name" in metadata

--- a/tests/unit/aegra/test_telemetry_hitl_trace.py
+++ b/tests/unit/aegra/test_telemetry_hitl_trace.py
@@ -395,6 +395,173 @@ class TestHitlAwareCallbackHandler:
         root_obs.end.assert_not_called()
         assert handler._open_hitl_roots["t1"] is root_obs
 
+    def test_store_replace_end_failure_is_swallowed(self, hitl_handler_class):
+        """Replacing a key must continue even if ending the prior obs fails."""
+        handler = hitl_handler_class()
+        first = _mock_root_obs()
+        first.end.side_effect = RuntimeError("end failed")
+        second = _mock_root_obs()
+
+        handler._store_open_hitl_root("t1", first)
+        handler._store_open_hitl_root("t1", second)
+
+        assert handler._open_hitl_roots["t1"] is second
+        first.end.assert_called_once()
+
+    def test_store_evict_end_failure_is_swallowed(self, hitl_handler_class):
+        """LRU eviction must continue even if ending the evicted obs fails."""
+        handler = hitl_handler_class()
+        oldest = _mock_root_obs()
+        oldest.end.side_effect = RuntimeError("end failed")
+        newest = _mock_root_obs()
+
+        with patch.object(telemetry_mod, "_MAX_OPEN_HITL_ROOTS", 1):
+            handler._store_open_hitl_root("t1", oldest)
+            handler._store_open_hitl_root("t2", newest)
+
+        assert "t1" not in handler._open_hitl_roots
+        assert handler._open_hitl_roots["t2"] is newest
+        oldest.end.assert_called_once()
+
+    def test_keep_open_on_chain_end_failure_still_clears_keep_open_set(
+        self, hitl_handler_class
+    ):
+        """keep-open on_chain_end errors must still discard bookkeeping in finally."""
+        pytest.importorskip("langgraph")
+        from langgraph.errors import GraphInterrupt
+
+        handler = hitl_handler_class()
+        root_id, child_id = uuid4(), uuid4()
+        handler._track_run(
+            run_id=root_id, parent_run_id=None, metadata={"thread_id": "t1"}
+        )
+        handler._track_run(
+            run_id=child_id, parent_run_id=root_id, metadata={"thread_id": "t1"}
+        )
+        root_obs = _mock_root_obs()
+        handler._runs[root_id] = root_obs
+
+        handler.on_chain_error(
+            GraphInterrupt(()), run_id=child_id, parent_run_id=root_id
+        )
+        assert root_id in handler._keep_open_root_run_ids
+
+        with patch.object(
+            handler, "_detach_observation", side_effect=RuntimeError("detach boom")
+        ):
+            handler.on_chain_end({"ok": True}, run_id=root_id, parent_run_id=None)
+
+        assert root_id not in handler._keep_open_root_run_ids
+        assert handler._open_hitl_roots["t1"] is root_obs
+
+    def test_stale_open_root_end_failure_is_swallowed(self, hitl_handler_class):
+        """A new user message must proceed even if ending the stale root fails."""
+        handler = hitl_handler_class()
+        stale = _mock_root_obs()
+        stale.end.side_effect = RuntimeError("end failed")
+        handler._open_hitl_roots["t1"] = stale
+
+        with patch.object(
+            handler.__class__.__bases__[0],
+            "on_chain_start",
+            return_value=None,
+        ) as super_start:
+            handler.on_chain_start(
+                {"name": "orchestrator"},
+                {"messages": [{"role": "user", "content": "hi"}]},
+                run_id=uuid4(),
+                parent_run_id=None,
+                metadata={"thread_id": "t1"},
+            )
+            super_start.assert_called_once()
+
+        stale.end.assert_called_once()
+        assert "t1" not in handler._open_hitl_roots
+
+    def test_resume_rebind_failure_end_failure_still_falls_back(
+        self, hitl_handler_class
+    ):
+        """If rebind fails and ending the open root also fails, still call super()."""
+        pytest.importorskip("langgraph")
+        from langgraph.types import Command
+
+        handler = hitl_handler_class()
+        resume_id = uuid4()
+        open_obs = _mock_root_obs()
+        open_obs.end.side_effect = RuntimeError("end failed")
+        handler._open_hitl_roots["t1"] = open_obs
+
+        with (
+            patch.object(
+                handler, "_attach_observation", side_effect=RuntimeError("boom")
+            ),
+            patch.object(
+                handler.__class__.__bases__[0],
+                "on_chain_start",
+                return_value=None,
+            ) as super_start,
+        ):
+            handler.on_chain_start(
+                {"name": "orchestrator"},
+                Command(resume={"decisions": [{"type": "approve"}]}),
+                run_id=resume_id,
+                parent_run_id=None,
+                metadata={"thread_id": "t1"},
+            )
+            super_start.assert_called_once()
+
+        open_obs.end.assert_called_once()
+        assert "t1" not in handler._open_hitl_roots
+
+    def test_keep_open_on_chain_end_when_detach_returns_none(self, hitl_handler_class):
+        """keep-open path must clear state even when there is no span to update."""
+        pytest.importorskip("langgraph")
+        from langgraph.errors import GraphInterrupt
+
+        handler = hitl_handler_class()
+        root_id, child_id = uuid4(), uuid4()
+        handler._track_run(
+            run_id=root_id, parent_run_id=None, metadata={"thread_id": "t1"}
+        )
+        handler._track_run(
+            run_id=child_id, parent_run_id=root_id, metadata={"thread_id": "t1"}
+        )
+        root_obs = _mock_root_obs()
+        handler._runs[root_id] = root_obs
+        handler.on_chain_error(
+            GraphInterrupt(()), run_id=child_id, parent_run_id=root_id
+        )
+
+        with patch.object(handler, "_detach_observation", return_value=None):
+            handler.on_chain_end({}, run_id=root_id, parent_run_id=None)
+
+        assert root_id not in handler._keep_open_root_run_ids
+        assert handler._open_hitl_roots["t1"] is root_obs
+
+    def test_resume_rebind_skips_non_string_trace_id(self, hitl_handler_class):
+        """Non-string observation.trace_id must not overwrite last_trace_id."""
+        pytest.importorskip("langgraph")
+        from langgraph.types import Command
+
+        handler = hitl_handler_class()
+        resume_id = uuid4()
+        open_obs = _mock_root_obs()
+        open_obs.trace_id = 12345  # not a str
+        handler._open_hitl_roots["t1"] = open_obs
+        handler.last_trace_id = "keep-me"
+
+        with patch.object(handler, "_attach_observation"):
+            handler.on_chain_start(
+                {"name": "orchestrator"},
+                Command(resume={"decisions": [{"type": "approve"}]}),
+                run_id=resume_id,
+                parent_run_id=None,
+                metadata={"thread_id": "t1"},
+            )
+
+        assert handler.last_trace_id == "keep-me"
+        assert "t1" not in handler._open_hitl_roots
+
 
 class TestLangfuseObservabilityProviderMetadata:
     def test_includes_thread_id_for_resume_key(self):
@@ -413,3 +580,80 @@ class TestLangfuseObservabilityProviderMetadata:
         assert metadata["langfuse_session_id"] == "thread-abc"
         assert metadata["thread_id"] == "thread-abc"
         assert "langfuse_trace_name" in metadata
+
+    def test_includes_encrypted_user_id_and_trace_tag(self):
+        provider = LangfuseObservabilityProvider()
+        with (
+            patch.object(
+                LangfuseObservabilityProvider,
+                "is_enabled",
+                return_value=True,
+            ),
+            patch(
+                "deep_agent.aegra.telemetry.encrypt_user_id",
+                return_value="hashed-user",
+            ),
+            patch("deep_agent.utils.pylogger._trace_id_var") as trace_var,
+        ):
+            trace_var.get.return_value = "app-trace-1"
+            metadata = provider.get_metadata(
+                run_id="run-1",
+                thread_id="thread-abc",
+                user_identity="user-1",
+            )
+
+        assert metadata["langfuse_user_id"] == "hashed-user"
+        assert metadata["thread_id"] == "thread-abc"
+        assert metadata["langfuse_tags"] == ["trace_id:app-trace-1"]
+
+
+class TestSetupLangfuseSharedHandler:
+    def test_registers_process_wide_hitl_aware_handler(self, monkeypatch):
+        """setup_langfuse_tracing must inject one shared HITL-aware handler."""
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+
+        prev_initialized = telemetry_mod._langfuse_tracing_initialized
+        prev_shared = telemetry_mod._shared_langfuse_handler
+        prev_cls = telemetry_mod.HitlAwareCallbackHandler
+        telemetry_mod._langfuse_tracing_initialized = False
+        telemetry_mod._shared_langfuse_handler = None
+        telemetry_mod.HitlAwareCallbackHandler = None
+
+        register = MagicMock()
+        manager = MagicMock()
+
+        try:
+            with (
+                patch(
+                    "langchain_core.tracers.context.register_configure_hook",
+                    register,
+                ),
+                patch(
+                    "deep_agent.src.pii.get_scrubber",
+                    return_value=None,
+                ),
+                patch(
+                    "aegra_api.observability.base.get_observability_manager",
+                    return_value=manager,
+                ),
+            ):
+                telemetry_mod.setup_langfuse_tracing()
+
+            assert telemetry_mod.HitlAwareCallbackHandler is not None
+            assert telemetry_mod._shared_langfuse_handler is not None
+            assert isinstance(
+                telemetry_mod._shared_langfuse_handler,
+                telemetry_mod.HitlAwareCallbackHandler,
+            )
+            register.assert_called_once()
+            # ContextVar default must be the shared handler (no per-run factory).
+            ctx_var = register.call_args.args[0]
+            assert ctx_var.get() is telemetry_mod._shared_langfuse_handler
+            assert register.call_args.args[1] is True
+            assert len(register.call_args.args) == 2
+            manager.register_provider.assert_called_once()
+        finally:
+            telemetry_mod._langfuse_tracing_initialized = prev_initialized
+            telemetry_mod._shared_langfuse_handler = prev_shared
+            telemetry_mod.HitlAwareCallbackHandler = prev_cls


### PR DESCRIPTION
## Problem

Human-in-the-loop (HITL) tool approval paused the agent via LangGraph soft-interrupt (`HumanInTheLoopMiddleware.after_model` → `interrupt()`). Each approve/`Command(resume=...)` opened a **new** Langfuse `orchestrator` root span (often a new `trace_id`), so one user turn appeared as multiple disconnected traces instead of a single continuous flow.

Root causes:
- A fresh Langfuse `CallbackHandler` per run dropped in-memory resume state.
- Soft-interrupts end the root chain with `on_chain_end` (not root `on_chain_error`), so upstream Langfuse resume stitching never ran for this path.

## Solution

Introduce a process-wide `HitlAwareCallbackHandler` that keeps one open Langfuse orchestrator observation across HITL:

1. On nested `GraphInterrupt`, remember the root observation by `thread_id` and skip `span.end()` on the interrupted root `on_chain_end`.
2. On `Command(resume=...)`, rebind the new LangChain `run_id` to that open observation (no new root span).
3. Inject `thread_id` into Langfuse metadata so resume keying matches Langfuse’s expected key.

Hardening included: GraphInterrupt-only keep-open (not `ParentCommand`), pop-on-rebind, clear on root hard error / rebind failure, LRU cap (1024), and mypy-safe `last_trace_id` assignment.

## Key Points

- One continuous `orchestrator` span across interrupt → approve → continue (and multi-HITL in the same turn).
- Shared handler is required; separate handler instances do not share open-root state.
- Open-root state is **in-process only** (interrupt and resume must hit the same worker).
- Keys are `thread_id`-scoped (same as Langfuse resume keys); thread ownership remains a platform auth concern.
- Covered by unit tests in `tests/unit/aegra/test_telemetry_hitl_trace.py` (keep-open, rebind, ParentCommand negative, LRU, zombie clear, second HITL).

## Files changed

- `deep_agent/aegra/telemetry.py` — HITL-aware Langfuse callback handler, shared handler registration, `thread_id` metadata
- `tests/unit/aegra/test_telemetry_hitl_trace.py` — unit coverage for open-root HITL lifecycle

Fixes: https://github.com/redhat-data-and-ai/template-agent/issues/131