### PR TITLE
fix: skills routing, MCP auth interrupts, and container entrypoint

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -25,7 +25,7 @@ USER 65532
 
 COPY --chown=65532:root deep_agent /app/deep_agent
 COPY --chown=65532:root aegra.json /app/aegra.json
-COPY --chown=65532:root entrypoint.sh /app/entrypoint.sh
+COPY --chown=65532:root --chmod=755 entrypoint.sh /app/entrypoint.sh
 
 ENV PYTHONPATH=/app
 ENV AGENT_HOST=0.0.0.0

--- a/deep_agent/aegra/graph.py
+++ b/deep_agent/aegra/graph.py
@@ -137,7 +137,10 @@ async def agent(runtime: ServerRuntime) -> Any:
         refresh_access_token,
         set_mcp_auth_context,
     )
-    from deep_agent.aegra.mcp_tool_auth import wrap_mcp_tools_for_auth
+    from deep_agent.aegra.mcp_tool_auth import (
+        reset_auth_interrupt_state,
+        wrap_mcp_tools_for_auth,
+    )
     from deep_agent.src.agent.config import agent_config
     from deep_agent.src.infrastructure.async_tasks import build_async_middleware
     from deep_agent.src.infrastructure.backend import get_configured_backend
@@ -155,6 +158,7 @@ async def agent(runtime: ServerRuntime) -> Any:
 
     user_identity = getattr(user, "identity", None) if user else None
 
+    reset_auth_interrupt_state()
     set_mcp_auth_context(sso_token, refresh_token, user_identity)
     orchestrator_cfg = agent_config.get_orchestrator_config()
     agent_name = orchestrator_cfg.get("name", "orchestrator")

--- a/deep_agent/aegra/mcp_tool_auth.py
+++ b/deep_agent/aegra/mcp_tool_auth.py
@@ -1,7 +1,15 @@
-"""Wrap MCP tools to raise LangGraph interrupts when OAuth is required."""
+"""Wrap MCP tools to raise LangGraph interrupts when OAuth is required.
+
+When multiple MCP tools need auth simultaneously (parallel tool calls in a
+single node), only the first fires an ``interrupt()``; the rest return an
+error string so the LLM retries them on the next turn.  This prevents the
+``RuntimeError: multiple pending interrupts`` that Aegra cannot resolve
+because it does not pass ``resume_interrupt_id``.
+"""
 
 from __future__ import annotations
 
+import contextvars
 import inspect
 import json
 from typing import Any
@@ -13,6 +21,19 @@ from deep_agent.utils.pylogger import get_python_logger
 
 logger = get_python_logger()
 
+_auth_interrupt_fired: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "_auth_interrupt_fired", default=False
+)
+
+
+def reset_auth_interrupt_state() -> None:
+    """Reset the per-invocation interrupt guard.
+
+    Called at the start of each graph factory build so that a fresh run
+    can fire an interrupt if needed.
+    """
+    _auth_interrupt_fired.set(False)
+
 
 def _mcp_auth_interrupt_payload(exc: NeedsAuthorization) -> str:
     return json.dumps(
@@ -23,6 +44,34 @@ def _mcp_auth_interrupt_payload(exc: NeedsAuthorization) -> str:
             "message": f"Connect to {exc.mcp_name} to use these tools",
         }
     )
+
+
+def _handle_needs_auth(exc: NeedsAuthorization) -> str | None:
+    """Fire an interrupt for the first auth failure; return error string for the rest.
+
+    Returns ``None`` when this is the first failure (caller should call
+    ``interrupt()``).  Returns an error-message string for subsequent
+    failures in the same node execution.
+    """
+    if _auth_interrupt_fired.get(False):
+        logger.info(
+            "MCP auth also required for '%s' — skipping duplicate interrupt",
+            exc.mcp_name,
+        )
+        return json.dumps(
+            {
+                "error": "mcp_auth_pending",
+                "mcp_name": exc.mcp_name,
+                "connect_url": exc.connect_url,
+                "message": (
+                    f"Authentication required for {exc.mcp_name}. "
+                    "Another MCP is already awaiting authentication — "
+                    "please connect and retry."
+                ),
+            }
+        )
+    _auth_interrupt_fired.set(True)
+    return None
 
 
 def wrap_mcp_tools_for_auth(tools: list[Any]) -> list[Any]:
@@ -48,6 +97,9 @@ def _wrap_single_tool(tool: Any) -> Any:
                         "MCP auth required for '%s' — interrupting run",
                         exc.mcp_name,
                     )
+                    fallback = _handle_needs_auth(exc)
+                    if fallback is not None:
+                        return fallback
                     interrupt(_mcp_auth_interrupt_payload(exc))
 
         try:
@@ -63,6 +115,9 @@ def _wrap_single_tool(tool: Any) -> Any:
                 try:
                     return func(**kwargs)
                 except NeedsAuthorization as exc:
+                    fallback = _handle_needs_auth(exc)
+                    if fallback is not None:
+                        return fallback
                     interrupt(_mcp_auth_interrupt_payload(exc))
 
         try:

--- a/deep_agent/src/agent/config/resolver.py
+++ b/deep_agent/src/agent/config/resolver.py
@@ -72,7 +72,7 @@ def to_virtual_skill_paths(skill_paths: list[str]) -> list[str]:
     Returns:
         Virtual paths like ["/skills/my-skill", "/skills/other-skill"].
     """
-    virtual: list[str] = []
+    virtual: set[str] = set()
     for p in skill_paths:
         name = Path(p).name
         parent_name = Path(p).parent.name
@@ -83,8 +83,8 @@ def to_virtual_skill_paths(skill_paths: list[str]) -> list[str]:
                 p,
                 name,
             )
-        virtual.append(f"/skills/{name}")
-    return virtual
+        virtual.add(f"/skills/{name}")
+    return sorted(virtual)
 
 
 def resolve_tools(

--- a/deep_agent/src/agent/config/resolver.py
+++ b/deep_agent/src/agent/config/resolver.py
@@ -83,7 +83,7 @@ def to_virtual_skill_paths(skill_paths: list[str]) -> list[str]:
                 p,
                 name,
             )
-        virtual.add(f"/skills/{name}")
+        virtual.add(f"/{parent_name}/")
     return sorted(virtual)
 
 

--- a/deep_agent/src/infrastructure/backend.py
+++ b/deep_agent/src/infrastructure/backend.py
@@ -250,6 +250,15 @@ def get_configured_backend() -> LocalShellBackend | Any:
 
     backend_type = fs_config.backend.type
 
+    skills_dir = agent_config.base_dir / "skills"
+    if backend_type == "state" and skills_dir.is_dir() and any(skills_dir.iterdir()):
+        logger.info(
+            "Skills detected but backend is 'state' — auto-promoting to composite"
+        )
+        fs_config.backend.type = "composite"
+        fs_config.backend.routes.setdefault("/skills/", "filesystem_readonly")
+        return _build_composite_backend(fs_config)
+
     if backend_type == "state":
         return _build_state_backend()
 


### PR DESCRIPTION
## Summary
- Auto-promote `state` backend to `composite` when a skills directory exists, ensuring the `/skills/` route is available for `filesystem_readonly` without explicit config.
- Use route-prefix virtual paths (`/{parent_name}/`) so the agent discovers skills via the backend filesystem rather than individual names.
- Prevent `RuntimeError: multiple pending interrupts` when parallel MCP tool calls both need OAuth -- only the first fires an interrupt, the rest return an error string for the LLM to retry.
- Add `--chmod=755` to `entrypoint.sh` COPY for non-root container execution.

## Test plan
- [ ] Deploy agent with skills configured and verify skills are discoverable and callable
- [ ] Test with 2+ MCP servers requiring OAuth -- confirm no duplicate interrupt crash
- [ ] Verify container starts correctly as non-root user
- [ ] Run existing unit tests (`tests/unit/infrastructure/test_subagents.py`)