### PR TITLE
fix: MCPPrefixTool Bug Fix

### DIFF
--- a/deep_agent/aegra/mcp.py
+++ b/deep_agent/aegra/mcp.py
@@ -423,6 +423,7 @@ async def _connect_single_server(
                     tool_interceptors=[
                         _TokenInjectorInterceptor(name, server_cfg),
                     ],
+                    tool_name_prefix=bool(server_cfg.get("tool_prefix", name)),
                 )
                 tools: list[Any] = await client.get_tools()
             logger.info(f"[{name}] loaded {len(tools)} tool(s)")

--- a/tests/unit/infrastructure/test_mcp.py
+++ b/tests/unit/infrastructure/test_mcp.py
@@ -159,6 +159,44 @@ class TestConnectSingleServer:
             assert tools[0].name == "test_tool"
 
     @pytest.mark.asyncio
+    async def test_tool_prefix_enables_name_prefix(self):
+        """Test that tool_prefix in server_cfg sets tool_name_prefix=True."""
+        mock_client = MagicMock()
+        mock_client.get_tools = AsyncMock(return_value=[])
+
+        config = {"url": "http://localhost:8000/mcp/", "transport": "http"}
+        server_cfg = {"tool_prefix": "myprefix"}
+
+        with patch(
+            "deep_agent.aegra.mcp.MultiServerMCPClient",
+            return_value=mock_client,
+        ) as mock_cls:
+            await _connect_single_server("myprefix", config, server_cfg, timeout=5)
+
+            mock_cls.assert_called_once()
+            call_kwargs = mock_cls.call_args[1]
+            assert call_kwargs["tool_name_prefix"] is True
+
+    @pytest.mark.asyncio
+    async def test_no_tool_prefix_falls_back_to_name(self):
+        """Test that without tool_prefix, name is used as fallback and prefixing is enabled."""
+        mock_client = MagicMock()
+        mock_client.get_tools = AsyncMock(return_value=[])
+
+        config = {"url": "http://localhost:8000/mcp/", "transport": "streamable_http"}
+        server_cfg = {}  # no tool_prefix
+
+        with patch(
+            "deep_agent.aegra.mcp.MultiServerMCPClient",
+            return_value=mock_client,
+        ) as mock_cls:
+            await _connect_single_server("server-key", config, server_cfg, timeout=5)
+
+            mock_cls.assert_called_once()
+            call_kwargs = mock_cls.call_args[1]
+            assert call_kwargs["tool_name_prefix"] is True
+
+    @pytest.mark.asyncio
     async def test_connection_timeout_returns_empty_list(self):
         """Test that connection timeout returns empty list."""
         mock_client = MagicMock()


### PR DESCRIPTION
Closes #124 
Bug: tool_name_prefix not applied to MultiServerMCPClient

The initial tool_prefix implementation passed the custom prefix as the connection name to MultiServerMCPClient but did not enable the tool_name_prefix flag. As a result, MultiServerMCPClient never actually prefixed the tool names — tools were always returned as raw names (e.g., send_email) regardless of configuration.

Fix: Pass tool_name_prefix=bool(server_cfg.get("tool_prefix", name)) to MultiServerMCPClient so that:

Without tool_prefix: tools are prefixed with the server key (e.g., template_mcp_server_send_email) — preserving the default behavior
With tool_prefix: tools are prefixed with the custom short prefix (e.g., template_send_email) — giving shorter, environment-portable names