### PR TITLE
fix: subagent backend context bug

### DIFF
--- a/deep_agent/src/infrastructure/backend.py
+++ b/deep_agent/src/infrastructure/backend.py
@@ -294,6 +294,51 @@ def _build_state_backend() -> Any:
         return get_backend()
 
 
+def _get_assistant_id_from_config(ctx: Any) -> str:
+    """Extract assistant_id from runtime config metadata, falling back to 'default'.
+
+    Mirrors the fallback logic in StoreBackend._get_namespace_legacy:
+    check runtime.config → metadata → assistant_id.
+    """
+    cfg = getattr(ctx.runtime, "config", None) or {}
+    if isinstance(cfg, dict):
+        assistant_id = cfg.get("metadata", {}).get("assistant_id")
+        if assistant_id:
+            return assistant_id
+    return "default"
+
+
+def _safe_namespace_user(ctx: Any) -> tuple[str, ...]:
+    """User-scoped namespace: (assistant_id, user_identity) on server, config fallback locally."""
+    si = getattr(ctx.runtime, "server_info", None)
+    if si is not None and getattr(si, "assistant_id", ""):
+        parts: list[str] = [si.assistant_id]
+        if si.user is not None and getattr(si.user, "identity", ""):
+            parts.append(si.user.identity)
+        return tuple(parts)
+    return (_get_assistant_id_from_config(ctx),)
+
+
+def _safe_namespace_assistant(ctx: Any) -> tuple[str, ...]:
+    """Assistant-scoped namespace: (assistant_id,) on server, config fallback locally."""
+    si = getattr(ctx.runtime, "server_info", None)
+    if si is not None and getattr(si, "assistant_id", ""):
+        return (si.assistant_id,)
+    return (_get_assistant_id_from_config(ctx),)
+
+
+def _safe_namespace_org(ctx: Any) -> tuple[str, ...]:
+    """Org-scoped namespace: (org_id,)."""
+    return (ctx.runtime.context.org_id,)
+
+
+_STORE_NAMESPACE_FACTORIES: dict[str, Any] = {
+    "user": _safe_namespace_user,
+    "assistant": _safe_namespace_assistant,
+    "org": _safe_namespace_org,
+}
+
+
 def _build_store_backend(fs_config: Any) -> Any:
     """Build a StoreBackend (cross-thread persistent via LangGraph Store).
 
@@ -308,19 +353,10 @@ def _build_store_backend(fs_config: Any) -> Any:
         scope = getattr(fs_config.backend, "store", None)
         scope_name = scope.scope if scope else "user"
 
-        namespace_factories = {
-            "user": lambda rt: (
-                rt.server_info.assistant_id,
-                rt.server_info.user.identity,
-            ),
-            "assistant": lambda rt: (rt.server_info.assistant_id,),
-            "org": lambda rt: (rt.context.org_id,),
-        }
-
-        namespace = namespace_factories.get(scope_name)
+        namespace = _STORE_NAMESPACE_FACTORIES.get(scope_name)
         if namespace is None:
             logger.warning("Unknown store scope '%s', using 'user'", scope_name)
-            namespace = namespace_factories["user"]
+            namespace = _safe_namespace_user
 
         logger.info("Using StoreBackend (scope=%s)", scope_name)
         return StoreBackend(namespace=namespace)
@@ -392,16 +428,8 @@ def _build_composite_backend(fs_config: Any) -> Any:
             try:
                 from deepagents.backends.store import StoreBackend
 
-                namespace_factories = {
-                    "user": lambda rt: (
-                        rt.server_info.assistant_id,
-                        rt.server_info.user.identity,
-                    ),
-                    "assistant": lambda rt: (rt.server_info.assistant_id,),
-                    "org": lambda rt: (rt.context.org_id,),
-                }
-                ns = namespace_factories.get(
-                    store_scope or "user", namespace_factories["user"]
+                ns = _STORE_NAMESPACE_FACTORIES.get(
+                    store_scope or "user", _safe_namespace_user
                 )
                 store_backend = StoreBackend(runtime, namespace=ns)
                 for prefix in store_route_prefixes:

--- a/deep_agent/src/infrastructure/backend.py
+++ b/deep_agent/src/infrastructure/backend.py
@@ -302,18 +302,18 @@ def _get_assistant_id_from_config(ctx: Any) -> str:
     """
     cfg = getattr(ctx.runtime, "config", None) or {}
     if isinstance(cfg, dict):
-        assistant_id = cfg.get("metadata", {}).get("assistant_id")
+        assistant_id: Any = cfg.get("metadata", {}).get("assistant_id")
         if assistant_id:
-            return assistant_id
+            return str(assistant_id)
     return "default"
 
 
 def _safe_namespace_user(ctx: Any) -> tuple[str, ...]:
     """User-scoped namespace: (assistant_id, user_identity) on server, config fallback locally."""
-    si = getattr(ctx.runtime, "server_info", None)
-    if si is not None and getattr(si, "assistant_id", ""):
+    si: Any = getattr(ctx.runtime, "server_info", None)
+    if si is not None and getattr(si, "assistant_id", None):
         parts: list[str] = [si.assistant_id]
-        if si.user is not None and getattr(si.user, "identity", ""):
+        if si.user is not None and getattr(si.user, "identity", None):
             parts.append(si.user.identity)
         return tuple(parts)
     return (_get_assistant_id_from_config(ctx),)
@@ -321,8 +321,8 @@ def _safe_namespace_user(ctx: Any) -> tuple[str, ...]:
 
 def _safe_namespace_assistant(ctx: Any) -> tuple[str, ...]:
     """Assistant-scoped namespace: (assistant_id,) on server, config fallback locally."""
-    si = getattr(ctx.runtime, "server_info", None)
-    if si is not None and getattr(si, "assistant_id", ""):
+    si: Any = getattr(ctx.runtime, "server_info", None)
+    if si is not None and getattr(si, "assistant_id", None):
         return (si.assistant_id,)
     return (_get_assistant_id_from_config(ctx),)
 

--- a/deep_agent/src/infrastructure/backend.py
+++ b/deep_agent/src/infrastructure/backend.py
@@ -302,7 +302,10 @@ def _get_assistant_id_from_config(ctx: Any) -> str:
     """
     cfg = getattr(ctx.runtime, "config", None) or {}
     if isinstance(cfg, dict):
-        assistant_id: Any = cfg.get("metadata", {}).get("assistant_id")
+        metadata = cfg.get("metadata")
+        assistant_id: Any = (
+            metadata.get("assistant_id") if isinstance(metadata, dict) else None
+        )
         if assistant_id:
             return str(assistant_id)
     return "default"
@@ -313,8 +316,9 @@ def _safe_namespace_user(ctx: Any) -> tuple[str, ...]:
     si: Any = getattr(ctx.runtime, "server_info", None)
     if si is not None and getattr(si, "assistant_id", None):
         parts: list[str] = [si.assistant_id]
-        if si.user is not None and getattr(si.user, "identity", None):
-            parts.append(si.user.identity)
+        user: Any = getattr(si, "user", None)
+        if getattr(user, "identity", None):
+            parts.append(user.identity)
         return tuple(parts)
     return (_get_assistant_id_from_config(ctx),)
 

--- a/tests/unit/infrastructure/test_backend.py
+++ b/tests/unit/infrastructure/test_backend.py
@@ -98,6 +98,14 @@ class TestGetAssistantIdFromConfig:
         del ctx.runtime.config
         assert _get_assistant_id_from_config(ctx) == "default"
 
+    def test_returns_default_when_metadata_is_none(self):
+        ctx = _make_ctx(config={"metadata": None})
+        assert _get_assistant_id_from_config(ctx) == "default"
+
+    def test_returns_default_when_metadata_is_not_dict(self):
+        ctx = _make_ctx(config={"metadata": ["not", "a", "dict"]})
+        assert _get_assistant_id_from_config(ctx) == "default"
+
 
 class TestSafeNamespaceUser:
     """Tests for _safe_namespace_user."""
@@ -117,6 +125,12 @@ class TestSafeNamespaceUser:
         si.assistant_id = "asst-1"
         si.user = MagicMock()
         si.user.identity = ""
+        ctx = _make_ctx(server_info=si)
+        assert _safe_namespace_user(ctx) == ("asst-1",)
+
+    def test_returns_only_assistant_id_when_server_info_has_no_user_attr(self):
+        si = MagicMock(spec=[])
+        si.assistant_id = "asst-1"
         ctx = _make_ctx(server_info=si)
         assert _safe_namespace_user(ctx) == ("asst-1",)
 

--- a/tests/unit/infrastructure/test_backend.py
+++ b/tests/unit/infrastructure/test_backend.py
@@ -9,6 +9,11 @@ import pytest
 from deep_agent.src.infrastructure.backend import (
     _base_python,
     _build_env,
+    _get_assistant_id_from_config,
+    _safe_namespace_assistant,
+    _safe_namespace_org,
+    _safe_namespace_user,
+    _STORE_NAMESPACE_FACTORIES,
 )
 
 
@@ -37,3 +42,153 @@ class TestBuildEnv:
             env = _build_env(tmp_path)
             assert env.get("HOME") == "/test/home"
             assert env.get("USER") == "tester"
+
+
+def _make_ctx(server_info=None, config=None, context=None):
+    """Build a minimal ctx mock for namespace tests."""
+    ctx = MagicMock()
+    ctx.runtime.server_info = server_info
+    ctx.runtime.config = config
+    if context is not None:
+        ctx.runtime.context = context
+    return ctx
+
+
+def _make_server_info(assistant_id="", user_identity=""):
+    """Build a server_info mock with optional assistant_id and user."""
+    si = MagicMock()
+    si.assistant_id = assistant_id
+    if user_identity:
+        si.user = MagicMock()
+        si.user.identity = user_identity
+    else:
+        si.user = None
+    return si
+
+
+class TestGetAssistantIdFromConfig:
+    """Tests for _get_assistant_id_from_config."""
+
+    def test_returns_assistant_id_from_metadata(self):
+        ctx = _make_ctx(config={"metadata": {"assistant_id": "agent-42"}})
+        assert _get_assistant_id_from_config(ctx) == "agent-42"
+
+    def test_returns_default_when_config_is_none(self):
+        ctx = _make_ctx(config=None)
+        assert _get_assistant_id_from_config(ctx) == "default"
+
+    def test_returns_default_when_config_missing_metadata(self):
+        ctx = _make_ctx(config={"other_key": "val"})
+        assert _get_assistant_id_from_config(ctx) == "default"
+
+    def test_returns_default_when_metadata_has_no_assistant_id(self):
+        ctx = _make_ctx(config={"metadata": {}})
+        assert _get_assistant_id_from_config(ctx) == "default"
+
+    def test_returns_default_when_assistant_id_is_empty_string(self):
+        ctx = _make_ctx(config={"metadata": {"assistant_id": ""}})
+        assert _get_assistant_id_from_config(ctx) == "default"
+
+    def test_returns_default_when_config_is_not_dict(self):
+        ctx = _make_ctx(config="not-a-dict")
+        assert _get_assistant_id_from_config(ctx) == "default"
+
+    def test_returns_default_when_runtime_has_no_config_attr(self):
+        ctx = MagicMock()
+        del ctx.runtime.config
+        assert _get_assistant_id_from_config(ctx) == "default"
+
+
+class TestSafeNamespaceUser:
+    """Tests for _safe_namespace_user."""
+
+    def test_returns_assistant_id_and_user_identity_from_server_info(self):
+        si = _make_server_info(assistant_id="asst-1", user_identity="user@example.com")
+        ctx = _make_ctx(server_info=si)
+        assert _safe_namespace_user(ctx) == ("asst-1", "user@example.com")
+
+    def test_returns_only_assistant_id_when_user_is_none(self):
+        si = _make_server_info(assistant_id="asst-1", user_identity="")
+        ctx = _make_ctx(server_info=si)
+        assert _safe_namespace_user(ctx) == ("asst-1",)
+
+    def test_returns_only_assistant_id_when_user_identity_empty(self):
+        si = MagicMock()
+        si.assistant_id = "asst-1"
+        si.user = MagicMock()
+        si.user.identity = ""
+        ctx = _make_ctx(server_info=si)
+        assert _safe_namespace_user(ctx) == ("asst-1",)
+
+    def test_falls_back_to_config_when_server_info_is_none(self):
+        ctx = _make_ctx(
+            server_info=None,
+            config={"metadata": {"assistant_id": "cfg-agent"}},
+        )
+        assert _safe_namespace_user(ctx) == ("cfg-agent",)
+
+    def test_falls_back_to_config_when_assistant_id_empty(self):
+        si = _make_server_info(assistant_id="", user_identity="user@x.com")
+        ctx = _make_ctx(
+            server_info=si,
+            config={"metadata": {"assistant_id": "cfg-agent"}},
+        )
+        assert _safe_namespace_user(ctx) == ("cfg-agent",)
+
+    def test_falls_back_to_default_when_no_server_info_and_no_config(self):
+        ctx = _make_ctx(server_info=None, config=None)
+        assert _safe_namespace_user(ctx) == ("default",)
+
+
+class TestSafeNamespaceAssistant:
+    """Tests for _safe_namespace_assistant."""
+
+    def test_returns_assistant_id_from_server_info(self):
+        si = _make_server_info(assistant_id="asst-2", user_identity="ignored")
+        ctx = _make_ctx(server_info=si)
+        assert _safe_namespace_assistant(ctx) == ("asst-2",)
+
+    def test_falls_back_to_config_when_server_info_is_none(self):
+        ctx = _make_ctx(
+            server_info=None,
+            config={"metadata": {"assistant_id": "cfg-asst"}},
+        )
+        assert _safe_namespace_assistant(ctx) == ("cfg-asst",)
+
+    def test_falls_back_to_config_when_assistant_id_empty(self):
+        si = _make_server_info(assistant_id="")
+        ctx = _make_ctx(
+            server_info=si,
+            config={"metadata": {"assistant_id": "cfg-asst"}},
+        )
+        assert _safe_namespace_assistant(ctx) == ("cfg-asst",)
+
+    def test_falls_back_to_default_when_no_config(self):
+        ctx = _make_ctx(server_info=None, config=None)
+        assert _safe_namespace_assistant(ctx) == ("default",)
+
+
+class TestSafeNamespaceOrg:
+    """Tests for _safe_namespace_org."""
+
+    def test_returns_org_id(self):
+        context = MagicMock()
+        context.org_id = "org-123"
+        ctx = _make_ctx(context=context)
+        assert _safe_namespace_org(ctx) == ("org-123",)
+
+
+class TestStoreNamespaceFactories:
+    """Tests for the _STORE_NAMESPACE_FACTORIES mapping."""
+
+    def test_contains_all_expected_keys(self):
+        assert set(_STORE_NAMESPACE_FACTORIES.keys()) == {"user", "assistant", "org"}
+
+    def test_user_maps_to_safe_namespace_user(self):
+        assert _STORE_NAMESPACE_FACTORIES["user"] is _safe_namespace_user
+
+    def test_assistant_maps_to_safe_namespace_assistant(self):
+        assert _STORE_NAMESPACE_FACTORIES["assistant"] is _safe_namespace_assistant
+
+    def test_org_maps_to_safe_namespace_org(self):
+        assert _STORE_NAMESPACE_FACTORIES["org"] is _safe_namespace_org


### PR DESCRIPTION
## Description

<!-- What does this MR do and why? Jira: DVRS-XXXX -->

Fixes subagent streaming crashes caused by namespace factory lambdas accessing `server_info` attributes that are `None` when running locally or in subagent contexts without a full runtime. Extracts inline lambdas into named functions with safe fallback logic (config metadata → "default"), and adds comprehensive unit test coverage.

## Changes

- Extract inline namespace factory lambdas from `_build_store_backend` and `_build_composite_backend` into module-level named functions (`_safe_namespace_user`, `_safe_namespace_assistant`, `_safe_namespace_org`)
- Add `_get_assistant_id_from_config` helper to safely extract assistant_id from runtime config metadata with a "default" fallback
- Introduce `_STORE_NAMESPACE_FACTORIES` module-level dict replacing duplicated inline dicts in two builder functions
- Add 22 unit tests covering all branches of the new namespace helpers (server_info present/absent, user identity present/empty, config fallback, "default" fallback)

## AI Disclosure

<!-- Helps reviewers calibrate: AI-generated code has different failure modes than hand-written code. -->

- **AI used**: Yes
- **Tool(s)**: Claude Code
- **Scope**: Unit tests for the new namespace helper functions in `tests/unit/infrastructure/test_backend.py`
- **Human verification**: Reviewed logic against source implementation, ran full test suite locally (27/27 passing), verified branch coverage on all new code paths

## Checklist

- [x] I have reviewed my own diff
- [x] Tests pass with adequate coverage
- [x] Docs and config updated if needed
- [x] AI output verified for correctness and hallucinated dependencies

## Deployment & Security Impact

<!--
Deployment: new env vars, config changes, migrations, resource scaling, downtime risk, rollback steps.
Security: auth/token changes, new endpoints exposed, input validation, secrets handling, RBAC changes.
-->

None

## Reviewer Notes

<!-- What to focus on. -->

The key behavioral change is graceful degradation: previously, accessing `server_info.assistant_id` or `server_info.user.identity` would raise `AttributeError` if `server_info` was `None` (e.g. subagent local execution). Now the functions fall back to `runtime.config.metadata.assistant_id` or `"default"`. Verify this matches the expected namespace partitioning for local/subagent contexts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backend scope selection when runtime server information is unavailable or incomplete.
  * Added reliable fallback behavior for user, assistant, and organization data scopes.
  * Ensured missing or invalid assistant and identity details no longer cause namespace resolution failures.

* **Tests**
  * Added coverage for scope selection, fallback behavior, and incomplete configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->