### PR TITLE
ci: exempt Dependabot PRs from title lint and linked issue checks

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -13,6 +13,7 @@ jobs:
     name: Conventional Commit Title
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - name: Validate PR title
         run: |

--- a/.github/workflows/require-issue.yml
+++ b/.github/workflows/require-issue.yml
@@ -13,6 +13,7 @@ jobs:
     name: Check Issue Link
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - name: Require linked issue
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7


### PR DESCRIPTION
## Summary
- Skip the PR title lint and linked issue checks when the PR author is `dependabot[bot]`
- Dependabot PRs were failing CI because they lack linked issues and sometimes generate titles with uppercase type prefixes (e.g. `Chore` instead of `chore`)

## Test plan
- [x] Verify existing Dependabot PRs (#183, #184) pass on re-run after merge
- [x] Verify non-Dependabot PRs still enforce title lint and linked issue checks

Closes #188