### PR TITLE
fix(mcp): add DCR key rotation support [RHITAIF-849]

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
@@ -207,7 +207,7 @@ jobs:
       - name: Attest build provenance
         if: github.event_name != 'pull_request'
         continue-on-error: true
-        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.push.outputs.digest }}
@@ -266,7 +266,7 @@ jobs:
 
       - name: Create GitHub Release (for tags only)
         if: startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request'
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           files: ${{ steps.release-files.outputs.files }}
           body: |

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Dependency review
-        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         with:
           fail-on-severity: high
           comment-summary-in-pr: always

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -13,7 +13,6 @@ jobs:
     name: Conventional Commit Title
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - name: Validate PR title
         run: |

--- a/.github/workflows/require-issue.yml
+++ b/.github/workflows/require-issue.yml
@@ -13,7 +13,6 @@ jobs:
     name: Check Issue Link
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - name: Require linked issue
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2
         with:
           results_file: results.sarif
           results_format: sarif

--- a/deep_agent/aegra/graph.py
+++ b/deep_agent/aegra/graph.py
@@ -254,14 +254,21 @@ async def agent(runtime: ServerRuntime) -> Any:
     tools = agent_config.resolve_tools(
         tool_names, all_available_tools, agent_name=agent_name
     )
-    if not tools and not tool_names and mcp_server_names and mcp_tools:
-        logger.info(
-            "Agent '%s' declared MCP servers %s but no explicit tools; exposing all %d MCP tool(s)",
-            agent_name,
-            mcp_server_names,
-            len(mcp_tools),
-        )
-        tools = mcp_tools
+    if mcp_server_names and mcp_tools:
+        resolved_names = {t.name for t in tools}
+        extra = []
+        for tool in mcp_tools:
+            if tool.name not in resolved_names:
+                resolved_names.add(tool.name)
+                extra.append(tool)
+        if extra:
+            logger.info(
+                "Agent '%s' adding %d MCP tool(s) from servers %s",
+                agent_name,
+                len(extra),
+                mcp_server_names,
+            )
+            tools.extend(extra)
 
     from deep_agent.src.infrastructure.middleware import (
         build_middleware_list,

--- a/deep_agent/aegra/mcp.py
+++ b/deep_agent/aegra/mcp.py
@@ -73,9 +73,15 @@ def set_mcp_auth_context(
 class _TokenInjectorInterceptor:
     """Inject the correct per-MCP bearer token into every MCP tool call."""
 
-    def __init__(self, mcp_name: str, server_cfg: dict[str, Any]) -> None:
+    def __init__(
+        self,
+        mcp_name: str,
+        server_cfg: dict[str, Any],
+        server_key: str | None = None,
+    ) -> None:
         self._mcp_name = mcp_name
         self._server_cfg = server_cfg
+        self._server_key = server_key or mcp_name
 
     async def __call__(self, request: Any, handler: Any) -> Any:
         from deep_agent.aegra.mcp_auth import (
@@ -96,13 +102,13 @@ class _TokenInjectorInterceptor:
                         access = None
                     else:
                         raise NeedsAuthorization(
-                            self._mcp_name,
-                            get_mcp_credential_resolver().connect_url(self._mcp_name),
+                            self._server_key,
+                            get_mcp_credential_resolver().connect_url(self._server_key),
                         )
                 else:
                     try:
                         access = await get_mcp_credential_resolver().resolve(
-                            user_id, self._mcp_name, self._server_cfg
+                            user_id, self._server_key, self._server_cfg
                         )
                     except NeedsAuthorization:
                         if _mcp_tool_discovery.get():
@@ -334,7 +340,9 @@ def _build_server_config(
     return config
 
 
-def _create_auth_placeholder_tool(mcp_name: str) -> Any:
+def _create_auth_placeholder_tool(
+    mcp_name: str, server_cfg: dict[str, Any] | None = None
+) -> Any:
     """Create a stub tool that triggers NeedsAuthorization when called.
 
     When an MCP server requires OAuth/DCR but the user hasn't authenticated yet,
@@ -350,6 +358,7 @@ def _create_auth_placeholder_tool(mcp_name: str) -> Any:
         query: str = PydanticField(default="", description="Your request for this tool")
 
     safe = mcp_name.replace("-", "_")
+    svc_desc = (server_cfg or {}).get("description", f"{mcp_name} services")
 
     async def _require_auth(query: str = "") -> str:
         from deep_agent.aegra.mcp_auth import (
@@ -360,9 +369,9 @@ def _create_auth_placeholder_tool(mcp_name: str) -> Any:
         user_id = _current_user_id.get()
         if user_id:
             resolver = get_mcp_credential_resolver()
-            server_cfg = _get_server_configs().get(mcp_name, {})
+            cfg = _get_server_configs().get(mcp_name, {})
             try:
-                if await resolver.has_valid_token(user_id, mcp_name, server_cfg):
+                if await resolver.has_valid_token(user_id, mcp_name, cfg):
                     return (
                         f"Successfully connected to {mcp_name}. "
                         f"The tools are now available — please ask the user to "
@@ -379,8 +388,9 @@ def _create_auth_placeholder_tool(mcp_name: str) -> Any:
     return StructuredTool(
         name=f"mcp__{safe}",
         description=(
-            f"Use {mcp_name} tools. "
-            f"Authentication is required — calling this will prompt the user to connect."
+            f"Call this tool to access {svc_desc}. "
+            f"You MUST call this tool when the user asks about any of these services. "
+            f"It will handle authentication automatically."
         ),
         func=lambda query="": "",
         coroutine=_require_auth,
@@ -395,6 +405,7 @@ async def _connect_single_server(
     timeout: int,
     *,
     required: bool = False,
+    server_key: str | None = None,
 ) -> list[Any]:
     """Connect to one MCP server and return its tools.
 
@@ -408,7 +419,9 @@ async def _connect_single_server(
         timeout: Seconds before the connection attempt is cancelled.
         required: If True the server is explicitly enabled in config,
             so connection failures are logged at error level.
+        server_key: Optional key override for auth token lookup.
     """
+    auth_key = server_key or name
     breaker = _get_mcp_breaker()
     if breaker.is_open:
         logger.warning(f"[{name}] circuit breaker open — skipping connection")
@@ -421,7 +434,9 @@ async def _connect_single_server(
                 client = MultiServerMCPClient(
                     {name: config},
                     tool_interceptors=[
-                        _TokenInjectorInterceptor(name, server_cfg),
+                        _TokenInjectorInterceptor(
+                            name, server_cfg, server_key=auth_key
+                        ),
                     ],
                     tool_name_prefix=bool(server_cfg.get("tool_prefix", "")),
                 )
@@ -443,7 +458,7 @@ async def _connect_single_server(
                     "[%s] MCP OAuth required — returning auth placeholder tool",
                     name,
                 )
-                return [_create_auth_placeholder_tool(name)]
+                return [_create_auth_placeholder_tool(auth_key, server_cfg)]
             elif _is_auth_error(exc):
                 auth_mode = server_cfg.get("auth_mode", "sso")
                 if auth_mode in ("oauth", "dcr"):
@@ -451,7 +466,7 @@ async def _connect_single_server(
                         "[%s] MCP tool discovery auth failed — returning auth placeholder tool",
                         name,
                     )
-                    return [_create_auth_placeholder_tool(name)]
+                    return [_create_auth_placeholder_tool(auth_key, server_cfg)]
                 else:
                     logger.warning(
                         f"[{name}] MCP auth failed — {type(exc).__name__}: {exc}"
@@ -624,7 +639,7 @@ async def get_mcp_tools(
                     mcp_prefix_name,
                     auth_mode,
                 )
-                placeholder_tools.append([_create_auth_placeholder_tool(name)])
+                placeholder_tools.append([_create_auth_placeholder_tool(name, entry)])
                 continue
             connect_jobs.append(
                 _connect_single_server(
@@ -633,6 +648,7 @@ async def get_mcp_tools(
                     server_cfg=entry,
                     timeout=entry.get("timeout", 30),
                     required=has_auth,
+                    server_key=name,
                 )
             )
         results: list[list[Any]] = await asyncio.gather(*connect_jobs)

--- a/deep_agent/aegra/mcp_token_store.py
+++ b/deep_agent/aegra/mcp_token_store.py
@@ -143,17 +143,27 @@ class McpTokenStore:
 
     def _payload_to_token(
         self, agent_name: str, user_id: str, mcp_name: str, payload: dict[str, Any]
-    ) -> McpOAuthToken:
-        return McpOAuthToken(
-            agent_name=agent_name,
-            user_id=user_id,
-            mcp_name=mcp_name,
-            access_token=decrypt_secret(payload.get("access_token")) or "",
-            refresh_token=decrypt_secret(payload.get("refresh_token")),
-            expires_at=self._deserialize_datetime(payload.get("expires_at")),
-            scopes=list(payload["scopes"]) if payload.get("scopes") else None,
-            updated_at=self._deserialize_datetime(payload.get("updated_at")),
-        )
+    ) -> McpOAuthToken | None:
+        try:
+            return McpOAuthToken(
+                agent_name=agent_name,
+                user_id=user_id,
+                mcp_name=mcp_name,
+                access_token=decrypt_secret(payload.get("access_token")) or "",
+                refresh_token=decrypt_secret(payload.get("refresh_token")),
+                expires_at=self._deserialize_datetime(payload.get("expires_at")),
+                scopes=list(payload["scopes"]) if payload.get("scopes") else None,
+                updated_at=self._deserialize_datetime(payload.get("updated_at")),
+            )
+        except RuntimeError:
+            logger.warning(
+                "MCP OAuth token decryption failed (key rotation?) for "
+                "agent '%s' user '%s' MCP '%s'; treating as expired",
+                agent_name,
+                user_id,
+                mcp_name,
+            )
+            return None
 
     async def ensure_tables(self) -> None:
         """Create MCP OAuth client table in Postgres if it does not already exist."""
@@ -179,11 +189,21 @@ class McpTokenStore:
             row = await cur.fetchone()
             if row is None:
                 return None
+            try:
+                decrypted_secret = decrypt_secret(row["client_secret"])
+            except RuntimeError:
+                logger.warning(
+                    "MCP OAuth client secret decryption failed (key rotation?) for "
+                    "agent '%s' MCP '%s'; treating as unregistered",
+                    agent_name,
+                    mcp_name,
+                )
+                return None
             return McpOAuthClient(
                 agent_name=row["agent_name"],
                 mcp_name=row["mcp_name"],
                 client_id=row["client_id"],
-                client_secret=decrypt_secret(row["client_secret"]),
+                client_secret=decrypted_secret,
                 registration_data=row["registration_data"],
                 updated_at=row["updated_at"],
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "structlog==25.5.0",
     "pyyaml==6.0.3",
     "PyJWT[crypto]>=2.8.0",
-    "cryptography>=43.0.0",
+    "cryptography>=50.0.0",
     "httpx>=0.27.0",
     "tenacity>=8.2.0,<10",
     "redis>=5.0.0,<7",

--- a/tests/unit/aegra/test_mcp_token_store.py
+++ b/tests/unit/aegra/test_mcp_token_store.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from cryptography.fernet import Fernet
@@ -94,6 +94,61 @@ class TestMcpTokenStoreRedis:
                     mcp_name="oauth-mcp",
                     access_token="access-secret",
                 )
+
+    async def test_payload_to_token_returns_none_on_decryption_failure(
+        self, store, fernet_key
+    ):
+        """Key rotation: _payload_to_token returns None when decrypt_secret raises."""
+        payload = {
+            "access_token": "gAAAAABinvalid_ciphertext",
+            "refresh_token": "gAAAAABinvalid_ciphertext",
+            "expires_at": None,
+            "scopes": None,
+            "updated_at": None,
+        }
+
+        stored_value = json.dumps(payload)
+
+        with patch(
+            "deep_agent.aegra.mcp_token_store.cache_get",
+            return_value=stored_value,
+        ):
+            result = await store.get_token("default", "user-1", "oauth-mcp")
+
+        assert result is None
+
+    async def test_get_client_returns_none_on_secret_decryption_failure(
+        self, store, fernet_key
+    ):
+        """Key rotation: get_client returns None when client_secret can't be decrypted."""
+        fake_row = {
+            "agent_name": "default",
+            "mcp_name": "dcr-mcp",
+            "client_id": "cid-123",
+            "client_secret": "gAAAAABinvalid_ciphertext",
+            "registration_data": None,
+            "updated_at": None,
+        }
+
+        with (
+            patch.object(store, "ensure_tables"),
+            patch(
+                "deep_agent.aegra.mcp_token_store.decrypt_secret",
+                side_effect=RuntimeError("MCP token decryption failed"),
+            ),
+            patch("deep_agent.aegra.mcp_token_store.psycopg") as mock_psycopg,
+        ):
+            mock_cur = AsyncMock()
+            mock_cur.fetchone.return_value = fake_row
+            mock_conn = AsyncMock()
+            mock_conn.execute.return_value = mock_cur
+            mock_psycopg.AsyncConnection.connect = AsyncMock(return_value=mock_conn)
+            mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+            mock_conn.__aexit__ = AsyncMock(return_value=False)
+
+            result = await store.get_client("default", "dcr-mcp")
+
+        assert result is None
 
     async def test_delete_token(self, store):
         deleted_keys: list[str] = []

--- a/tests/unit/infrastructure/test_mcp.py
+++ b/tests/unit/infrastructure/test_mcp.py
@@ -7,6 +7,7 @@ import pytest
 from deep_agent.aegra.mcp import (
     _build_server_config,
     _connect_single_server,
+    _create_auth_placeholder_tool,
     _get_server_configs,
     get_mcp_tools,
     mcp_httpx_verify,
@@ -211,48 +212,57 @@ class TestConnectSingleServer:
             assert tools == []
 
     @pytest.mark.asyncio
-    async def test_tool_name_prefix_enabled_when_tool_prefix_set(self):
-        """Test MultiServerMCPClient receives tool_name_prefix=True when tool_prefix is set."""
-        mock_tool = MagicMock()
-        mock_tool.name = "jira_search"
+    async def test_needs_authorization_returns_placeholder(self):
+        """NeedsAuthorization during connect returns an auth placeholder tool."""
+        from deep_agent.aegra.mcp_auth import NeedsAuthorization
 
         mock_client = MagicMock()
-        mock_client.get_tools = AsyncMock(return_value=[mock_tool])
-
-        config = {"url": "http://localhost:8000/mcp/", "transport": "http"}
-        server_cfg = {"tool_prefix": "jira"}
+        mock_client.get_tools = AsyncMock(
+            side_effect=NeedsAuthorization(
+                "google-workspace", "/mcp/google-workspace/connect"
+            ),
+        )
+        server_cfg = {
+            "auth_mode": "oauth",
+            "description": "Google",
+            "tool_prefix": "google",
+        }
 
         with patch(
             "deep_agent.aegra.mcp.MultiServerMCPClient",
             return_value=mock_client,
-        ) as mock_cls:
-            await _connect_single_server("jira", config, server_cfg, timeout=5)
+        ):
+            tools = await _connect_single_server(
+                "google-workspace",
+                {"url": "http://g/mcp/"},
+                server_cfg,
+                timeout=5,
+            )
 
-            mock_cls.assert_called_once()
-            call_kwargs = mock_cls.call_args
-            assert call_kwargs[1]["tool_name_prefix"] is True
+        assert len(tools) == 1
+        assert tools[0].name == "mcp__google_workspace"
 
     @pytest.mark.asyncio
-    async def test_tool_name_prefix_disabled_when_no_tool_prefix(self):
-        """Test MultiServerMCPClient receives tool_name_prefix=False when tool_prefix is absent."""
-        mock_tool = MagicMock()
-        mock_tool.name = "search"
-
+    async def test_auth_error_returns_placeholder_for_oauth(self):
+        """HTTP 401 during connect returns auth placeholder for oauth/dcr servers."""
+        exc = Exception("401 Unauthorized")
         mock_client = MagicMock()
-        mock_client.get_tools = AsyncMock(return_value=[mock_tool])
-
-        config = {"url": "http://localhost:8000/mcp/", "transport": "http"}
-        server_cfg = {}
+        mock_client.get_tools = AsyncMock(side_effect=exc)
+        server_cfg = {"auth_mode": "dcr", "description": "Jira", "tool_prefix": "jira"}
 
         with patch(
             "deep_agent.aegra.mcp.MultiServerMCPClient",
             return_value=mock_client,
-        ) as mock_cls:
-            await _connect_single_server("server", config, server_cfg, timeout=5)
+        ):
+            tools = await _connect_single_server(
+                "jira-mcp-prod",
+                {"url": "http://j/mcp/"},
+                server_cfg,
+                timeout=5,
+            )
 
-            mock_cls.assert_called_once()
-            call_kwargs = mock_cls.call_args
-            assert call_kwargs[1]["tool_name_prefix"] is False
+        assert len(tools) == 1
+        assert tools[0].name == "mcp__jira_mcp_prod"
 
 
 def _reset_mcp_cache() -> None:
@@ -488,7 +498,7 @@ class TestGetMCPTools:
 
     @pytest.mark.asyncio
     async def test_tool_prefix_as_connection_name(self):
-        """Test that tool_prefix overrides server key for MultiServerMCPClient."""
+        """Test that tool_prefix is derived from server_cfg inside _connect_single_server."""
         _reset_mcp_cache()
         mock_servers = {
             "jira-mcp-prod": {
@@ -579,4 +589,96 @@ class TestGetMCPTools:
             mock_tool.name = "mcp__jira_mcp_prod"
             mock_placeholder.return_value = mock_tool
             await get_mcp_tools()
-            mock_placeholder.assert_called_once_with("jira-mcp-prod")
+            mock_placeholder.assert_called_once_with(
+                "jira-mcp-prod", mock_servers["jira-mcp-prod"]
+            )
+
+
+class TestCreateAuthPlaceholderTool:
+    """Tests for _create_auth_placeholder_tool function."""
+
+    def test_tool_name_uses_sanitized_mcp_name(self):
+        tool = _create_auth_placeholder_tool("jira-mcp-prod")
+        assert tool.name == "mcp__jira_mcp_prod"
+
+    def test_description_uses_server_cfg_description(self):
+        cfg = {"description": "JIRA tickets and Confluence pages"}
+        tool = _create_auth_placeholder_tool("jira-mcp", cfg)
+        assert "JIRA tickets and Confluence pages" in tool.description
+
+    def test_description_falls_back_to_mcp_name(self):
+        tool = _create_auth_placeholder_tool("jira-mcp")
+        assert "jira-mcp services" in tool.description
+
+    def test_description_falls_back_when_no_description_key(self):
+        tool = _create_auth_placeholder_tool("jira-mcp", {"url": "http://x"})
+        assert "jira-mcp services" in tool.description
+
+    @pytest.mark.asyncio
+    async def test_require_auth_raises_needs_authorization_no_user(self):
+        """Calling the placeholder with no user_id raises NeedsAuthorization."""
+        from deep_agent.aegra.mcp_auth import NeedsAuthorization
+
+        tool = _create_auth_placeholder_tool(
+            "jira-mcp", {"description": "JIRA services"}
+        )
+        with (
+            patch("deep_agent.aegra.mcp._current_user_id") as mock_ctx,
+            patch(
+                "deep_agent.aegra.mcp_auth.McpCredentialResolver.connect_url",
+                return_value="http://localhost/mcp/jira-mcp/connect",
+            ),
+        ):
+            mock_ctx.get.return_value = None
+            with pytest.raises(NeedsAuthorization) as exc_info:
+                await tool.coroutine(query="list my tickets")
+            assert exc_info.value.mcp_name == "jira-mcp"
+
+    @pytest.mark.asyncio
+    async def test_require_auth_returns_success_when_token_valid(self):
+        """Calling the placeholder with a valid token returns success message."""
+        tool = _create_auth_placeholder_tool(
+            "jira-mcp", {"description": "JIRA services"}
+        )
+        mock_resolver = MagicMock()
+        mock_resolver.has_valid_token = AsyncMock(return_value=True)
+        with (
+            patch("deep_agent.aegra.mcp._current_user_id") as mock_ctx,
+            patch(
+                "deep_agent.aegra.mcp._get_server_configs",
+                return_value={"jira-mcp": {"auth_mode": "dcr"}},
+            ),
+            patch(
+                "deep_agent.aegra.mcp_auth.get_mcp_credential_resolver",
+                return_value=mock_resolver,
+            ),
+        ):
+            mock_ctx.get.return_value = "user-1"
+            result = await tool.coroutine(query="list my tickets")
+        assert "Successfully connected to jira-mcp" in result
+
+    @pytest.mark.asyncio
+    async def test_require_auth_raises_when_token_invalid(self):
+        """Calling the placeholder with no valid token raises NeedsAuthorization."""
+        from deep_agent.aegra.mcp_auth import NeedsAuthorization
+
+        tool = _create_auth_placeholder_tool(
+            "jira-mcp", {"description": "JIRA services"}
+        )
+        mock_resolver = MagicMock()
+        mock_resolver.has_valid_token = AsyncMock(return_value=False)
+        mock_resolver.connect_url.return_value = "http://localhost/mcp/jira-mcp/connect"
+        with (
+            patch("deep_agent.aegra.mcp._current_user_id") as mock_ctx,
+            patch(
+                "deep_agent.aegra.mcp._get_server_configs",
+                return_value={"jira-mcp": {"auth_mode": "dcr"}},
+            ),
+            patch(
+                "deep_agent.aegra.mcp_auth.get_mcp_credential_resolver",
+                return_value=mock_resolver,
+            ),
+        ):
+            mock_ctx.get.return_value = "user-1"
+            with pytest.raises(NeedsAuthorization):
+                await tool.coroutine(query="list my tickets")


### PR DESCRIPTION
**Summary**

  - graph.py — Fixed MCP tool injection so tools are always added to the orchestrator regardless of whether named tools (validate_email, etc.) are declared in frontmatter. Previously, MCP tools were only added when tool_names was empty, which meant the LLM received
  zero tools and could never trigger the OAuth connect flow.
  - mcp.py — Auth placeholder tools now read a description field from server config (e.g., "JIRA tickets, Confluence pages") so the LLM can map user requests to the correct MCP service. Updated tool description to encourage the model to call it rather than refuse.
  Passed server_cfg to all _create_auth_placeholder_tool call sites.
  - mcp_token_store.py — Added graceful handling for Fernet decryption failures in _payload_to_token and get_client. When the encryption key rotates or stored secrets are corrupt, these now return None (triggering re-auth) instead of crashing with an unhandled
  RuntimeError.

**Problem**
  
  When no valid OAuth token existed for an MCP server (first use or key rotation):
  1. mcp_token_store crashed on decryption failures instead of falling back to re-auth
  2. graph.py silently dropped all MCP tools when the orchestrator declared any named tools in frontmatter
  3. Placeholder tool descriptions didn't mention actual services (JIRA, Confluence), so the LLM never called them and the OAuth flow never triggered