### PR TITLE
fix: load model config files and apply temperature/max_tokens to LLM

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -7,7 +7,6 @@ on:
     branches:
       # - main
       - deep-agent
-      - fix/model-config
   pull_request:
     branches: [ main, deep-agent ]
     paths-ignore:

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -7,6 +7,7 @@ on:
     branches:
       # - main
       - deep-agent
+      - fix/model-config
   pull_request:
     branches: [ main, deep-agent ]
     paths-ignore:

--- a/deep_agent/aegra/graph.py
+++ b/deep_agent/aegra/graph.py
@@ -217,15 +217,25 @@ async def agent(runtime: ServerRuntime) -> Any:
     orch_spec = parse_model_config(orch_model_raw)
     model_name = orch_spec.name  # For logging and cache key
 
+    model_params = agent_config.get_model_params(orch_spec.name)
+    orch_temperature = model_params.get("temperature", 0.0)
+    orch_max_tokens = model_params.get("max_tokens") or None
+
     logger.info(
-        "Building agent '%s' (model=%s, provider=%s, mcp_auth=%s)",
+        "Building agent '%s' (model=%s, provider=%s, temp=%s, max_tokens=%s, mcp_auth=%s)",
         agent_name,
         orch_spec.name,
         orch_spec.provider.value,
+        orch_temperature,
+        orch_max_tokens or "default",
         bool(sso_token),
     )
 
-    model = get_or_create_model_from_spec(orch_spec)
+    model = get_or_create_model_from_spec(
+        orch_spec,
+        temperature=float(orch_temperature),
+        max_output_tokens=int(orch_max_tokens) if orch_max_tokens else None,
+    )
 
     providers_config = agent_config.get_providers_config()
     register_profiles_from_config(providers_config)

--- a/deep_agent/aegra/graph.py
+++ b/deep_agent/aegra/graph.py
@@ -90,6 +90,8 @@ def _graph_fingerprint(
     hitl_enabled: bool = False,
     hitl_mode: str = "all",
     hitl_exclude: list[str] | None = None,
+    temperature: float = 0.0,
+    max_tokens: int | None = None,
 ) -> str:
     """Stable fingerprint for graph cache keying."""
     hitl_flag = (
@@ -97,7 +99,8 @@ def _graph_fingerprint(
         f",mode={hitl_mode}"
         f",exclude={','.join(sorted(hitl_exclude or []))}"
     )
-    raw = f"{model_name}\0{system_prompt}\0{','.join(sorted(tool_names))}\0{hitl_flag}"
+    model_flag = f"temp={temperature},max_tokens={max_tokens}"
+    raw = f"{model_name}\0{system_prompt}\0{','.join(sorted(tool_names))}\0{hitl_flag}\0{model_flag}"
     return hashlib.sha256(raw.encode()).hexdigest()[:16]
 
 
@@ -278,6 +281,8 @@ async def agent(runtime: ServerRuntime) -> Any:
         hitl_enabled=hitl.enabled if hitl else False,
         hitl_mode=hitl.mode if hitl else "",
         hitl_exclude=hitl.exclude if hitl else [],
+        temperature=float(orch_temperature),
+        max_tokens=int(orch_max_tokens) if orch_max_tokens else None,
     )
     now = time.time()
     graph_ttl = float(agent_config.get_cache_config().graph.ttl)

--- a/deep_agent/src/agent/config/loader.py
+++ b/deep_agent/src/agent/config/loader.py
@@ -396,6 +396,31 @@ class AgentConfig:
                 if not isinstance(data, dict):
                     continue
                 model_id = data.get("model_id", model_file.stem)
+
+                raw_temp = data.get("temperature")
+                if raw_temp is not None:
+                    try:
+                        data["temperature"] = float(raw_temp)
+                    except (TypeError, ValueError):
+                        logger.warning(
+                            "Invalid temperature %r in %s, using default",
+                            raw_temp,
+                            model_file.name,
+                        )
+                        data.pop("temperature")
+
+                raw_max = data.get("max_tokens")
+                if raw_max is not None:
+                    try:
+                        data["max_tokens"] = int(float(raw_max))
+                    except (TypeError, ValueError):
+                        logger.warning(
+                            "Invalid max_tokens %r in %s, using default",
+                            raw_max,
+                            model_file.name,
+                        )
+                        data.pop("max_tokens")
+
                 configs[model_id] = data
                 logger.info(
                     "Loaded model config: %s (provider=%s, temp=%s, max_tokens=%s)",

--- a/deep_agent/src/agent/config/loader.py
+++ b/deep_agent/src/agent/config/loader.py
@@ -429,7 +429,7 @@ class AgentConfig:
                     data.get("temperature", "default"),
                     data.get("max_tokens", "default"),
                 )
-            except Exception as e:
+            except (yaml.YAMLError, OSError, ValueError) as e:
                 logger.warning(
                     "Failed to parse model config %s: %s", model_file.name, e
                 )

--- a/deep_agent/src/agent/config/loader.py
+++ b/deep_agent/src/agent/config/loader.py
@@ -121,6 +121,7 @@ class AgentConfig:
     _token_budget_config: TokenBudgetConfig
     _guardrails_config: GuardrailsConfig
     _pii_config: PIIConfig
+    _model_configs: dict[str, dict[str, Any]]
     _name: str
 
     def __new__(cls, base_dir: Path | None = None) -> "AgentConfig":
@@ -300,6 +301,7 @@ class AgentConfig:
         self._name = raw.get("name", "Agent")
         # Scan skills first, as orchestrator and subagents need them for resolution
         self._available_skills: dict[str, Path] = self._scan_available_skills()
+        self._model_configs: dict[str, dict[str, Any]] = self._load_model_configs()
         self._orchestrator: dict[str, Any] = self._load_orchestrator()
         self._subagents: dict[str, dict[str, Any]] = self._load_all_subagents()
         self._mcp_servers: dict[str, Any] = self._load_mcp_servers()
@@ -372,6 +374,42 @@ class AgentConfig:
                 f"Failed to load orchestrator config: {e}",
                 ErrorCodes.CONFIGURATION_VALIDATION_ERROR,
             )
+
+    def _load_model_configs(self) -> dict[str, dict[str, Any]]:
+        """Load model config YAML files from config/agent/models/.
+
+        Each file provides runtime LLM parameters (temperature, max_tokens,
+        provider, project, location) that the agent-engine materialized from
+        the registry's MODEL.yaml packages.
+
+        Returns:
+            Dict mapping model_id to its config dict.
+        """
+        models_dir = self._base_dir / "models"
+        if not models_dir.is_dir():
+            return {}
+
+        configs: dict[str, dict[str, Any]] = {}
+        for model_file in sorted(models_dir.glob("*.yaml")):
+            try:
+                data = yaml.safe_load(model_file.read_text()) or {}
+                if not isinstance(data, dict):
+                    continue
+                model_id = data.get("model_id", model_file.stem)
+                configs[model_id] = data
+                logger.info(
+                    "Loaded model config: %s (provider=%s, temp=%s, max_tokens=%s)",
+                    model_id,
+                    data.get("provider", "?"),
+                    data.get("temperature", "default"),
+                    data.get("max_tokens", "default"),
+                )
+            except Exception as e:
+                logger.warning(
+                    "Failed to parse model config %s: %s", model_file.name, e
+                )
+
+        return configs
 
     def _load_all_subagents(self) -> dict[str, dict[str, Any]]:
         """Load all subagent configurations at initialization.
@@ -525,6 +563,15 @@ class AgentConfig:
         """
         self._ensure_loaded()
         return self._orchestrator
+
+    def get_model_params(self, model_id: str) -> dict[str, Any]:
+        """Look up runtime LLM parameters for a model by model_id.
+
+        Returns the model config dict if a matching models/{name}.yaml
+        was materialized by agent-engine, or an empty dict if not found.
+        """
+        self._ensure_loaded()
+        return self._model_configs.get(model_id, {})
 
     def get_all_subagent_configs(self) -> dict[str, dict[str, Any]]:
         """Get all subagent configurations.

--- a/deep_agent/src/infrastructure/subagents.py
+++ b/deep_agent/src/infrastructure/subagents.py
@@ -227,7 +227,11 @@ def _inject_fallback_if_missing(
     return model_dict
 
 
-def _create_primary_model(spec: ModelSpec) -> object:
+def _create_primary_model(
+    spec: ModelSpec,
+    temperature: float | None = None,
+    max_output_tokens: int | None = None,
+) -> object:
     """Create only the primary BaseChatModel from a ModelSpec, without fallback wrapper.
 
     Uses the model cache for efficient reuse. Fallbacks should be handled via
@@ -235,6 +239,8 @@ def _create_primary_model(spec: ModelSpec) -> object:
 
     Args:
         spec: Parsed model specification (fallback config ignored).
+        temperature: Override from model config file, or None for default.
+        max_output_tokens: Override from model config file, or None for default.
 
     Returns:
         A BaseChatModel instance for the primary model only.
@@ -242,8 +248,13 @@ def _create_primary_model(spec: ModelSpec) -> object:
     # Create a spec without fallback for the primary model
     primary_spec = ModelSpec(provider=spec.provider, name=spec.name, fallback=None)
 
-    # Use the cache to get or create the model
-    return get_or_create_model_from_spec(primary_spec)
+    kwargs: dict[str, Any] = {}
+    if temperature is not None:
+        kwargs["temperature"] = temperature
+    if max_output_tokens is not None:
+        kwargs["max_output_tokens"] = max_output_tokens
+
+    return get_or_create_model_from_spec(primary_spec, **kwargs)
 
 
 def _resolve_subagent_model(agent_cfg: dict[str, Any]) -> object:
@@ -256,11 +267,17 @@ def _resolve_subagent_model(agent_cfg: dict[str, Any]) -> object:
     if raw_model is None:
         raise ValueError("missing required 'model' field in frontmatter")
 
-    # Parse model spec (may include fallback config)
     spec = parse_model_config(raw_model)
 
-    # Create only the primary model using the cache
-    return _create_primary_model(spec)
+    model_params = agent_config.get_model_params(spec.name)
+    temp = model_params.get("temperature")
+    max_tok = model_params.get("max_tokens")
+
+    return _create_primary_model(
+        spec,
+        temperature=float(temp) if temp is not None else None,
+        max_output_tokens=int(max_tok) if max_tok is not None else None,
+    )
 
 
 def _format_model_log(spec: ModelSpec) -> str:


### PR DESCRIPTION
Reads model config YAML files from config/agent/models/ (materialized by agent-engine from registry MODEL.yaml packages) and passes temperature and max_tokens to LLM creation for both orchestrator and subagents.