### PR TITLE
ci: rename test job to match required status check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   unit-tests:
-    name: Unit Tests
+    name: Test Suite
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,6 @@ jobs:
     name: Test Suite
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    strategy:
-      matrix:
-        python-version: ["3.14"]
 
     steps:
     - name: Checkout code
@@ -30,7 +27,7 @@ jobs:
     - name: Setup Python with uv
       uses: ./.github/actions/setup-python-uv
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.14"
 
     - name: Run unit tests with coverage
       env:
@@ -43,7 +40,7 @@ jobs:
       continue-on-error: true
       run: |
         if [ -f test-results.xml ]; then
-          echo "### Test Results (Python ${{ matrix.python-version }})" >> $GITHUB_STEP_SUMMARY
+          echo "### Test Results (Python 3.14)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           TESTS=$(grep -oP 'tests="\K[^"]+' test-results.xml | head -1)
           FAILURES=$(grep -oP 'failures="\K[^"]+' test-results.xml | head -1)
@@ -56,7 +53,7 @@ jobs:
         fi
 
     - name: Upload coverage reports to Codecov
-      if: matrix.python-version == '3.14'
+      if: always()
       continue-on-error: true
       uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
       with:


### PR DESCRIPTION
Fixes #133

## Summary

- The branch protection rule on `deep-agent` expects a required status check named **"Test Suite"**, but the workflow job in `test.yml` was named **"Unit Tests"**
- Additionally, the single-entry matrix strategy caused GitHub to report the check as **"Test Suite (3.14)"** instead of **"Test Suite"**
- This mismatch caused all PRs (e.g. #124) to hang indefinitely with "Expected -- Waiting for status to be reported"
- Renames the job from `Unit Tests` to `Test Suite` and removes the unnecessary matrix to produce the exact check name branch protection expects

## Test plan

- [x] Verify this PR's own "Test Suite" check runs and reports status
- [x] Confirm PR #124 no longer shows "Expected -- Waiting for status to be reported" after rebase/re-run