### PR TITLE
fix: Enable streaming=True for ChatGoogleGenerativeAI and ChatAnthropic , Issue #140

### DIFF
--- a/deep_agent/src/agent/llm.py
+++ b/deep_agent/src/agent/llm.py
@@ -103,6 +103,7 @@ def _create_vertex_model(
                 temperature=temperature,
                 max_tokens=max_output_tokens,
                 max_retries=2,
+                streaming=True,
             )
         else:
             return ChatGoogleGenerativeAI(
@@ -112,6 +113,7 @@ def _create_vertex_model(
                 project=project,
                 max_output_tokens=max_output_tokens,
                 max_retries=2,
+                streaming=True,
             )
 
     except (ValueError, LLMError):
@@ -163,6 +165,7 @@ def _create_vllm_model(
             temperature=temperature,
             max_tokens=max_output_tokens,
             max_retries=2,
+            streaming=True,
         )
 
     except ImportError:

--- a/tests/unit/agent/test_llm.py
+++ b/tests/unit/agent/test_llm.py
@@ -29,6 +29,7 @@ class TestCreateModel:
                     project="test-project",
                     max_output_tokens=8192,
                     max_retries=2,
+                    streaming=True,
                 )
 
     def test_create_claude_model(self):
@@ -49,6 +50,7 @@ class TestCreateModel:
                     temperature=0.7,
                     max_tokens=8192,
                     max_retries=2,
+                    streaming=True,
                 )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Adding streaming=True by default while instantiation. tested using make container in local . Fixes Issue #140 

https://github.com/redhat-data-and-ai/template-agent/issues/140