### PR TITLE
fix: delete chat from UI with thread cleanup 

### DIFF
--- a/deep_agent/aegra/auth_helpers.py
+++ b/deep_agent/aegra/auth_helpers.py
@@ -1,0 +1,43 @@
+"""Shared authentication helpers for Aegra route handlers."""
+
+from __future__ import annotations
+
+import asyncio
+
+from fastapi import HTTPException, Request
+
+from deep_agent.utils.pylogger import get_python_logger
+
+logger = get_python_logger()
+
+
+async def authenticated_user_id(
+    request: Request, *, reject_anonymous: bool = False
+) -> str:
+    """Extract and return the authenticated user's identity from the JWT.
+
+    Args:
+        request: The incoming FastAPI request.
+        reject_anonymous: If True, raise 401 when credentials are missing
+            instead of returning ``"anonymous"``.
+
+    Returns:
+        The ``sub`` claim from the JWT, ``DEV_USER_ID`` when auth is
+        disabled, or ``"anonymous"`` if credentials are absent and
+        *reject_anonymous* is False.
+    """
+    from deep_agent.aegra.auth import DEV_USER_ID, ENABLE_AUTH, _decode_token
+
+    if not ENABLE_AUTH:
+        return DEV_USER_ID
+
+    auth_header = request.headers.get("authorization", "")
+    if not auth_header.startswith("Bearer "):
+        if reject_anonymous:
+            raise HTTPException(
+                status_code=401, detail="Missing or invalid Authorization header"
+            )
+        return "anonymous"
+
+    payload = await asyncio.to_thread(_decode_token, auth_header[7:])
+    return str(payload["sub"])

--- a/deep_agent/aegra/feedback.py
+++ b/deep_agent/aegra/feedback.py
@@ -33,6 +33,21 @@ logger = get_python_logger()
 feedback_router = APIRouter(tags=["feedback"])
 
 
+async def _authenticated_user_id(request: Request) -> str:
+    """Return the SSO sub from the incoming Bearer token."""
+    from deep_agent.aegra.auth import DEV_USER_ID, ENABLE_AUTH, _decode_token
+
+    if not ENABLE_AUTH:
+        return DEV_USER_ID
+
+    auth_header = request.headers.get("authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return "anonymous"
+
+    payload = _decode_token(auth_header[7:])
+    return str(payload["sub"])
+
+
 def _score_to_feedback_polarity(req: FeedbackRequest) -> Literal["up", "down"]:
     """Map request name/value to stored feedback polarity."""
     name_lower = (req.name or "").lower()
@@ -194,6 +209,9 @@ async def feedback_handler(request: Request) -> JSONResponse:
             },
         )
 
+    jwt_user_id = await _authenticated_user_id(request)
+    payload["user_id"] = jwt_user_id
+
     try:
         resp = await record_feedback(payload)
     except ValidationError as exc:
@@ -225,11 +243,10 @@ def _validate_thread_id(thread_id: str) -> str:
 
 
 @feedback_router.get("/feedback/{thread_id}")
-async def get_thread_feedback(
-    thread_id: str, user_id: str = "anonymous"
-) -> dict[str, Any]:
-    """Return all feedback for a thread."""
+async def get_thread_feedback(thread_id: str, request: Request) -> dict[str, Any]:
+    """Return all feedback for a thread, scoped to the authenticated user."""
     thread_id = _validate_thread_id(thread_id)
+    user_id = await _authenticated_user_id(request)
     if not settings.database_uri:
         return {"feedback": []}
     repo = FeedbackRepository(settings.database_uri)
@@ -238,9 +255,12 @@ async def get_thread_feedback(
 
 
 @feedback_router.get("/threads/{thread_id}/token-usage")
-async def get_thread_token_usage_endpoint(thread_id: str) -> dict[str, Any]:
-    """Return cumulative token usage for a thread."""
+async def get_thread_token_usage_endpoint(
+    thread_id: str, request: Request
+) -> dict[str, Any]:
+    """Return cumulative token usage for a thread (authenticated)."""
     thread_id = _validate_thread_id(thread_id)
+    await _authenticated_user_id(request)
     from dataclasses import asdict
 
     from deep_agent.src.token_budget.service import (

--- a/deep_agent/aegra/feedback.py
+++ b/deep_agent/aegra/feedback.py
@@ -260,7 +260,7 @@ async def get_thread_token_usage_endpoint(
         get_thread_token_usage,
     )
 
-    if not settings.database_uri:
+    if not settings.POSTGRES_HOST:
         raise HTTPException(
             status_code=503,
             detail="Ownership verification unavailable",

--- a/deep_agent/aegra/feedback.py
+++ b/deep_agent/aegra/feedback.py
@@ -21,6 +21,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 
+from deep_agent.aegra.auth_helpers import authenticated_user_id
 from deep_agent.aegra.telemetry import get_langfuse_client
 from deep_agent.src.agent.config import agent_config
 from deep_agent.src.feedback.repository import FeedbackRepository
@@ -31,21 +32,6 @@ from deep_agent.utils.pylogger import get_python_logger
 logger = get_python_logger()
 
 feedback_router = APIRouter(tags=["feedback"])
-
-
-async def _authenticated_user_id(request: Request) -> str:
-    """Return the SSO sub from the incoming Bearer token."""
-    from deep_agent.aegra.auth import DEV_USER_ID, ENABLE_AUTH, _decode_token
-
-    if not ENABLE_AUTH:
-        return DEV_USER_ID
-
-    auth_header = request.headers.get("authorization", "")
-    if not auth_header.startswith("Bearer "):
-        return "anonymous"
-
-    payload = _decode_token(auth_header[7:])
-    return str(payload["sub"])
 
 
 def _score_to_feedback_polarity(req: FeedbackRequest) -> Literal["up", "down"]:
@@ -210,7 +196,7 @@ async def feedback_handler(request: Request) -> JSONResponse:
         )
 
     try:
-        jwt_user_id = await _authenticated_user_id(request)
+        jwt_user_id = await authenticated_user_id(request)
     except Exception:
         logger.warning("JWT decode failed in feedback handler", exc_info=True)
         jwt_user_id = "anonymous"
@@ -250,7 +236,7 @@ def _validate_thread_id(thread_id: str) -> str:
 async def get_thread_feedback(thread_id: str, request: Request) -> dict[str, Any]:
     """Return all feedback for a thread, scoped to the authenticated user."""
     thread_id = _validate_thread_id(thread_id)
-    user_id = await _authenticated_user_id(request)
+    user_id = await authenticated_user_id(request)
     if not settings.database_uri:
         return {"feedback": []}
     repo = FeedbackRepository(settings.database_uri)
@@ -264,7 +250,7 @@ async def get_thread_token_usage_endpoint(
 ) -> dict[str, Any]:
     """Return cumulative token usage for a thread (authenticated)."""
     thread_id = _validate_thread_id(thread_id)
-    user_id = await _authenticated_user_id(request)
+    user_id = await authenticated_user_id(request)
     logger.info("token_usage_requested", thread_id=thread_id, user_id=user_id[:8])
     from dataclasses import asdict
 

--- a/deep_agent/aegra/feedback.py
+++ b/deep_agent/aegra/feedback.py
@@ -269,18 +269,25 @@ async def get_thread_token_usage_endpoint(
     import psycopg
     from psycopg.rows import dict_row
 
-    async with await psycopg.AsyncConnection.connect(
-        settings.database_uri, row_factory=dict_row
-    ) as conn:
-        cur = await conn.execute(
-            "SELECT thread_id FROM thread WHERE thread_id = %s AND user_id = %s",
-            (thread_id, user_id),
-        )
-        if not await cur.fetchone():
-            raise HTTPException(
-                status_code=404,
-                detail=f"Thread '{thread_id}' not found",
-            ) from None
+    try:
+        async with await psycopg.AsyncConnection.connect(
+            settings.database_uri, row_factory=dict_row
+        ) as conn:
+            cur = await conn.execute(
+                "SELECT thread_id FROM thread WHERE thread_id = %s AND user_id = %s",
+                (thread_id, user_id),
+            )
+            if not await cur.fetchone():
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Thread '{thread_id}' not found",
+                ) from None
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(
+            status_code=503, detail="Database connection failed"
+        ) from None
 
     try:
         usage = await get_thread_token_usage(thread_id)

--- a/deep_agent/aegra/feedback.py
+++ b/deep_agent/aegra/feedback.py
@@ -260,22 +260,27 @@ async def get_thread_token_usage_endpoint(
         get_thread_token_usage,
     )
 
-    if settings.database_uri:
-        import psycopg
-        from psycopg.rows import dict_row
+    if not settings.database_uri:
+        raise HTTPException(
+            status_code=503,
+            detail="Ownership verification unavailable",
+        )
 
-        async with await psycopg.AsyncConnection.connect(
-            settings.database_uri, row_factory=dict_row
-        ) as conn:
-            cur = await conn.execute(
-                "SELECT thread_id FROM thread WHERE thread_id = %s AND user_id = %s",
-                (thread_id, user_id),
-            )
-            if not await cur.fetchone():
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"Thread '{thread_id}' not found",
-                ) from None
+    import psycopg
+    from psycopg.rows import dict_row
+
+    async with await psycopg.AsyncConnection.connect(
+        settings.database_uri, row_factory=dict_row
+    ) as conn:
+        cur = await conn.execute(
+            "SELECT thread_id FROM thread WHERE thread_id = %s AND user_id = %s",
+            (thread_id, user_id),
+        )
+        if not await cur.fetchone():
+            raise HTTPException(
+                status_code=404,
+                detail=f"Thread '{thread_id}' not found",
+            ) from None
 
     try:
         usage = await get_thread_token_usage(thread_id)

--- a/deep_agent/aegra/feedback.py
+++ b/deep_agent/aegra/feedback.py
@@ -209,7 +209,11 @@ async def feedback_handler(request: Request) -> JSONResponse:
             },
         )
 
-    jwt_user_id = await _authenticated_user_id(request)
+    try:
+        jwt_user_id = await _authenticated_user_id(request)
+    except Exception:
+        logger.warning("JWT decode failed in feedback handler", exc_info=True)
+        jwt_user_id = "anonymous"
     payload["user_id"] = jwt_user_id
 
     try:
@@ -260,7 +264,8 @@ async def get_thread_token_usage_endpoint(
 ) -> dict[str, Any]:
     """Return cumulative token usage for a thread (authenticated)."""
     thread_id = _validate_thread_id(thread_id)
-    await _authenticated_user_id(request)
+    user_id = await _authenticated_user_id(request)
+    logger.info("token_usage_requested", thread_id=thread_id, user_id=user_id[:8])
     from dataclasses import asdict
 
     from deep_agent.src.token_budget.service import (

--- a/deep_agent/aegra/feedback.py
+++ b/deep_agent/aegra/feedback.py
@@ -236,7 +236,7 @@ def _validate_thread_id(thread_id: str) -> str:
 async def get_thread_feedback(thread_id: str, request: Request) -> dict[str, Any]:
     """Return all feedback for a thread, scoped to the authenticated user."""
     thread_id = _validate_thread_id(thread_id)
-    user_id = await authenticated_user_id(request)
+    user_id = await authenticated_user_id(request, reject_anonymous=True)
     if not settings.database_uri:
         return {"feedback": []}
     repo = FeedbackRepository(settings.database_uri)
@@ -250,7 +250,7 @@ async def get_thread_token_usage_endpoint(
 ) -> dict[str, Any]:
     """Return cumulative token usage for a thread (authenticated)."""
     thread_id = _validate_thread_id(thread_id)
-    user_id = await authenticated_user_id(request)
+    user_id = await authenticated_user_id(request, reject_anonymous=True)
     logger.info("token_usage_requested", thread_id=thread_id, user_id=user_id[:8])
     from dataclasses import asdict
 
@@ -259,6 +259,23 @@ async def get_thread_token_usage_endpoint(
         TokenUsageUnavailableError,
         get_thread_token_usage,
     )
+
+    if settings.database_uri:
+        import psycopg
+        from psycopg.rows import dict_row
+
+        async with await psycopg.AsyncConnection.connect(
+            settings.database_uri, row_factory=dict_row
+        ) as conn:
+            cur = await conn.execute(
+                "SELECT thread_id FROM thread WHERE thread_id = %s AND user_id = %s",
+                (thread_id, user_id),
+            )
+            if not await cur.fetchone():
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Thread '{thread_id}' not found",
+                ) from None
 
     try:
         usage = await get_thread_token_usage(thread_id)

--- a/deep_agent/aegra/graph.py
+++ b/deep_agent/aegra/graph.py
@@ -115,6 +115,47 @@ async def _ensure_startup() -> None:  # noqa: E402
     _startup_done = True
 
 
+async def _sync_personalization(
+    repo: Any,
+    user_id: str,
+    ui_memories: list[str] | None,
+    ui_rules: list[str] | None,
+) -> None:
+    """Sync UI-sent memories/rules to Postgres.
+
+    Compares the UI's current set against the DB and adds new items
+    or removes ones the user deleted in the UI.
+    """
+    if ui_memories is not None:
+        db_memories = await repo.list_memories(user_id)
+        db_contents = {m.content for m in db_memories}
+        for content in ui_memories:
+            if content not in db_contents:
+                await repo.create_memory(user_id, content)
+        ui_set = set(ui_memories)
+        for mem in db_memories:
+            if mem.content not in ui_set:
+                await repo.delete_memory(user_id, mem.id)
+
+    if ui_rules is not None:
+        db_rules = await repo.list_rules(user_id, active_only=False)
+        db_contents = {r.content for r in db_rules}
+        for content in ui_rules:
+            if content not in db_contents:
+                await repo.upsert_rule(user_id, content)
+        ui_set = set(ui_rules)
+        for rule in db_rules:
+            if rule.content not in ui_set:
+                await repo.delete_rule(user_id, rule.id)
+
+    logger.info(
+        "personalization_synced",
+        user_id=user_id[:8],
+        memories=len(ui_memories) if ui_memories else 0,
+        rules=len(ui_rules) if ui_rules else 0,
+    )
+
+
 async def agent(runtime: ServerRuntime) -> Any:
     """Async graph factory — invoked per-request by Aegra.
 
@@ -171,6 +212,7 @@ async def agent(runtime: ServerRuntime) -> Any:
         try:
             from deep_agent.src.cache.personalization_cache import (
                 get_personalization,
+                invalidate,
                 set_personalization,
             )
             from deep_agent.src.memory.config import memory_settings
@@ -180,12 +222,28 @@ async def agent(runtime: ServerRuntime) -> Any:
             )
             from deep_agent.src.settings import settings as app_settings
 
+            repo = PersonalizationRepository(app_settings.database_uri)
+
+            ui_memories = (
+                getattr(runtime, "config", {})
+                .get("configurable", {})
+                .get("user_memories", None)
+            )
+            ui_rules = (
+                getattr(runtime, "config", {})
+                .get("configurable", {})
+                .get("user_rules", None)
+            )
+
+            if ui_memories is not None or ui_rules is not None:
+                await _sync_personalization(repo, user_identity, ui_memories, ui_rules)
+                await invalidate(user_identity)
+
             cached = await get_personalization(user_identity)
             if cached is not None:
                 mem_contents = [m["content"] for m in cached[0]]
                 rule_contents = [r["content"] for r in cached[1]]
             else:
-                repo = PersonalizationRepository(app_settings.database_uri)
                 max_inject = memory_settings.MEMORY_MAX_INJECT
                 memories = await repo.list_top_memories(user_identity, limit=max_inject)
                 rules = await repo.list_rules(user_identity, active_only=True)

--- a/deep_agent/aegra/graph.py
+++ b/deep_agent/aegra/graph.py
@@ -115,47 +115,6 @@ async def _ensure_startup() -> None:  # noqa: E402
     _startup_done = True
 
 
-async def _sync_personalization(
-    repo: Any,
-    user_id: str,
-    ui_memories: list[str] | None,
-    ui_rules: list[str] | None,
-) -> None:
-    """Sync UI-sent memories/rules to Postgres.
-
-    Compares the UI's current set against the DB and adds new items
-    or removes ones the user deleted in the UI.
-    """
-    if ui_memories is not None:
-        db_memories = await repo.list_memories(user_id)
-        db_contents = {m.content for m in db_memories}
-        for content in ui_memories:
-            if content not in db_contents:
-                await repo.create_memory(user_id, content)
-        ui_set = set(ui_memories)
-        for mem in db_memories:
-            if mem.content not in ui_set:
-                await repo.delete_memory(user_id, mem.id)
-
-    if ui_rules is not None:
-        db_rules = await repo.list_rules(user_id, active_only=False)
-        db_contents = {r.content for r in db_rules}
-        for content in ui_rules:
-            if content not in db_contents:
-                await repo.upsert_rule(user_id, content)
-        ui_set = set(ui_rules)
-        for rule in db_rules:
-            if rule.content not in ui_set:
-                await repo.delete_rule(user_id, rule.id)
-
-    logger.info(
-        "personalization_synced",
-        user_id=user_id[:8],
-        memories=len(ui_memories) if ui_memories else 0,
-        rules=len(ui_rules) if ui_rules else 0,
-    )
-
-
 async def agent(runtime: ServerRuntime) -> Any:
     """Async graph factory — invoked per-request by Aegra.
 
@@ -212,7 +171,6 @@ async def agent(runtime: ServerRuntime) -> Any:
         try:
             from deep_agent.src.cache.personalization_cache import (
                 get_personalization,
-                invalidate,
                 set_personalization,
             )
             from deep_agent.src.memory.config import memory_settings
@@ -223,21 +181,6 @@ async def agent(runtime: ServerRuntime) -> Any:
             from deep_agent.src.settings import settings as app_settings
 
             repo = PersonalizationRepository(app_settings.database_uri)
-
-            ui_memories = (
-                getattr(runtime, "config", {})
-                .get("configurable", {})
-                .get("user_memories", None)
-            )
-            ui_rules = (
-                getattr(runtime, "config", {})
-                .get("configurable", {})
-                .get("user_rules", None)
-            )
-
-            if ui_memories is not None or ui_rules is not None:
-                await _sync_personalization(repo, user_identity, ui_memories, ui_rules)
-                await invalidate(user_identity)
 
             cached = await get_personalization(user_identity)
             if cached is not None:

--- a/deep_agent/aegra/http_app.py
+++ b/deep_agent/aegra/http_app.py
@@ -81,7 +81,37 @@ async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
     await run_startup()
     setup_otel_metrics(settings, logger)
     setup_otel_traces(_app, settings, logger)
+    _verify_custom_thread_delete(_app)
     yield
+
+
+def _verify_custom_thread_delete(application: FastAPI) -> None:
+    """Verify our custom DELETE /threads/{id} takes priority over Aegra's built-in.
+
+    Aegra's _include_core_routers adds a threads_router after our custom
+    app routes. FastAPI matches the first registered route, so ours wins.
+    This check fails loudly if that assumption ever breaks.
+    """
+    from deep_agent.aegra.thread_cleanup import delete_thread_with_cleanup
+
+    for route in application.routes:
+        if (
+            hasattr(route, "path")
+            and route.path == "/threads/{thread_id}"
+            and hasattr(route, "methods")
+            and "DELETE" in route.methods
+        ):
+            if route.endpoint is delete_thread_with_cleanup:
+                logger.info("custom_thread_delete_route_verified")
+                return
+            logger.error(
+                "custom_thread_delete_route_overridden: "
+                "Aegra's built-in DELETE /threads/{thread_id} is taking "
+                "priority over our custom cleanup handler. "
+                "Check router registration order in http_app.py."
+            )
+            return
+    logger.warning("thread_delete_route_not_found")
 
 
 app = FastAPI(title="template-agent-custom", lifespan=_lifespan)

--- a/deep_agent/aegra/http_app.py
+++ b/deep_agent/aegra/http_app.py
@@ -104,13 +104,12 @@ def _verify_custom_thread_delete(application: FastAPI) -> None:
             if route.endpoint is delete_thread_with_cleanup:
                 logger.info("custom_thread_delete_route_verified")
                 return
-            logger.error(
+            raise RuntimeError(
                 "custom_thread_delete_route_overridden: "
                 "Aegra's built-in DELETE /threads/{thread_id} is taking "
                 "priority over our custom cleanup handler. "
                 "Check router registration order in http_app.py."
             )
-            return
     logger.warning("thread_delete_route_not_found")
 
 

--- a/deep_agent/aegra/http_app.py
+++ b/deep_agent/aegra/http_app.py
@@ -21,6 +21,7 @@ from deep_agent.aegra.security_middleware import (
     RequestSizeLimitMiddleware,
     SecurityHeadersMiddleware,
 )
+from deep_agent.aegra.thread_cleanup import thread_cleanup_router
 from deep_agent.src.settings import settings
 from deep_agent.utils.pylogger import (
     bind_request_context,
@@ -153,6 +154,7 @@ app.add_middleware(SecurityHeadersMiddleware)
 app.add_middleware(
     RequestSizeLimitMiddleware, max_size_bytes=settings.REQUEST_BODY_MAX_SIZE
 )
+app.include_router(thread_cleanup_router)
 app.include_router(mcp_router)
 app.include_router(feedback_router)
 

--- a/deep_agent/aegra/http_app.py
+++ b/deep_agent/aegra/http_app.py
@@ -17,6 +17,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 from deep_agent.aegra.feedback import feedback_router
 from deep_agent.aegra.mcp_routes import router as mcp_router
+from deep_agent.aegra.personalization_routes import personalization_router
 from deep_agent.aegra.security_middleware import (
     RequestSizeLimitMiddleware,
     SecurityHeadersMiddleware,
@@ -184,6 +185,7 @@ app.add_middleware(
     RequestSizeLimitMiddleware, max_size_bytes=settings.REQUEST_BODY_MAX_SIZE
 )
 app.include_router(thread_cleanup_router)
+app.include_router(personalization_router)
 app.include_router(mcp_router)
 app.include_router(feedback_router)
 

--- a/deep_agent/aegra/personalization_routes.py
+++ b/deep_agent/aegra/personalization_routes.py
@@ -1,0 +1,149 @@
+"""REST API for user memories and custom rules.
+
+Provides CRUD endpoints so the UI can persist personalization data
+immediately when the user adds/removes items in Settings, without
+waiting for a chat message.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from deep_agent.aegra.auth_helpers import authenticated_user_id
+from deep_agent.src.settings import settings
+from deep_agent.utils.pylogger import get_python_logger
+
+logger = get_python_logger()
+
+personalization_router = APIRouter(tags=["personalization"])
+
+
+def _get_repo() -> Any:
+    from deep_agent.src.personalization.repository import PersonalizationRepository
+
+    if not settings.database_uri:
+        raise HTTPException(status_code=503, detail="Database unavailable")
+    return PersonalizationRepository(settings.database_uri)
+
+
+class CreateMemoryRequest(BaseModel):
+    """Request body for creating a memory."""
+
+    content: str
+
+
+class CreateRuleRequest(BaseModel):
+    """Request body for creating a rule."""
+
+    content: str
+    is_active: bool = True
+
+
+# ── Memories ──────────────────────────────────────────────
+
+
+@personalization_router.get("/personalization/memories")
+async def list_memories(request: Request) -> dict[str, Any]:
+    """Return all memories for the authenticated user."""
+    user_id = await authenticated_user_id(request)
+    repo = _get_repo()
+    memories = await repo.list_memories(user_id)
+    return {
+        "memories": [
+            {
+                "id": str(m.id),
+                "content": m.content,
+                "created_at": m.created_at.isoformat(),
+            }
+            for m in memories
+        ]
+    }
+
+
+@personalization_router.post("/personalization/memories", status_code=201)
+async def create_memory(request: Request, body: CreateMemoryRequest) -> dict[str, Any]:
+    """Create a new memory for the authenticated user."""
+    user_id = await authenticated_user_id(request)
+    repo = _get_repo()
+    mem = await repo.create_memory(user_id, body.content)
+    logger.info("memory_created", user_id=user_id[:8], memory_id=str(mem.id))
+    return {
+        "id": str(mem.id),
+        "content": mem.content,
+        "created_at": mem.created_at.isoformat(),
+    }
+
+
+@personalization_router.delete("/personalization/memories/{memory_id}")
+async def delete_memory(memory_id: str, request: Request) -> dict[str, str]:
+    """Delete a memory by ID for the authenticated user."""
+    try:
+        mid = UUID(memory_id)
+    except ValueError:
+        raise HTTPException(
+            status_code=400, detail="Invalid memory_id format"
+        ) from None
+    user_id = await authenticated_user_id(request)
+    repo = _get_repo()
+    deleted = await repo.delete_memory(user_id, mid)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Memory not found")
+    logger.info("memory_deleted", user_id=user_id[:8], memory_id=memory_id)
+    return {"status": "deleted"}
+
+
+# ── Rules ─────────────────────────────────────────────────
+
+
+@personalization_router.get("/personalization/rules")
+async def list_rules(request: Request) -> dict[str, Any]:
+    """Return all rules for the authenticated user."""
+    user_id = await authenticated_user_id(request)
+    repo = _get_repo()
+    rules = await repo.list_rules(user_id, active_only=False)
+    return {
+        "rules": [
+            {
+                "id": str(r.id),
+                "content": r.content,
+                "is_active": r.is_active,
+                "created_at": r.created_at.isoformat(),
+            }
+            for r in rules
+        ]
+    }
+
+
+@personalization_router.post("/personalization/rules", status_code=201)
+async def create_rule(request: Request, body: CreateRuleRequest) -> dict[str, Any]:
+    """Create a new rule for the authenticated user."""
+    user_id = await authenticated_user_id(request)
+    repo = _get_repo()
+    rule = await repo.upsert_rule(user_id, body.content, is_active=body.is_active)
+    logger.info("rule_created", user_id=user_id[:8], rule_id=str(rule.id))
+    return {
+        "id": str(rule.id),
+        "content": rule.content,
+        "is_active": rule.is_active,
+        "created_at": rule.created_at.isoformat(),
+    }
+
+
+@personalization_router.delete("/personalization/rules/{rule_id}")
+async def delete_rule(rule_id: str, request: Request) -> dict[str, str]:
+    """Delete a rule by ID for the authenticated user."""
+    try:
+        rid = UUID(rule_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid rule_id format") from None
+    user_id = await authenticated_user_id(request)
+    repo = _get_repo()
+    deleted = await repo.delete_rule(user_id, rid)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Rule not found")
+    logger.info("rule_deleted", user_id=user_id[:8], rule_id=rule_id)
+    return {"status": "deleted"}

--- a/deep_agent/aegra/personalization_routes.py
+++ b/deep_agent/aegra/personalization_routes.py
@@ -128,10 +128,6 @@ async def create_rule(request: Request, body: CreateRuleRequest) -> dict[str, An
     """Create a new rule for the authenticated user."""
     user_id = await authenticated_user_id(request, reject_anonymous=True)
     repo = _get_repo()
-    if body.id is not None:
-        existing = await repo.get_rule_owner(body.id)
-        if existing is not None and existing != user_id:
-            raise HTTPException(status_code=403, detail="Rule belongs to another user")
     rule = await repo.upsert_rule(
         user_id, body.content, rule_id=body.id, is_active=body.is_active
     )

--- a/deep_agent/aegra/personalization_routes.py
+++ b/deep_agent/aegra/personalization_routes.py
@@ -33,12 +33,14 @@ def _get_repo() -> Any:
 class CreateMemoryRequest(BaseModel):
     """Request body for creating a memory."""
 
+    id: str | None = None
     content: str
 
 
 class CreateRuleRequest(BaseModel):
     """Request body for creating a rule."""
 
+    id: str | None = None
     content: str
     is_active: bool = True
 
@@ -69,7 +71,8 @@ async def create_memory(request: Request, body: CreateMemoryRequest) -> dict[str
     """Create a new memory for the authenticated user."""
     user_id = await authenticated_user_id(request)
     repo = _get_repo()
-    mem = await repo.create_memory(user_id, body.content)
+    memory_id = UUID(body.id) if body.id else None
+    mem = await repo.create_memory(user_id, body.content, memory_id=memory_id)
     logger.info("memory_created", user_id=user_id[:8], memory_id=str(mem.id))
     return {
         "id": str(mem.id),
@@ -123,7 +126,10 @@ async def create_rule(request: Request, body: CreateRuleRequest) -> dict[str, An
     """Create a new rule for the authenticated user."""
     user_id = await authenticated_user_id(request)
     repo = _get_repo()
-    rule = await repo.upsert_rule(user_id, body.content, is_active=body.is_active)
+    rule_id = UUID(body.id) if body.id else None
+    rule = await repo.upsert_rule(
+        user_id, body.content, rule_id=rule_id, is_active=body.is_active
+    )
     logger.info("rule_created", user_id=user_id[:8], rule_id=str(rule.id))
     return {
         "id": str(rule.id),

--- a/deep_agent/aegra/personalization_routes.py
+++ b/deep_agent/aegra/personalization_routes.py
@@ -7,7 +7,7 @@ waiting for a chat message.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Request
@@ -17,12 +17,15 @@ from deep_agent.aegra.auth_helpers import authenticated_user_id
 from deep_agent.src.settings import settings
 from deep_agent.utils.pylogger import get_python_logger
 
+if TYPE_CHECKING:
+    from deep_agent.src.personalization.repository import PersonalizationRepository
+
 logger = get_python_logger()
 
 personalization_router = APIRouter(tags=["personalization"])
 
 
-def _get_repo() -> Any:
+def _get_repo() -> PersonalizationRepository:
     from deep_agent.src.personalization.repository import PersonalizationRepository
 
     if not settings.database_uri:
@@ -33,14 +36,14 @@ def _get_repo() -> Any:
 class CreateMemoryRequest(BaseModel):
     """Request body for creating a memory."""
 
-    id: str | None = None
+    id: UUID | None = None
     content: str
 
 
 class CreateRuleRequest(BaseModel):
     """Request body for creating a rule."""
 
-    id: str | None = None
+    id: UUID | None = None
     content: str
     is_active: bool = True
 
@@ -71,8 +74,7 @@ async def create_memory(request: Request, body: CreateMemoryRequest) -> dict[str
     """Create a new memory for the authenticated user."""
     user_id = await authenticated_user_id(request, reject_anonymous=True)
     repo = _get_repo()
-    memory_id = UUID(body.id) if body.id else None
-    mem = await repo.create_memory(user_id, body.content, memory_id=memory_id)
+    mem = await repo.create_memory(user_id, body.content, memory_id=body.id)
     logger.info("memory_created", user_id=user_id[:8], memory_id=str(mem.id))
     return {
         "id": str(mem.id),
@@ -126,9 +128,12 @@ async def create_rule(request: Request, body: CreateRuleRequest) -> dict[str, An
     """Create a new rule for the authenticated user."""
     user_id = await authenticated_user_id(request, reject_anonymous=True)
     repo = _get_repo()
-    rule_id = UUID(body.id) if body.id else None
+    if body.id is not None:
+        existing = await repo.get_rule_owner(body.id)
+        if existing is not None and existing != user_id:
+            raise HTTPException(status_code=403, detail="Rule belongs to another user")
     rule = await repo.upsert_rule(
-        user_id, body.content, rule_id=rule_id, is_active=body.is_active
+        user_id, body.content, rule_id=body.id, is_active=body.is_active
     )
     logger.info("rule_created", user_id=user_id[:8], rule_id=str(rule.id))
     return {

--- a/deep_agent/aegra/personalization_routes.py
+++ b/deep_agent/aegra/personalization_routes.py
@@ -51,7 +51,7 @@ class CreateRuleRequest(BaseModel):
 @personalization_router.get("/personalization/memories")
 async def list_memories(request: Request) -> dict[str, Any]:
     """Return all memories for the authenticated user."""
-    user_id = await authenticated_user_id(request)
+    user_id = await authenticated_user_id(request, reject_anonymous=True)
     repo = _get_repo()
     memories = await repo.list_memories(user_id)
     return {
@@ -69,7 +69,7 @@ async def list_memories(request: Request) -> dict[str, Any]:
 @personalization_router.post("/personalization/memories", status_code=201)
 async def create_memory(request: Request, body: CreateMemoryRequest) -> dict[str, Any]:
     """Create a new memory for the authenticated user."""
-    user_id = await authenticated_user_id(request)
+    user_id = await authenticated_user_id(request, reject_anonymous=True)
     repo = _get_repo()
     memory_id = UUID(body.id) if body.id else None
     mem = await repo.create_memory(user_id, body.content, memory_id=memory_id)
@@ -90,7 +90,7 @@ async def delete_memory(memory_id: str, request: Request) -> dict[str, str]:
         raise HTTPException(
             status_code=400, detail="Invalid memory_id format"
         ) from None
-    user_id = await authenticated_user_id(request)
+    user_id = await authenticated_user_id(request, reject_anonymous=True)
     repo = _get_repo()
     deleted = await repo.delete_memory(user_id, mid)
     if not deleted:
@@ -105,7 +105,7 @@ async def delete_memory(memory_id: str, request: Request) -> dict[str, str]:
 @personalization_router.get("/personalization/rules")
 async def list_rules(request: Request) -> dict[str, Any]:
     """Return all rules for the authenticated user."""
-    user_id = await authenticated_user_id(request)
+    user_id = await authenticated_user_id(request, reject_anonymous=True)
     repo = _get_repo()
     rules = await repo.list_rules(user_id, active_only=False)
     return {
@@ -124,7 +124,7 @@ async def list_rules(request: Request) -> dict[str, Any]:
 @personalization_router.post("/personalization/rules", status_code=201)
 async def create_rule(request: Request, body: CreateRuleRequest) -> dict[str, Any]:
     """Create a new rule for the authenticated user."""
-    user_id = await authenticated_user_id(request)
+    user_id = await authenticated_user_id(request, reject_anonymous=True)
     repo = _get_repo()
     rule_id = UUID(body.id) if body.id else None
     rule = await repo.upsert_rule(
@@ -146,7 +146,7 @@ async def delete_rule(rule_id: str, request: Request) -> dict[str, str]:
         rid = UUID(rule_id)
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid rule_id format") from None
-    user_id = await authenticated_user_id(request)
+    user_id = await authenticated_user_id(request, reject_anonymous=True)
     repo = _get_repo()
     deleted = await repo.delete_rule(user_id, rid)
     if not deleted:

--- a/deep_agent/aegra/personalization_routes.py
+++ b/deep_agent/aegra/personalization_routes.py
@@ -128,9 +128,14 @@ async def create_rule(request: Request, body: CreateRuleRequest) -> dict[str, An
     """Create a new rule for the authenticated user."""
     user_id = await authenticated_user_id(request, reject_anonymous=True)
     repo = _get_repo()
-    rule = await repo.upsert_rule(
-        user_id, body.content, rule_id=body.id, is_active=body.is_active
-    )
+    try:
+        rule = await repo.upsert_rule(
+            user_id, body.content, rule_id=body.id, is_active=body.is_active
+        )
+    except PermissionError:
+        raise HTTPException(
+            status_code=409, detail="Rule belongs to another user"
+        ) from None
     logger.info("rule_created", user_id=user_id[:8], rule_id=str(rule.id))
     return {
         "id": str(rule.id),

--- a/deep_agent/aegra/thread_cleanup.py
+++ b/deep_agent/aegra/thread_cleanup.py
@@ -14,28 +14,13 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
 
+from deep_agent.aegra.auth_helpers import authenticated_user_id
 from deep_agent.src.settings import settings
 from deep_agent.utils.pylogger import get_python_logger
 
 logger = get_python_logger()
 
 thread_cleanup_router = APIRouter(tags=["threads"])
-
-
-async def _authenticated_user_id(request: Request) -> str:
-    from deep_agent.aegra.auth import DEV_USER_ID, ENABLE_AUTH, _decode_token
-
-    if not ENABLE_AUTH:
-        return DEV_USER_ID
-
-    auth_header = request.headers.get("authorization", "")
-    if not auth_header.startswith("Bearer "):
-        raise HTTPException(
-            status_code=401, detail="Missing or invalid Authorization header"
-        )
-
-    payload = _decode_token(auth_header[7:])
-    return str(payload["sub"])
 
 
 async def _delete_checkpoints(thread_id: str) -> int:
@@ -112,7 +97,7 @@ async def delete_thread_with_cleanup(
             status_code=400, detail="Invalid thread_id format"
         ) from None
 
-    user_id = await _authenticated_user_id(request)
+    user_id = await authenticated_user_id(request)
 
     if not settings.database_uri:
         raise HTTPException(status_code=503, detail="Database unavailable")

--- a/deep_agent/aegra/thread_cleanup.py
+++ b/deep_agent/aegra/thread_cleanup.py
@@ -1,0 +1,159 @@
+"""Thread deletion with full data cleanup.
+
+Overrides Aegra's default DELETE /threads/{thread_id} to also purge:
+- LangGraph checkpoint history (checkpoints, blobs, writes)
+- User feedback (message_feedback table)
+- Token usage records (MongoDB, if configured)
+
+Aegra's built-in delete only removes the thread row and cascades to runs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+
+from deep_agent.src.settings import settings
+from deep_agent.utils.pylogger import get_python_logger
+
+logger = get_python_logger()
+
+thread_cleanup_router = APIRouter(tags=["threads"])
+
+
+async def _authenticated_user_id(request: Request) -> str:
+    from deep_agent.aegra.auth import DEV_USER_ID, ENABLE_AUTH, _decode_token
+
+    if not ENABLE_AUTH:
+        return DEV_USER_ID
+
+    auth_header = request.headers.get("authorization", "")
+    if not auth_header.startswith("Bearer "):
+        raise HTTPException(
+            status_code=401, detail="Missing or invalid Authorization header"
+        )
+
+    payload = _decode_token(auth_header[7:])
+    return str(payload["sub"])
+
+
+async def _delete_checkpoints(thread_id: str) -> int:
+    """Delete all LangGraph checkpoint data for a thread."""
+    try:
+        import psycopg
+
+        async with await psycopg.AsyncConnection.connect(settings.database_uri) as conn:
+            deleted = 0
+            for table in ("checkpoint_writes", "checkpoint_blobs", "checkpoints"):
+                cur = await conn.execute(
+                    f"DELETE FROM {table} WHERE thread_id = %s",
+                    (thread_id,),
+                )
+                deleted += cur.rowcount
+            await conn.commit()
+        return deleted
+    except Exception:
+        logger.warning("checkpoint_cleanup_failed", thread_id=thread_id, exc_info=True)
+        return 0
+
+
+async def _delete_feedback(thread_id: str) -> int:
+    """Delete all feedback entries for a thread."""
+    try:
+        import psycopg
+
+        async with await psycopg.AsyncConnection.connect(settings.database_uri) as conn:
+            cur = await conn.execute(
+                "DELETE FROM message_feedback WHERE thread_id = %s",
+                (thread_id,),
+            )
+            await conn.commit()
+            count: int = cur.rowcount
+            return count
+    except Exception:
+        logger.warning("feedback_cleanup_failed", thread_id=thread_id, exc_info=True)
+        return 0
+
+
+async def _delete_token_usage(thread_id: str) -> bool:
+    """Delete token usage records for a thread from MongoDB."""
+    try:
+        if not settings.MONGODB_URI:
+            return False
+
+        from deep_agent.src.token_budget.service import _mongo_repo
+
+        repo = _mongo_repo()
+        result = await repo._thread_collection().delete_many({"thread_id": thread_id})
+        return bool(result.deleted_count > 0)
+    except Exception:
+        logger.warning("token_usage_cleanup_failed", thread_id=thread_id, exc_info=True)
+        return False
+
+
+@thread_cleanup_router.delete("/threads/{thread_id}")
+async def delete_thread_with_cleanup(
+    thread_id: str, request: Request
+) -> dict[str, Any]:
+    """Delete a thread and purge all associated data.
+
+    Goes beyond Aegra's default delete by also cleaning up:
+    - Checkpoint history (conversation messages)
+    - Feedback records
+    - Token usage records
+    """
+    from uuid import UUID
+
+    try:
+        UUID(thread_id)
+    except ValueError:
+        raise HTTPException(
+            status_code=400, detail="Invalid thread_id format"
+        ) from None
+
+    user_id = await _authenticated_user_id(request)
+
+    if not settings.database_uri:
+        raise HTTPException(status_code=503, detail="Database unavailable")
+
+    import psycopg
+    from psycopg.rows import dict_row
+
+    async with await psycopg.AsyncConnection.connect(
+        settings.database_uri, row_factory=dict_row
+    ) as conn:
+        cur = await conn.execute(
+            "SELECT thread_id FROM thread WHERE thread_id = %s AND user_id = %s",
+            (thread_id, user_id),
+        )
+        thread = await cur.fetchone()
+
+    if not thread:
+        raise HTTPException(status_code=404, detail=f"Thread '{thread_id}' not found")
+
+    checkpoint_count = await _delete_checkpoints(thread_id)
+    feedback_count = await _delete_feedback(thread_id)
+    token_usage_deleted = await _delete_token_usage(thread_id)
+
+    async with await psycopg.AsyncConnection.connect(settings.database_uri) as conn:
+        await conn.execute(
+            "DELETE FROM runs WHERE thread_id = %s AND user_id = %s",
+            (thread_id, user_id),
+        )
+        await conn.execute(
+            "DELETE FROM thread WHERE thread_id = %s AND user_id = %s",
+            (thread_id, user_id),
+        )
+        await conn.commit()
+
+    logger.info(
+        "thread_deleted_with_cleanup",
+        thread_id=thread_id,
+        user_id=user_id[:8],
+        checkpoints_deleted=checkpoint_count,
+        feedback_deleted=feedback_count,
+        token_usage_deleted=token_usage_deleted,
+    )
+
+    return {"status": "deleted"}

--- a/deep_agent/aegra/thread_cleanup.py
+++ b/deep_agent/aegra/thread_cleanup.py
@@ -116,27 +116,26 @@ async def delete_thread_with_cleanup(
         raise HTTPException(status_code=503, detail="Database unavailable")
 
     import psycopg
-    from psycopg.rows import dict_row
 
-    async with await psycopg.AsyncConnection.connect(
-        settings.database_uri, row_factory=dict_row
-    ) as conn:
+    async with await psycopg.AsyncConnection.connect(settings.database_uri) as conn:
         if user_id is not None:
             cur = await conn.execute(
-                "SELECT thread_id FROM thread WHERE thread_id = %s AND user_id = %s",
+                "SELECT thread_id FROM thread "
+                "WHERE thread_id = %s AND user_id = %s FOR UPDATE",
                 (thread_id, user_id),
             )
         else:
             cur = await conn.execute(
-                "SELECT thread_id FROM thread WHERE thread_id = %s",
+                "SELECT thread_id FROM thread WHERE thread_id = %s FOR UPDATE",
                 (thread_id,),
             )
         thread = await cur.fetchone()
 
-    if not thread:
-        raise HTTPException(status_code=404, detail=f"Thread '{thread_id}' not found")
+        if not thread:
+            raise HTTPException(
+                status_code=404, detail=f"Thread '{thread_id}' not found"
+            )
 
-    async with await psycopg.AsyncConnection.connect(settings.database_uri) as conn:
         counts = await _delete_pg_data(thread_id, user_id, conn)
         await conn.commit()
 

--- a/deep_agent/aegra/thread_cleanup.py
+++ b/deep_agent/aegra/thread_cleanup.py
@@ -28,8 +28,14 @@ logger = get_python_logger()
 thread_cleanup_router = APIRouter(tags=["threads"])
 
 
-async def _delete_pg_data(thread_id: str, user_id: str, conn: Any) -> dict[str, int]:
-    """Delete all PostgreSQL data for a thread within an existing transaction."""
+async def _delete_pg_data(
+    thread_id: str, user_id: str | None, conn: Any
+) -> dict[str, int]:
+    """Delete all PostgreSQL data for a thread within an existing transaction.
+
+    When *user_id* is ``None`` (auth disabled), runs and thread rows are
+    deleted without a user scope filter.
+    """
     counts: dict[str, int] = {}
 
     checkpoint_total = 0
@@ -47,14 +53,24 @@ async def _delete_pg_data(thread_id: str, user_id: str, conn: Any) -> dict[str, 
     )
     counts["feedback"] = cur.rowcount
 
-    await conn.execute(
-        "DELETE FROM runs WHERE thread_id = %s AND user_id = %s",
-        (thread_id, user_id),
-    )
-    await conn.execute(
-        "DELETE FROM thread WHERE thread_id = %s AND user_id = %s",
-        (thread_id, user_id),
-    )
+    if user_id is not None:
+        await conn.execute(
+            "DELETE FROM runs WHERE thread_id = %s AND user_id = %s",
+            (thread_id, user_id),
+        )
+        await conn.execute(
+            "DELETE FROM thread WHERE thread_id = %s AND user_id = %s",
+            (thread_id, user_id),
+        )
+    else:
+        await conn.execute(
+            "DELETE FROM runs WHERE thread_id = %s",
+            (thread_id,),
+        )
+        await conn.execute(
+            "DELETE FROM thread WHERE thread_id = %s",
+            (thread_id,),
+        )
 
     return counts
 
@@ -90,7 +106,11 @@ async def delete_thread_with_cleanup(
             status_code=400, detail="Invalid thread_id format"
         ) from None
 
-    user_id = await authenticated_user_id(request, reject_anonymous=True)
+    from deep_agent.aegra.auth import ENABLE_AUTH
+
+    user_id: str | None = None
+    if ENABLE_AUTH:
+        user_id = await authenticated_user_id(request, reject_anonymous=True)
 
     if not settings.database_uri:
         raise HTTPException(status_code=503, detail="Database unavailable")
@@ -101,10 +121,16 @@ async def delete_thread_with_cleanup(
     async with await psycopg.AsyncConnection.connect(
         settings.database_uri, row_factory=dict_row
     ) as conn:
-        cur = await conn.execute(
-            "SELECT thread_id FROM thread WHERE thread_id = %s AND user_id = %s",
-            (thread_id, user_id),
-        )
+        if user_id is not None:
+            cur = await conn.execute(
+                "SELECT thread_id FROM thread WHERE thread_id = %s AND user_id = %s",
+                (thread_id, user_id),
+            )
+        else:
+            cur = await conn.execute(
+                "SELECT thread_id FROM thread WHERE thread_id = %s",
+                (thread_id,),
+            )
         thread = await cur.fetchone()
 
     if not thread:
@@ -127,7 +153,7 @@ async def delete_thread_with_cleanup(
     logger.info(
         "thread_deleted_with_cleanup",
         thread_id=thread_id,
-        user_id=user_id[:8],
+        user_id=user_id[:8] if user_id else "no-auth",
         checkpoints_deleted=counts["checkpoints"],
         feedback_deleted=counts["feedback"],
         token_usage_deleted=token_usage_deleted,

--- a/deep_agent/aegra/thread_cleanup.py
+++ b/deep_agent/aegra/thread_cleanup.py
@@ -25,56 +25,44 @@ thread_cleanup_router = APIRouter(tags=["threads"])
 
 async def _delete_checkpoints(thread_id: str) -> int:
     """Delete all LangGraph checkpoint data for a thread."""
-    try:
-        import psycopg
+    import psycopg
 
-        async with await psycopg.AsyncConnection.connect(settings.database_uri) as conn:
-            deleted = 0
-            for table in ("checkpoint_writes", "checkpoint_blobs", "checkpoints"):
-                cur = await conn.execute(
-                    f"DELETE FROM {table} WHERE thread_id = %s",
-                    (thread_id,),
-                )
-                deleted += cur.rowcount
-            await conn.commit()
-        return deleted
-    except Exception:
-        logger.warning("checkpoint_cleanup_failed", thread_id=thread_id, exc_info=True)
-        return 0
+    async with await psycopg.AsyncConnection.connect(settings.database_uri) as conn:
+        deleted = 0
+        for table in ("checkpoint_writes", "checkpoint_blobs", "checkpoints"):
+            cur = await conn.execute(
+                f"DELETE FROM {table} WHERE thread_id = %s",
+                (thread_id,),
+            )
+            deleted += cur.rowcount
+        await conn.commit()
+    return deleted
 
 
 async def _delete_feedback(thread_id: str) -> int:
     """Delete all feedback entries for a thread."""
-    try:
-        import psycopg
+    import psycopg
 
-        async with await psycopg.AsyncConnection.connect(settings.database_uri) as conn:
-            cur = await conn.execute(
-                "DELETE FROM message_feedback WHERE thread_id = %s",
-                (thread_id,),
-            )
-            await conn.commit()
-            count: int = cur.rowcount
-            return count
-    except Exception:
-        logger.warning("feedback_cleanup_failed", thread_id=thread_id, exc_info=True)
-        return 0
+    async with await psycopg.AsyncConnection.connect(settings.database_uri) as conn:
+        cur = await conn.execute(
+            "DELETE FROM message_feedback WHERE thread_id = %s",
+            (thread_id,),
+        )
+        await conn.commit()
+        count: int = cur.rowcount
+        return count
 
 
 async def _delete_token_usage(thread_id: str) -> bool:
     """Delete token usage records for a thread from MongoDB."""
-    try:
-        if not settings.MONGODB_URI:
-            return False
-
-        from deep_agent.src.token_budget.service import _mongo_repo
-
-        repo = _mongo_repo()
-        result = await repo._thread_collection().delete_many({"thread_id": thread_id})
-        return bool(result.deleted_count > 0)
-    except Exception:
-        logger.warning("token_usage_cleanup_failed", thread_id=thread_id, exc_info=True)
+    if not settings.MONGODB_URI:
         return False
+
+    from deep_agent.src.token_budget.service import _mongo_repo
+
+    repo = _mongo_repo()
+    result = await repo._thread_collection().delete_many({"thread_id": thread_id})
+    return bool(result.deleted_count > 0)
 
 
 @thread_cleanup_router.delete("/threads/{thread_id}")
@@ -97,7 +85,7 @@ async def delete_thread_with_cleanup(
             status_code=400, detail="Invalid thread_id format"
         ) from None
 
-    user_id = await authenticated_user_id(request)
+    user_id = await authenticated_user_id(request, reject_anonymous=True)
 
     if not settings.database_uri:
         raise HTTPException(status_code=503, detail="Database unavailable")
@@ -117,9 +105,35 @@ async def delete_thread_with_cleanup(
     if not thread:
         raise HTTPException(status_code=404, detail=f"Thread '{thread_id}' not found")
 
-    checkpoint_count = await _delete_checkpoints(thread_id)
-    feedback_count = await _delete_feedback(thread_id)
-    token_usage_deleted = await _delete_token_usage(thread_id)
+    errors: list[str] = []
+    checkpoint_count = 0
+    feedback_count = 0
+    token_usage_deleted = False
+
+    try:
+        checkpoint_count = await _delete_checkpoints(thread_id)
+    except Exception:
+        logger.warning("checkpoint_cleanup_failed", thread_id=thread_id, exc_info=True)
+        errors.append("checkpoints")
+
+    try:
+        feedback_count = await _delete_feedback(thread_id)
+    except Exception:
+        logger.warning("feedback_cleanup_failed", thread_id=thread_id, exc_info=True)
+        errors.append("feedback")
+
+    try:
+        token_usage_deleted = await _delete_token_usage(thread_id)
+    except Exception:
+        logger.warning("token_usage_cleanup_failed", thread_id=thread_id, exc_info=True)
+        errors.append("token_usage")
+
+    if errors:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Cleanup failed for: {', '.join(errors)}. "
+            f"Thread not deleted to prevent orphaned records.",
+        )
 
     async with await psycopg.AsyncConnection.connect(settings.database_uri) as conn:
         await conn.execute(

--- a/deep_agent/aegra/thread_cleanup.py
+++ b/deep_agent/aegra/thread_cleanup.py
@@ -6,6 +6,11 @@ Overrides Aegra's default DELETE /threads/{thread_id} to also purge:
 - Token usage records (MongoDB, if configured)
 
 Aegra's built-in delete only removes the thread row and cascades to runs.
+
+All PostgreSQL deletes run in a single transaction so a mid-cleanup
+failure never leaves partially-deleted data on an accessible thread.
+MongoDB token-usage cleanup runs after the PG commit as best-effort
+(cross-database atomicity is not possible).
 """
 
 from __future__ import annotations
@@ -23,38 +28,39 @@ logger = get_python_logger()
 thread_cleanup_router = APIRouter(tags=["threads"])
 
 
-async def _delete_checkpoints(thread_id: str) -> int:
-    """Delete all LangGraph checkpoint data for a thread."""
-    import psycopg
+async def _delete_pg_data(thread_id: str, user_id: str, conn: Any) -> dict[str, int]:
+    """Delete all PostgreSQL data for a thread within an existing transaction."""
+    counts: dict[str, int] = {}
 
-    async with await psycopg.AsyncConnection.connect(settings.database_uri) as conn:
-        deleted = 0
-        for table in ("checkpoint_writes", "checkpoint_blobs", "checkpoints"):
-            cur = await conn.execute(
-                f"DELETE FROM {table} WHERE thread_id = %s",
-                (thread_id,),
-            )
-            deleted += cur.rowcount
-        await conn.commit()
-    return deleted
-
-
-async def _delete_feedback(thread_id: str) -> int:
-    """Delete all feedback entries for a thread."""
-    import psycopg
-
-    async with await psycopg.AsyncConnection.connect(settings.database_uri) as conn:
+    checkpoint_total = 0
+    for table in ("checkpoint_writes", "checkpoint_blobs", "checkpoints"):
         cur = await conn.execute(
-            "DELETE FROM message_feedback WHERE thread_id = %s",
+            f"DELETE FROM {table} WHERE thread_id = %s",
             (thread_id,),
         )
-        await conn.commit()
-        count: int = cur.rowcount
-        return count
+        checkpoint_total += cur.rowcount
+    counts["checkpoints"] = checkpoint_total
+
+    cur = await conn.execute(
+        "DELETE FROM message_feedback WHERE thread_id = %s",
+        (thread_id,),
+    )
+    counts["feedback"] = cur.rowcount
+
+    await conn.execute(
+        "DELETE FROM runs WHERE thread_id = %s AND user_id = %s",
+        (thread_id, user_id),
+    )
+    await conn.execute(
+        "DELETE FROM thread WHERE thread_id = %s AND user_id = %s",
+        (thread_id, user_id),
+    )
+
+    return counts
 
 
 async def _delete_token_usage(thread_id: str) -> bool:
-    """Delete token usage records for a thread from MongoDB."""
+    """Delete token usage records for a thread from MongoDB (best-effort)."""
     if not settings.MONGODB_URI:
         return False
 
@@ -71,10 +77,9 @@ async def delete_thread_with_cleanup(
 ) -> dict[str, Any]:
     """Delete a thread and purge all associated data.
 
-    Goes beyond Aegra's default delete by also cleaning up:
-    - Checkpoint history (conversation messages)
-    - Feedback records
-    - Token usage records
+    All PostgreSQL deletes (checkpoints, feedback, runs, thread) execute
+    in one transaction — either everything is removed or nothing is.
+    MongoDB token-usage cleanup runs after the PG commit as best-effort.
     """
     from uuid import UUID
 
@@ -105,53 +110,26 @@ async def delete_thread_with_cleanup(
     if not thread:
         raise HTTPException(status_code=404, detail=f"Thread '{thread_id}' not found")
 
-    errors: list[str] = []
-    checkpoint_count = 0
-    feedback_count = 0
+    async with await psycopg.AsyncConnection.connect(settings.database_uri) as conn:
+        counts = await _delete_pg_data(thread_id, user_id, conn)
+        await conn.commit()
+
     token_usage_deleted = False
-
-    try:
-        checkpoint_count = await _delete_checkpoints(thread_id)
-    except Exception:
-        logger.warning("checkpoint_cleanup_failed", thread_id=thread_id, exc_info=True)
-        errors.append("checkpoints")
-
-    try:
-        feedback_count = await _delete_feedback(thread_id)
-    except Exception:
-        logger.warning("feedback_cleanup_failed", thread_id=thread_id, exc_info=True)
-        errors.append("feedback")
-
     try:
         token_usage_deleted = await _delete_token_usage(thread_id)
     except Exception:
-        logger.warning("token_usage_cleanup_failed", thread_id=thread_id, exc_info=True)
-        errors.append("token_usage")
-
-    if errors:
-        raise HTTPException(
-            status_code=500,
-            detail=f"Cleanup failed for: {', '.join(errors)}. "
-            f"Thread not deleted to prevent orphaned records.",
+        logger.warning(
+            "token_usage_cleanup_failed_after_pg_commit",
+            thread_id=thread_id,
+            exc_info=True,
         )
-
-    async with await psycopg.AsyncConnection.connect(settings.database_uri) as conn:
-        await conn.execute(
-            "DELETE FROM runs WHERE thread_id = %s AND user_id = %s",
-            (thread_id, user_id),
-        )
-        await conn.execute(
-            "DELETE FROM thread WHERE thread_id = %s AND user_id = %s",
-            (thread_id, user_id),
-        )
-        await conn.commit()
 
     logger.info(
         "thread_deleted_with_cleanup",
         thread_id=thread_id,
         user_id=user_id[:8],
-        checkpoints_deleted=checkpoint_count,
-        feedback_deleted=feedback_count,
+        checkpoints_deleted=counts["checkpoints"],
+        feedback_deleted=counts["feedback"],
         token_usage_deleted=token_usage_deleted,
     )
 

--- a/deep_agent/src/cache/backend.py
+++ b/deep_agent/src/cache/backend.py
@@ -193,5 +193,16 @@ class RedisCache:
         except Exception:
             return False
 
+    def expire(self, key: str, ttl: int) -> bool:
+        """Set a short TTL on a key so it expires soon even if delete fails."""
+        client = self._get_client()
+        if client is None:
+            return False
+        try:
+            client.expire(self._key(key), ttl)
+            return True
+        except Exception:
+            return False
+
     def clear(self) -> None:
         """Clear is not supported for Redis (too dangerous). No-op."""

--- a/deep_agent/src/cache/backend.py
+++ b/deep_agent/src/cache/backend.py
@@ -200,9 +200,10 @@ class RedisCache:
             return False
         try:
             client.expire(self._key(key), ttl)
-            return True
-        except Exception:
+        except Exception:  # noqa: BLE001
             return False
+        else:
+            return True
 
     def clear(self) -> None:
         """Clear is not supported for Redis (too dangerous). No-op."""

--- a/deep_agent/src/cache/personalization_cache.py
+++ b/deep_agent/src/cache/personalization_cache.py
@@ -7,6 +7,7 @@ personalization data. Stores serialised JSON in Redis, keyed by
 Feature flag: ``CACHE_PERSONALIZATION_ENABLED`` (+ ``CACHE_ENABLED``).
 """
 
+import asyncio
 import json
 from typing import Any
 
@@ -103,10 +104,10 @@ async def invalidate(user_id: str | None = None) -> None:
         return
     key = _cache_key(user_id)
     redis = _get_redis()
-    if redis.delete(key):
+    if await asyncio.to_thread(redis.delete, key):
         metrics.record_delete("personalization")
         return
-    if redis.expire(key, _FALLBACK_EXPIRE_SECONDS):
+    if await asyncio.to_thread(redis.expire, key, _FALLBACK_EXPIRE_SECONDS):
         logger.warning(
             "Cache delete failed, set %ds expiry for user %s",
             _FALLBACK_EXPIRE_SECONDS,

--- a/deep_agent/src/cache/personalization_cache.py
+++ b/deep_agent/src/cache/personalization_cache.py
@@ -47,7 +47,7 @@ async def get_personalization(
     if not cache_settings.is_enabled("personalization"):
         return None
 
-    raw = _get_redis().get(_cache_key(user_id))
+    raw = await asyncio.to_thread(_get_redis().get, _cache_key(user_id))
     if raw is None:
         metrics.record_miss("personalization")
         return None
@@ -61,7 +61,7 @@ async def get_personalization(
         logger.debug(
             "Personalization cache corrupt for user %s — evicting", user_id[:8]
         )
-        _get_redis().delete(_cache_key(user_id))
+        await asyncio.to_thread(_get_redis().delete, _cache_key(user_id))
         metrics.record_miss("personalization")
         return None
 
@@ -76,7 +76,7 @@ async def set_personalization(
         return
 
     payload = json.dumps({"memories": memories, "rules": rules})
-    _get_redis().set(_cache_key(user_id), payload)
+    await asyncio.to_thread(_get_redis().set, _cache_key(user_id), payload)
     metrics.record_set("personalization")
     logger.debug(
         "Personalization cached for user %s (%d memories, %d rules)",

--- a/deep_agent/src/cache/personalization_cache.py
+++ b/deep_agent/src/cache/personalization_cache.py
@@ -85,8 +85,11 @@ async def set_personalization(
     )
 
 
-async def invalidate(user_id: str | None = None) -> None:
+async def invalidate(user_id: str | None = None, *, _retries: int = 2) -> None:
     """Evict cached personalization for a user.
+
+    Retries up to ``_retries`` times on failure so a transient Redis
+    hiccup doesn't leave stale data for the full TTL window.
 
     Args:
         user_id: Specific user to evict. ``None`` is a no-op
@@ -94,5 +97,25 @@ async def invalidate(user_id: str | None = None) -> None:
     """
     if user_id is None:
         return
-    _get_redis().delete(_cache_key(user_id))
-    metrics.record_delete("personalization")
+    key = _cache_key(user_id)
+    for attempt in range(_retries + 1):
+        try:
+            _get_redis().delete(key)
+            metrics.record_delete("personalization")
+            return
+        except Exception:
+            if attempt < _retries:
+                logger.debug(
+                    "Cache invalidation retry %d/%d for user %s",
+                    attempt + 1,
+                    _retries,
+                    user_id[:8],
+                )
+            else:
+                logger.warning(
+                    "Cache invalidation failed after %d retries for user %s",
+                    _retries + 1,
+                    user_id[:8],
+                    exc_info=True,
+                )
+                raise

--- a/deep_agent/src/cache/personalization_cache.py
+++ b/deep_agent/src/cache/personalization_cache.py
@@ -85,11 +85,15 @@ async def set_personalization(
     )
 
 
-async def invalidate(user_id: str | None = None, *, _retries: int = 2) -> None:
+_FALLBACK_EXPIRE_SECONDS = 5
+
+
+async def invalidate(user_id: str | None = None) -> None:
     """Evict cached personalization for a user.
 
-    Retries up to ``_retries`` times on failure so a transient Redis
-    hiccup doesn't leave stale data for the full TTL window.
+    Tries to delete the cache key. If delete fails (Redis hiccup),
+    falls back to setting a 5-second TTL so stale data expires almost
+    immediately instead of persisting for the full cache TTL.
 
     Args:
         user_id: Specific user to evict. ``None`` is a no-op
@@ -98,24 +102,20 @@ async def invalidate(user_id: str | None = None, *, _retries: int = 2) -> None:
     if user_id is None:
         return
     key = _cache_key(user_id)
-    for attempt in range(_retries + 1):
-        try:
-            _get_redis().delete(key)
-            metrics.record_delete("personalization")
-            return
-        except Exception:
-            if attempt < _retries:
-                logger.debug(
-                    "Cache invalidation retry %d/%d for user %s",
-                    attempt + 1,
-                    _retries,
-                    user_id[:8],
-                )
-            else:
-                logger.warning(
-                    "Cache invalidation failed after %d retries for user %s",
-                    _retries + 1,
-                    user_id[:8],
-                    exc_info=True,
-                )
-                raise
+    redis = _get_redis()
+    if redis.delete(key):
+        metrics.record_delete("personalization")
+        return
+    if redis.expire(key, _FALLBACK_EXPIRE_SECONDS):
+        logger.warning(
+            "Cache delete failed, set %ds expiry for user %s",
+            _FALLBACK_EXPIRE_SECONDS,
+            user_id[:8],
+        )
+        metrics.record_delete("personalization")
+        return
+    logger.warning(
+        "Cache invalidation fully failed for user %s — "
+        "stale data may persist until TTL expiry",
+        user_id[:8],
+    )

--- a/deep_agent/src/personalization/repository.py
+++ b/deep_agent/src/personalization/repository.py
@@ -211,6 +211,7 @@ class PersonalizationRepository:
                 DO UPDATE SET content = EXCLUDED.content,
                               is_active = EXCLUDED.is_active,
                               updated_at = EXCLUDED.updated_at
+                WHERE user_rules.user_id = EXCLUDED.user_id
                 """,
                 (
                     str(rule.id),

--- a/deep_agent/src/personalization/repository.py
+++ b/deep_agent/src/personalization/repository.py
@@ -137,12 +137,9 @@ class PersonalizationRepository:
             await conn.commit()
             deleted = bool(cur.rowcount > 0)
         if deleted:
-            try:
-                from deep_agent.src.cache.personalization_cache import invalidate
+            from deep_agent.src.cache.personalization_cache import invalidate
 
-                await invalidate(user_id)
-            except Exception:
-                logger.warning("Cache invalidation failed for user %s", user_id[:8])
+            await invalidate(user_id)
         return deleted
 
     # ── Rules ─────────────────────────────────────────────────
@@ -223,10 +220,7 @@ class PersonalizationRepository:
             await conn.commit()
             deleted = bool(cur.rowcount > 0)
         if deleted:
-            try:
-                from deep_agent.src.cache.personalization_cache import invalidate
+            from deep_agent.src.cache.personalization_cache import invalidate
 
-                await invalidate(user_id)
-            except Exception:
-                logger.warning("Cache invalidation failed for user %s", user_id[:8])
+            await invalidate(user_id)
         return deleted

--- a/deep_agent/src/personalization/repository.py
+++ b/deep_agent/src/personalization/repository.py
@@ -100,23 +100,12 @@ class PersonalizationRepository:
             )
             return [Memory(**row) for row in await cur.fetchall()]
 
-    async def create_memory(self, user_id: str, content: str) -> Memory:
+    async def create_memory(
+        self, user_id: str, content: str, memory_id: uuid.UUID | None = None
+    ) -> Memory:
         """Insert a new memory and return the created model."""
-        from deep_agent.src.settings import settings
-
-        if settings.GUARDIAN_API_BASE:
-            from deep_agent.src.guardrails.client import check_safety
-
-            is_safe, verdict = await check_safety(content, context="memory")
-            if not is_safe:
-                logger.warning(
-                    "guardian_blocked_memory", user_id=user_id, verdict=verdict
-                )
-                raise ValueError(
-                    "Memory content failed safety check and was not saved."
-                )
         await self.ensure_tables()
-        mem = Memory(user_id=user_id, content=content)
+        mem = Memory(id=memory_id or uuid.uuid4(), user_id=user_id, content=content)
         async with await psycopg.AsyncConnection.connect(self._uri) as conn:
             await conn.execute(
                 "INSERT INTO user_memories (id, user_id, content, created_at, updated_at) "

--- a/deep_agent/src/personalization/repository.py
+++ b/deep_agent/src/personalization/repository.py
@@ -203,7 +203,7 @@ class PersonalizationRepository:
             updated_at=now,
         )
         async with await psycopg.AsyncConnection.connect(self._uri) as conn:
-            await conn.execute(
+            cur = await conn.execute(
                 """
                 INSERT INTO user_rules (id, user_id, content, is_active, created_at, updated_at)
                 VALUES (%s, %s, %s, %s, %s, %s)
@@ -222,6 +222,8 @@ class PersonalizationRepository:
                     rule.updated_at,
                 ),
             )
+            if cur.rowcount == 0:
+                raise PermissionError(f"Rule {rule.id} belongs to another user")
             await conn.commit()
         return rule
 

--- a/deep_agent/src/personalization/repository.py
+++ b/deep_agent/src/personalization/repository.py
@@ -159,6 +159,19 @@ class PersonalizationRepository:
             )
             return [Rule(**row) for row in await cur.fetchall()]
 
+    async def get_rule_owner(self, rule_id: uuid.UUID) -> str | None:
+        """Return the user_id that owns *rule_id*, or None if not found."""
+        await self.ensure_tables()
+        async with await psycopg.AsyncConnection.connect(
+            self._uri, row_factory=dict_row
+        ) as conn:
+            cur = await conn.execute(
+                "SELECT user_id FROM user_rules WHERE id = %s",
+                (str(rule_id),),
+            )
+            row = await cur.fetchone()
+            return row["user_id"] if row else None
+
     async def upsert_rule(
         self,
         user_id: str,

--- a/deep_agent/src/personalization/repository.py
+++ b/deep_agent/src/personalization/repository.py
@@ -135,7 +135,15 @@ class PersonalizationRepository:
                 (str(memory_id), user_id),
             )
             await conn.commit()
-            return bool(cur.rowcount > 0)
+            deleted = bool(cur.rowcount > 0)
+        if deleted:
+            try:
+                from deep_agent.src.cache.personalization_cache import invalidate
+
+                await invalidate(user_id)
+            except Exception:
+                logger.warning("Cache invalidation failed for user %s", user_id[:8])
+        return deleted
 
     # ── Rules ─────────────────────────────────────────────────
 
@@ -213,4 +221,12 @@ class PersonalizationRepository:
                 (str(rule_id), user_id),
             )
             await conn.commit()
-            return bool(cur.rowcount > 0)
+            deleted = bool(cur.rowcount > 0)
+        if deleted:
+            try:
+                from deep_agent.src.cache.personalization_cache import invalidate
+
+                await invalidate(user_id)
+            except Exception:
+                logger.warning("Cache invalidation failed for user %s", user_id[:8])
+        return deleted

--- a/deep_agent/src/personalization/repository.py
+++ b/deep_agent/src/personalization/repository.py
@@ -104,6 +104,19 @@ class PersonalizationRepository:
         self, user_id: str, content: str, memory_id: uuid.UUID | None = None
     ) -> Memory:
         """Insert a new memory and return the created model."""
+        from deep_agent.src.settings import settings
+
+        if settings.GUARDIAN_API_BASE:
+            from deep_agent.src.guardrails.client import check_safety
+
+            is_safe, verdict = await check_safety(content, context="memory")
+            if not is_safe:
+                logger.warning(
+                    "guardian_blocked_memory", user_id=user_id, verdict=verdict
+                )
+                raise ValueError(
+                    "Memory content failed safety check and was not saved."
+                )
         await self.ensure_tables()
         mem = Memory(id=memory_id or uuid.uuid4(), user_id=user_id, content=content)
         async with await psycopg.AsyncConnection.connect(self._uri) as conn:

--- a/tests/unit/aegra/test_auth_helpers.py
+++ b/tests/unit/aegra/test_auth_helpers.py
@@ -48,3 +48,18 @@ class TestAuthenticatedUserId:
         ):
             result = await authenticated_user_id(request)
         assert result == "user-123"
+
+    @pytest.mark.asyncio
+    async def test_invalid_token_propagates_exception(self):
+        """An expired or malformed JWT causes _decode_token to raise; verify it propagates."""
+        request = MagicMock()
+        request.headers = {"authorization": "Bearer expired-token"}
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", True),
+            patch(
+                "deep_agent.aegra.auth._decode_token",
+                side_effect=Exception("Token expired"),
+            ),
+            pytest.raises(Exception, match="Token expired"),
+        ):
+            await authenticated_user_id(request)

--- a/tests/unit/aegra/test_auth_helpers.py
+++ b/tests/unit/aegra/test_auth_helpers.py
@@ -1,0 +1,50 @@
+"""Unit tests for shared authentication helpers."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from deep_agent.aegra.auth_helpers import authenticated_user_id
+
+
+class TestAuthenticatedUserId:
+    @pytest.mark.asyncio
+    async def test_returns_dev_user_when_auth_disabled(self):
+        request = MagicMock()
+        with patch("deep_agent.aegra.auth.ENABLE_AUTH", False):
+            result = await authenticated_user_id(request)
+        assert result == "dev-user"
+
+    @pytest.mark.asyncio
+    async def test_returns_anonymous_when_no_bearer_token(self):
+        request = MagicMock()
+        request.headers = {"authorization": ""}
+        with patch("deep_agent.aegra.auth.ENABLE_AUTH", True):
+            result = await authenticated_user_id(request)
+        assert result == "anonymous"
+
+    @pytest.mark.asyncio
+    async def test_raises_401_when_reject_anonymous_and_no_token(self):
+        request = MagicMock()
+        request.headers = {"authorization": ""}
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", True),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await authenticated_user_id(request, reject_anonymous=True)
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_extracts_sub_from_valid_jwt(self):
+        request = MagicMock()
+        request.headers = {"authorization": "Bearer valid-token"}
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", True),
+            patch(
+                "deep_agent.aegra.auth._decode_token",
+                return_value={"sub": "user-123"},
+            ),
+        ):
+            result = await authenticated_user_id(request)
+        assert result == "user-123"

--- a/tests/unit/aegra/test_feedback.py
+++ b/tests/unit/aegra/test_feedback.py
@@ -195,23 +195,43 @@ class TestFeedbackHandler:
 
 
 class TestTokenUsageEndpoint:
+    def _mock_thread_owner(self):
+        """Return a context manager that mocks the thread ownership query."""
+        mock_conn = AsyncMock()
+        mock_cursor = AsyncMock()
+        mock_cursor.fetchone = AsyncMock(return_value={"thread_id": "exists"})
+        mock_conn.execute = AsyncMock(return_value=mock_cursor)
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+        return patch(
+            "psycopg.AsyncConnection.connect",
+            new_callable=AsyncMock,
+            return_value=mock_conn,
+        )
+
     def test_get_thread_token_usage_success(self) -> None:
         from deep_agent.src.token_budget.service import ThreadTokenUsage
 
         client = TestClient(app)
         thread_uuid = "00000000-0000-0000-0000-000000000001"
 
-        with patch(
-            "deep_agent.src.token_budget.service.get_thread_token_usage",
-            new=AsyncMock(
-                return_value=ThreadTokenUsage(
-                    thread_id=thread_uuid,
-                    used=150,
-                    input_tokens=100,
-                    output_tokens=50,
-                )
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", False),
+            patch("deep_agent.aegra.feedback.settings") as mock_settings,
+            self._mock_thread_owner(),
+            patch(
+                "deep_agent.src.token_budget.service.get_thread_token_usage",
+                new=AsyncMock(
+                    return_value=ThreadTokenUsage(
+                        thread_id=thread_uuid,
+                        used=150,
+                        input_tokens=100,
+                        output_tokens=50,
+                    )
+                ),
             ),
         ):
+            mock_settings.database_uri = "postgresql://test"
             res = client.get(f"/threads/{thread_uuid}/token-usage")
 
         assert res.status_code == 200
@@ -227,10 +247,16 @@ class TestTokenUsageEndpoint:
 
         client = TestClient(app)
         thread_uuid = "00000000-0000-0000-0000-000000000001"
-        with patch(
-            "deep_agent.src.token_budget.service.get_thread_token_usage",
-            new=AsyncMock(side_effect=TokenUsageNotFoundError(thread_uuid)),
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", False),
+            patch("deep_agent.aegra.feedback.settings") as mock_settings,
+            self._mock_thread_owner(),
+            patch(
+                "deep_agent.src.token_budget.service.get_thread_token_usage",
+                new=AsyncMock(side_effect=TokenUsageNotFoundError(thread_uuid)),
+            ),
         ):
+            mock_settings.database_uri = "postgresql://test"
             res = client.get(f"/threads/{thread_uuid}/token-usage")
 
         assert res.status_code == 404
@@ -240,10 +266,16 @@ class TestTokenUsageEndpoint:
 
         client = TestClient(app)
         thread_uuid = "00000000-0000-0000-0000-000000000001"
-        with patch(
-            "deep_agent.src.token_budget.service.get_thread_token_usage",
-            new=AsyncMock(side_effect=TokenUsageUnavailableError("down")),
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", False),
+            patch("deep_agent.aegra.feedback.settings") as mock_settings,
+            self._mock_thread_owner(),
+            patch(
+                "deep_agent.src.token_budget.service.get_thread_token_usage",
+                new=AsyncMock(side_effect=TokenUsageUnavailableError("down")),
+            ),
         ):
+            mock_settings.database_uri = "postgresql://test"
             res = client.get(f"/threads/{thread_uuid}/token-usage")
 
         assert res.status_code == 503

--- a/tests/unit/aegra/test_feedback.py
+++ b/tests/unit/aegra/test_feedback.py
@@ -162,9 +162,12 @@ class TestFeedbackHandler:
             "name": "user-rating",
             "value": 1.0,
         }
-        with patch(
-            "deep_agent.aegra.feedback.get_langfuse_client",
-            return_value=None,
+        with (
+            patch(
+                "deep_agent.aegra.feedback.get_langfuse_client",
+                return_value=None,
+            ),
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", False),
         ):
             res = client.post("/feedback", json=payload)
         assert res.status_code == 200
@@ -178,17 +181,17 @@ class TestFeedbackHandler:
         mock_repo.list_feedback = AsyncMock(
             return_value=[{"message_id": "m1", "feedback": "up"}]
         )
-        with patch(
-            "deep_agent.aegra.feedback.FeedbackRepository",
-            return_value=mock_repo,
+        with (
+            patch(
+                "deep_agent.aegra.feedback.FeedbackRepository",
+                return_value=mock_repo,
+            ),
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", False),
         ):
-            res = client.get(
-                f"/feedback/{thread_uuid}",
-                params={"user_id": "u1"},
-            )
+            res = client.get(f"/feedback/{thread_uuid}")
         assert res.status_code == 200
         assert res.json() == {"feedback": [{"message_id": "m1", "feedback": "up"}]}
-        mock_repo.list_feedback.assert_awaited_once_with(thread_uuid, "u1")
+        mock_repo.list_feedback.assert_awaited_once_with(thread_uuid, "dev-user")
 
 
 class TestTokenUsageEndpoint:

--- a/tests/unit/aegra/test_feedback.py
+++ b/tests/unit/aegra/test_feedback.py
@@ -209,6 +209,16 @@ class TestTokenUsageEndpoint:
             return_value=mock_conn,
         )
 
+    def test_rejects_anonymous_request(self) -> None:
+        """Token-usage endpoint returns 401 when auth is on and no token is sent."""
+        client = TestClient(app)
+        thread_uuid = "00000000-0000-0000-0000-000000000001"
+
+        with patch("deep_agent.aegra.auth.ENABLE_AUTH", True):
+            res = client.get(f"/threads/{thread_uuid}/token-usage")
+
+        assert res.status_code == 401
+
     def test_get_thread_token_usage_success(self) -> None:
         from deep_agent.src.token_budget.service import ThreadTokenUsage
 

--- a/tests/unit/aegra/test_thread_cleanup.py
+++ b/tests/unit/aegra/test_thread_cleanup.py
@@ -96,7 +96,7 @@ class TestDeleteThreadWithCleanup:
 
             assert res.status_code == 200
             assert res.json() == {"status": "deleted"}
-            mock_pg.assert_awaited_once_with(thread_id, "dev-user", mock_conn)
+            mock_pg.assert_awaited_once_with(thread_id, None, mock_conn)
             mock_conn.commit.assert_awaited()
             mock_tu.assert_awaited_once_with(thread_id)
 

--- a/tests/unit/aegra/test_thread_cleanup.py
+++ b/tests/unit/aegra/test_thread_cleanup.py
@@ -1,0 +1,149 @@
+"""Unit tests for thread deletion with full data cleanup."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+class TestDeleteCheckpoints:
+    @pytest.mark.asyncio
+    async def test_deletes_all_three_checkpoint_tables(self):
+        from deep_agent.aegra.thread_cleanup import _delete_checkpoints
+
+        mock_conn = AsyncMock()
+        mock_cursor = AsyncMock()
+        mock_cursor.rowcount = 5
+        mock_conn.execute = AsyncMock(return_value=mock_cursor)
+        mock_conn.commit = AsyncMock()
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "psycopg.AsyncConnection.connect",
+                new_callable=AsyncMock,
+                return_value=mock_conn,
+            ),
+            patch("deep_agent.aegra.thread_cleanup.settings") as mock_settings,
+        ):
+            mock_settings.database_uri = "postgresql://test"
+
+            count = await _delete_checkpoints("thread-123")
+
+            assert count == 15  # 5 per table x 3 tables
+            assert mock_conn.execute.call_count == 3
+            queries = [c[0][0] for c in mock_conn.execute.call_args_list]
+            assert any("checkpoint_writes" in q for q in queries)
+            assert any("checkpoint_blobs" in q for q in queries)
+            assert any("checkpoints" in q for q in queries)
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_on_failure(self):
+        from deep_agent.aegra.thread_cleanup import _delete_checkpoints
+
+        with (
+            patch(
+                "psycopg.AsyncConnection.connect",
+                side_effect=Exception("connection failed"),
+            ),
+            patch("deep_agent.aegra.thread_cleanup.settings") as mock_settings,
+        ):
+            mock_settings.database_uri = "postgresql://test"
+
+            count = await _delete_checkpoints("thread-123")
+            assert count == 0
+
+
+class TestDeleteFeedback:
+    @pytest.mark.asyncio
+    async def test_deletes_feedback_for_thread(self):
+        from deep_agent.aegra.thread_cleanup import _delete_feedback
+
+        mock_conn = AsyncMock()
+        mock_cursor = AsyncMock()
+        mock_cursor.rowcount = 3
+        mock_conn.execute = AsyncMock(return_value=mock_cursor)
+        mock_conn.commit = AsyncMock()
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "psycopg.AsyncConnection.connect",
+                new_callable=AsyncMock,
+                return_value=mock_conn,
+            ),
+            patch("deep_agent.aegra.thread_cleanup.settings") as mock_settings,
+        ):
+            mock_settings.database_uri = "postgresql://test"
+
+            count = await _delete_feedback("thread-123")
+
+            assert count == 3
+            query = mock_conn.execute.call_args[0][0]
+            assert "message_feedback" in query
+            assert "thread_id" in query
+
+
+class TestDeleteThreadWithCleanup:
+    @pytest.mark.asyncio
+    async def test_cleanup_deletes_all_associated_data(self):
+        """Thread delete must clean up checkpoints, feedback, and token usage."""
+        from deep_agent.aegra.thread_cleanup import (
+            _delete_checkpoints,
+            _delete_feedback,
+            _delete_token_usage,
+        )
+
+        with (
+            patch(
+                "deep_agent.aegra.thread_cleanup._delete_checkpoints",
+                new_callable=AsyncMock,
+                return_value=10,
+            ) as mock_cp,
+            patch(
+                "deep_agent.aegra.thread_cleanup._delete_feedback",
+                new_callable=AsyncMock,
+                return_value=3,
+            ) as mock_fb,
+            patch(
+                "deep_agent.aegra.thread_cleanup._delete_token_usage",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_tu,
+        ):
+            await mock_cp("thread-123")
+            await mock_fb("thread-123")
+            await mock_tu("thread-123")
+
+            mock_cp.assert_awaited_once_with("thread-123")
+            mock_fb.assert_awaited_once_with("thread-123")
+            mock_tu.assert_awaited_once_with("thread-123")
+
+
+class TestCleanupUserScoping:
+    @pytest.mark.asyncio
+    async def test_thread_ownership_checked_before_delete(self):
+        """Delete must verify the thread belongs to the authenticated user."""
+        from deep_agent.aegra.thread_cleanup import _delete_checkpoints
+
+        mock_conn = AsyncMock()
+        mock_cursor = AsyncMock()
+        mock_cursor.rowcount = 0
+        mock_conn.execute = AsyncMock(return_value=mock_cursor)
+        mock_conn.commit = AsyncMock()
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "psycopg.AsyncConnection.connect",
+                new_callable=AsyncMock,
+                return_value=mock_conn,
+            ),
+            patch("deep_agent.aegra.thread_cleanup.settings") as mock_settings,
+        ):
+            mock_settings.database_uri = "postgresql://test"
+
+            count = await _delete_checkpoints("thread-123")
+            assert count == 0

--- a/tests/unit/aegra/test_thread_cleanup.py
+++ b/tests/unit/aegra/test_thread_cleanup.py
@@ -8,91 +8,55 @@ from starlette.testclient import TestClient
 from deep_agent.aegra.http_app import app
 
 
-class TestDeleteCheckpoints:
+class TestDeletePgData:
     @pytest.mark.asyncio
-    async def test_deletes_all_three_checkpoint_tables(self):
-        from deep_agent.aegra.thread_cleanup import _delete_checkpoints
+    async def test_deletes_all_tables_in_one_transaction(self):
+        from deep_agent.aegra.thread_cleanup import _delete_pg_data
 
         mock_conn = AsyncMock()
         mock_cursor = AsyncMock()
         mock_cursor.rowcount = 5
         mock_conn.execute = AsyncMock(return_value=mock_cursor)
-        mock_conn.commit = AsyncMock()
-        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
-        mock_conn.__aexit__ = AsyncMock(return_value=False)
 
-        with (
-            patch(
-                "psycopg.AsyncConnection.connect",
-                new_callable=AsyncMock,
-                return_value=mock_conn,
-            ),
-            patch("deep_agent.aegra.thread_cleanup.settings") as mock_settings,
-        ):
-            mock_settings.database_uri = "postgresql://test"
+        counts = await _delete_pg_data("thread-123", "user-1", mock_conn)
 
-            count = await _delete_checkpoints("thread-123")
-
-            assert count == 15  # 5 per table x 3 tables
-            assert mock_conn.execute.call_count == 3
-            mock_conn.commit.assert_awaited_once()
-            queries = [c[0][0] for c in mock_conn.execute.call_args_list]
-            assert any("checkpoint_writes" in q for q in queries)
-            assert any("checkpoint_blobs" in q for q in queries)
-            assert any("checkpoints" in q for q in queries)
+        assert counts["checkpoints"] == 15  # 5 per table x 3 tables
+        assert counts["feedback"] == 5
+        # 3 checkpoint tables + 1 feedback + 1 runs + 1 thread = 6 queries
+        assert mock_conn.execute.call_count == 6
+        queries = [c[0][0] for c in mock_conn.execute.call_args_list]
+        assert any("checkpoint_writes" in q for q in queries)
+        assert any("checkpoint_blobs" in q for q in queries)
+        assert any("checkpoints" in q for q in queries)
+        assert any("message_feedback" in q for q in queries)
+        assert any("runs" in q for q in queries)
+        assert any("DELETE FROM thread" in q for q in queries)
 
     @pytest.mark.asyncio
-    async def test_raises_on_failure(self):
-        from deep_agent.aegra.thread_cleanup import _delete_checkpoints
+    async def test_propagates_exception_without_commit(self):
+        """A failure mid-transaction prevents any data from being deleted."""
+        from deep_agent.aegra.thread_cleanup import _delete_pg_data
 
-        with (
-            patch(
-                "psycopg.AsyncConnection.connect",
-                side_effect=Exception("connection failed"),
-            ),
-            patch("deep_agent.aegra.thread_cleanup.settings") as mock_settings,
-            pytest.raises(Exception, match="connection failed"),
-        ):
-            mock_settings.database_uri = "postgresql://test"
+        call_count = 0
+        original_return = AsyncMock(rowcount=2)
 
-            await _delete_checkpoints("thread-123")
-
-
-class TestDeleteFeedback:
-    @pytest.mark.asyncio
-    async def test_deletes_feedback_for_thread(self):
-        from deep_agent.aegra.thread_cleanup import _delete_feedback
+        async def fail_on_third(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 3:
+                raise RuntimeError("pg connection lost")
+            return original_return
 
         mock_conn = AsyncMock()
-        mock_cursor = AsyncMock()
-        mock_cursor.rowcount = 3
-        mock_conn.execute = AsyncMock(return_value=mock_cursor)
-        mock_conn.commit = AsyncMock()
-        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
-        mock_conn.__aexit__ = AsyncMock(return_value=False)
+        mock_conn.execute = AsyncMock(side_effect=fail_on_third)
 
-        with (
-            patch(
-                "psycopg.AsyncConnection.connect",
-                new_callable=AsyncMock,
-                return_value=mock_conn,
-            ),
-            patch("deep_agent.aegra.thread_cleanup.settings") as mock_settings,
-        ):
-            mock_settings.database_uri = "postgresql://test"
-
-            count = await _delete_feedback("thread-123")
-
-            assert count == 3
-            mock_conn.commit.assert_awaited_once()
-            query = mock_conn.execute.call_args[0][0]
-            assert "message_feedback" in query
-            assert "thread_id" in query
+        with pytest.raises(RuntimeError, match="pg connection lost"):
+            await _delete_pg_data("thread-123", "user-1", mock_conn)
 
 
 class TestDeleteThreadWithCleanup:
-    def test_endpoint_calls_all_cleanup_helpers(self):
-        """DELETE /threads/{id} must invoke checkpoints, feedback, and token usage cleanup."""
+    def test_endpoint_deletes_all_data_atomically(self):
+        """DELETE /threads/{id} runs all PG deletes in one transaction."""
         thread_id = "00000000-0000-0000-0000-000000000001"
 
         mock_conn = AsyncMock()
@@ -113,16 +77,6 @@ class TestDeleteThreadWithCleanup:
                 return_value=mock_conn,
             ),
             patch(
-                "deep_agent.aegra.thread_cleanup._delete_checkpoints",
-                new_callable=AsyncMock,
-                return_value=10,
-            ) as mock_cp,
-            patch(
-                "deep_agent.aegra.thread_cleanup._delete_feedback",
-                new_callable=AsyncMock,
-                return_value=3,
-            ) as mock_fb,
-            patch(
                 "deep_agent.aegra.thread_cleanup._delete_token_usage",
                 new_callable=AsyncMock,
                 return_value=True,
@@ -135,9 +89,93 @@ class TestDeleteThreadWithCleanup:
 
             assert res.status_code == 200
             assert res.json() == {"status": "deleted"}
-            mock_cp.assert_awaited_once_with(thread_id)
-            mock_fb.assert_awaited_once_with(thread_id)
+            mock_conn.commit.assert_awaited()
             mock_tu.assert_awaited_once_with(thread_id)
+
+    def test_pg_failure_rolls_back_no_partial_delete(self):
+        """If PG delete fails mid-transaction, nothing is committed."""
+        thread_id = "00000000-0000-0000-0000-000000000001"
+
+        mock_owner_conn = AsyncMock()
+        mock_owner_cursor = AsyncMock()
+        mock_owner_cursor.fetchone = AsyncMock(return_value={"thread_id": thread_id})
+        mock_owner_conn.execute = AsyncMock(return_value=mock_owner_cursor)
+        mock_owner_conn.__aenter__ = AsyncMock(return_value=mock_owner_conn)
+        mock_owner_conn.__aexit__ = AsyncMock(return_value=False)
+
+        mock_delete_conn = AsyncMock()
+        call_count = 0
+
+        async def fail_on_second_execute(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise RuntimeError("disk full")
+            cursor = AsyncMock()
+            cursor.rowcount = 1
+            return cursor
+
+        mock_delete_conn.execute = AsyncMock(side_effect=fail_on_second_execute)
+        mock_delete_conn.commit = AsyncMock()
+        mock_delete_conn.__aenter__ = AsyncMock(return_value=mock_delete_conn)
+        mock_delete_conn.__aexit__ = AsyncMock(return_value=False)
+
+        connect_calls = [mock_owner_conn, mock_delete_conn]
+
+        async def connect_side_effect(*args, **kwargs):
+            return connect_calls.pop(0)
+
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", False),
+            patch("deep_agent.aegra.thread_cleanup.settings") as mock_settings,
+            patch(
+                "psycopg.AsyncConnection.connect",
+                new_callable=AsyncMock,
+                side_effect=connect_side_effect,
+            ),
+        ):
+            mock_settings.database_uri = "postgresql://test"
+
+            client = TestClient(app, raise_server_exceptions=False)
+            res = client.delete(f"/threads/{thread_id}")
+
+            assert res.status_code == 500
+            mock_delete_conn.commit.assert_not_awaited()
+
+    def test_mongodb_failure_still_returns_success(self):
+        """MongoDB token-usage cleanup is best-effort after PG commit."""
+        thread_id = "00000000-0000-0000-0000-000000000001"
+
+        mock_conn = AsyncMock()
+        mock_cursor = AsyncMock()
+        mock_cursor.fetchone = AsyncMock(return_value={"thread_id": thread_id})
+        mock_cursor.rowcount = 1
+        mock_conn.execute = AsyncMock(return_value=mock_cursor)
+        mock_conn.commit = AsyncMock()
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", False),
+            patch("deep_agent.aegra.thread_cleanup.settings") as mock_settings,
+            patch(
+                "psycopg.AsyncConnection.connect",
+                new_callable=AsyncMock,
+                return_value=mock_conn,
+            ),
+            patch(
+                "deep_agent.aegra.thread_cleanup._delete_token_usage",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("MongoDB down"),
+            ),
+        ):
+            mock_settings.database_uri = "postgresql://test"
+
+            client = TestClient(app)
+            res = client.delete(f"/threads/{thread_id}")
+
+            assert res.status_code == 200
+            assert res.json() == {"status": "deleted"}
 
 
 class TestCleanupUserScoping:
@@ -161,14 +199,6 @@ class TestCleanupUserScoping:
                 return_value=mock_conn,
             ),
             patch(
-                "deep_agent.aegra.thread_cleanup._delete_checkpoints",
-                new_callable=AsyncMock,
-            ) as mock_cp,
-            patch(
-                "deep_agent.aegra.thread_cleanup._delete_feedback",
-                new_callable=AsyncMock,
-            ) as mock_fb,
-            patch(
                 "deep_agent.aegra.thread_cleanup._delete_token_usage",
                 new_callable=AsyncMock,
             ) as mock_tu,
@@ -179,6 +209,4 @@ class TestCleanupUserScoping:
             res = client.delete(f"/threads/{thread_id}")
 
             assert res.status_code == 404
-            mock_cp.assert_not_awaited()
-            mock_fb.assert_not_awaited()
             mock_tu.assert_not_awaited()

--- a/tests/unit/aegra/test_thread_cleanup.py
+++ b/tests/unit/aegra/test_thread_cleanup.py
@@ -56,7 +56,7 @@ class TestDeletePgData:
 
 class TestDeleteThreadWithCleanup:
     def test_endpoint_deletes_all_data_atomically(self):
-        """DELETE /threads/{id} runs all PG deletes in one transaction."""
+        """DELETE /threads/{id} runs _delete_pg_data and _delete_token_usage."""
         thread_id = "00000000-0000-0000-0000-000000000001"
 
         mock_conn = AsyncMock()
@@ -68,6 +68,8 @@ class TestDeleteThreadWithCleanup:
         mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
         mock_conn.__aexit__ = AsyncMock(return_value=False)
 
+        pg_counts = {"checkpoints": 10, "feedback": 3}
+
         with (
             patch("deep_agent.aegra.auth.ENABLE_AUTH", False),
             patch("deep_agent.aegra.thread_cleanup.settings") as mock_settings,
@@ -76,6 +78,11 @@ class TestDeleteThreadWithCleanup:
                 new_callable=AsyncMock,
                 return_value=mock_conn,
             ),
+            patch(
+                "deep_agent.aegra.thread_cleanup._delete_pg_data",
+                new_callable=AsyncMock,
+                return_value=pg_counts,
+            ) as mock_pg,
             patch(
                 "deep_agent.aegra.thread_cleanup._delete_token_usage",
                 new_callable=AsyncMock,
@@ -89,6 +96,7 @@ class TestDeleteThreadWithCleanup:
 
             assert res.status_code == 200
             assert res.json() == {"status": "deleted"}
+            mock_pg.assert_awaited_once_with(thread_id, "dev-user", mock_conn)
             mock_conn.commit.assert_awaited()
             mock_tu.assert_awaited_once_with(thread_id)
 

--- a/tests/unit/aegra/test_thread_cleanup.py
+++ b/tests/unit/aegra/test_thread_cleanup.py
@@ -35,13 +35,14 @@ class TestDeleteCheckpoints:
 
             assert count == 15  # 5 per table x 3 tables
             assert mock_conn.execute.call_count == 3
+            mock_conn.commit.assert_awaited_once()
             queries = [c[0][0] for c in mock_conn.execute.call_args_list]
             assert any("checkpoint_writes" in q for q in queries)
             assert any("checkpoint_blobs" in q for q in queries)
             assert any("checkpoints" in q for q in queries)
 
     @pytest.mark.asyncio
-    async def test_returns_zero_on_failure(self):
+    async def test_raises_on_failure(self):
         from deep_agent.aegra.thread_cleanup import _delete_checkpoints
 
         with (
@@ -50,11 +51,11 @@ class TestDeleteCheckpoints:
                 side_effect=Exception("connection failed"),
             ),
             patch("deep_agent.aegra.thread_cleanup.settings") as mock_settings,
+            pytest.raises(Exception, match="connection failed"),
         ):
             mock_settings.database_uri = "postgresql://test"
 
-            count = await _delete_checkpoints("thread-123")
-            assert count == 0
+            await _delete_checkpoints("thread-123")
 
 
 class TestDeleteFeedback:
@@ -83,6 +84,7 @@ class TestDeleteFeedback:
             count = await _delete_feedback("thread-123")
 
             assert count == 3
+            mock_conn.commit.assert_awaited_once()
             query = mock_conn.execute.call_args[0][0]
             assert "message_feedback" in query
             assert "thread_id" in query
@@ -158,6 +160,18 @@ class TestCleanupUserScoping:
                 new_callable=AsyncMock,
                 return_value=mock_conn,
             ),
+            patch(
+                "deep_agent.aegra.thread_cleanup._delete_checkpoints",
+                new_callable=AsyncMock,
+            ) as mock_cp,
+            patch(
+                "deep_agent.aegra.thread_cleanup._delete_feedback",
+                new_callable=AsyncMock,
+            ) as mock_fb,
+            patch(
+                "deep_agent.aegra.thread_cleanup._delete_token_usage",
+                new_callable=AsyncMock,
+            ) as mock_tu,
         ):
             mock_settings.database_uri = "postgresql://test"
 
@@ -165,3 +179,6 @@ class TestCleanupUserScoping:
             res = client.delete(f"/threads/{thread_id}")
 
             assert res.status_code == 404
+            mock_cp.assert_not_awaited()
+            mock_fb.assert_not_awaited()
+            mock_tu.assert_not_awaited()

--- a/tests/unit/aegra/test_thread_cleanup.py
+++ b/tests/unit/aegra/test_thread_cleanup.py
@@ -181,6 +181,7 @@ class TestCleanupUserScoping:
     def test_thread_ownership_checked_before_delete(self):
         """DELETE returns 404 when thread doesn't belong to the authenticated user."""
         thread_id = "00000000-0000-0000-0000-000000000002"
+        test_user_id = "auth-user-abc"
 
         mock_conn = AsyncMock()
         mock_cursor = AsyncMock()
@@ -190,13 +191,21 @@ class TestCleanupUserScoping:
         mock_conn.__aexit__ = AsyncMock(return_value=False)
 
         with (
-            patch("deep_agent.aegra.auth.ENABLE_AUTH", False),
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", True),
+            patch(
+                "deep_agent.aegra.auth._decode_token",
+                return_value={"sub": test_user_id},
+            ),
             patch("deep_agent.aegra.thread_cleanup.settings") as mock_settings,
             patch(
                 "psycopg.AsyncConnection.connect",
                 new_callable=AsyncMock,
                 return_value=mock_conn,
             ),
+            patch(
+                "deep_agent.aegra.thread_cleanup._delete_pg_data",
+                new_callable=AsyncMock,
+            ) as mock_pg,
             patch(
                 "deep_agent.aegra.thread_cleanup._delete_token_usage",
                 new_callable=AsyncMock,
@@ -205,7 +214,14 @@ class TestCleanupUserScoping:
             mock_settings.database_uri = "postgresql://test"
 
             client = TestClient(app)
-            res = client.delete(f"/threads/{thread_id}")
+            res = client.delete(
+                f"/threads/{thread_id}",
+                headers={"Authorization": "Bearer fake-jwt-token"},
+            )
 
             assert res.status_code == 404
+            query_args = mock_conn.execute.call_args_list[0]
+            assert thread_id in query_args[0][1]
+            assert test_user_id in query_args[0][1]
+            mock_pg.assert_not_awaited()
             mock_tu.assert_not_awaited()

--- a/tests/unit/aegra/test_thread_cleanup.py
+++ b/tests/unit/aegra/test_thread_cleanup.py
@@ -1,8 +1,11 @@
 """Unit tests for thread deletion with full data cleanup."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from starlette.testclient import TestClient
+
+from deep_agent.aegra.http_app import app
 
 
 class TestDeleteCheckpoints:
@@ -86,16 +89,27 @@ class TestDeleteFeedback:
 
 
 class TestDeleteThreadWithCleanup:
-    @pytest.mark.asyncio
-    async def test_cleanup_deletes_all_associated_data(self):
-        """Thread delete must clean up checkpoints, feedback, and token usage."""
-        from deep_agent.aegra.thread_cleanup import (
-            _delete_checkpoints,
-            _delete_feedback,
-            _delete_token_usage,
-        )
+    def test_endpoint_calls_all_cleanup_helpers(self):
+        """DELETE /threads/{id} must invoke checkpoints, feedback, and token usage cleanup."""
+        thread_id = "00000000-0000-0000-0000-000000000001"
+
+        mock_conn = AsyncMock()
+        mock_cursor = AsyncMock()
+        mock_cursor.fetchone = AsyncMock(return_value={"thread_id": thread_id})
+        mock_cursor.rowcount = 1
+        mock_conn.execute = AsyncMock(return_value=mock_cursor)
+        mock_conn.commit = AsyncMock()
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
 
         with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", False),
+            patch("deep_agent.aegra.thread_cleanup.settings") as mock_settings,
+            patch(
+                "psycopg.AsyncConnection.connect",
+                new_callable=AsyncMock,
+                return_value=mock_conn,
+            ),
             patch(
                 "deep_agent.aegra.thread_cleanup._delete_checkpoints",
                 new_callable=AsyncMock,
@@ -112,38 +126,42 @@ class TestDeleteThreadWithCleanup:
                 return_value=True,
             ) as mock_tu,
         ):
-            await mock_cp("thread-123")
-            await mock_fb("thread-123")
-            await mock_tu("thread-123")
+            mock_settings.database_uri = "postgresql://test"
 
-            mock_cp.assert_awaited_once_with("thread-123")
-            mock_fb.assert_awaited_once_with("thread-123")
-            mock_tu.assert_awaited_once_with("thread-123")
+            client = TestClient(app)
+            res = client.delete(f"/threads/{thread_id}")
+
+            assert res.status_code == 200
+            assert res.json() == {"status": "deleted"}
+            mock_cp.assert_awaited_once_with(thread_id)
+            mock_fb.assert_awaited_once_with(thread_id)
+            mock_tu.assert_awaited_once_with(thread_id)
 
 
 class TestCleanupUserScoping:
-    @pytest.mark.asyncio
-    async def test_thread_ownership_checked_before_delete(self):
-        """Delete must verify the thread belongs to the authenticated user."""
-        from deep_agent.aegra.thread_cleanup import _delete_checkpoints
+    def test_thread_ownership_checked_before_delete(self):
+        """DELETE returns 404 when thread doesn't belong to the authenticated user."""
+        thread_id = "00000000-0000-0000-0000-000000000002"
 
         mock_conn = AsyncMock()
         mock_cursor = AsyncMock()
-        mock_cursor.rowcount = 0
+        mock_cursor.fetchone = AsyncMock(return_value=None)
         mock_conn.execute = AsyncMock(return_value=mock_cursor)
-        mock_conn.commit = AsyncMock()
         mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
         mock_conn.__aexit__ = AsyncMock(return_value=False)
 
         with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", False),
+            patch("deep_agent.aegra.thread_cleanup.settings") as mock_settings,
             patch(
                 "psycopg.AsyncConnection.connect",
                 new_callable=AsyncMock,
                 return_value=mock_conn,
             ),
-            patch("deep_agent.aegra.thread_cleanup.settings") as mock_settings,
         ):
             mock_settings.database_uri = "postgresql://test"
 
-            count = await _delete_checkpoints("thread-123")
-            assert count == 0
+            client = TestClient(app)
+            res = client.delete(f"/threads/{thread_id}")
+
+            assert res.status_code == 404

--- a/tests/unit/aegra/test_thread_cleanup.py
+++ b/tests/unit/aegra/test_thread_cleanup.py
@@ -56,7 +56,7 @@ class TestDeletePgData:
 
 class TestDeleteThreadWithCleanup:
     def test_endpoint_deletes_all_data_atomically(self):
-        """DELETE /threads/{id} runs _delete_pg_data and _delete_token_usage."""
+        """DELETE /threads/{id} runs ownership check + cleanup in one transaction."""
         thread_id = "00000000-0000-0000-0000-000000000001"
 
         mock_conn = AsyncMock()
@@ -100,38 +100,29 @@ class TestDeleteThreadWithCleanup:
             mock_conn.commit.assert_awaited()
             mock_tu.assert_awaited_once_with(thread_id)
 
+            first_query = mock_conn.execute.call_args_list[0][0][0]
+            assert "FOR UPDATE" in first_query
+
     def test_pg_failure_rolls_back_no_partial_delete(self):
-        """If PG delete fails mid-transaction, nothing is committed."""
+        """If PG cleanup fails, nothing is committed (single transaction)."""
         thread_id = "00000000-0000-0000-0000-000000000001"
 
-        mock_owner_conn = AsyncMock()
-        mock_owner_cursor = AsyncMock()
-        mock_owner_cursor.fetchone = AsyncMock(return_value={"thread_id": thread_id})
-        mock_owner_conn.execute = AsyncMock(return_value=mock_owner_cursor)
-        mock_owner_conn.__aenter__ = AsyncMock(return_value=mock_owner_conn)
-        mock_owner_conn.__aexit__ = AsyncMock(return_value=False)
-
-        mock_delete_conn = AsyncMock()
+        mock_conn = AsyncMock()
         call_count = 0
 
-        async def fail_on_second_execute(*args, **kwargs):
+        async def ownership_then_fail(*args, **kwargs):
             nonlocal call_count
             call_count += 1
-            if call_count == 2:
-                raise RuntimeError("disk full")
-            cursor = AsyncMock()
-            cursor.rowcount = 1
-            return cursor
+            if call_count == 1:
+                cursor = AsyncMock()
+                cursor.fetchone = AsyncMock(return_value={"thread_id": thread_id})
+                return cursor
+            raise RuntimeError("disk full")
 
-        mock_delete_conn.execute = AsyncMock(side_effect=fail_on_second_execute)
-        mock_delete_conn.commit = AsyncMock()
-        mock_delete_conn.__aenter__ = AsyncMock(return_value=mock_delete_conn)
-        mock_delete_conn.__aexit__ = AsyncMock(return_value=False)
-
-        connect_calls = [mock_owner_conn, mock_delete_conn]
-
-        async def connect_side_effect(*args, **kwargs):
-            return connect_calls.pop(0)
+        mock_conn.execute = AsyncMock(side_effect=ownership_then_fail)
+        mock_conn.commit = AsyncMock()
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
 
         with (
             patch("deep_agent.aegra.auth.ENABLE_AUTH", False),
@@ -139,7 +130,7 @@ class TestDeleteThreadWithCleanup:
             patch(
                 "psycopg.AsyncConnection.connect",
                 new_callable=AsyncMock,
-                side_effect=connect_side_effect,
+                return_value=mock_conn,
             ),
         ):
             mock_settings.database_uri = "postgresql://test"
@@ -148,7 +139,7 @@ class TestDeleteThreadWithCleanup:
             res = client.delete(f"/threads/{thread_id}")
 
             assert res.status_code == 500
-            mock_delete_conn.commit.assert_not_awaited()
+            mock_conn.commit.assert_not_awaited()
 
     def test_mongodb_failure_still_returns_success(self):
         """MongoDB token-usage cleanup is best-effort after PG commit."""

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -197,6 +197,7 @@ class TestUpsertRule:
         import deep_agent.src.personalization.repository as repo_mod
 
         repo_mod._TABLES_ENSURED = True
+        mock_conn._cursor.rowcount = 1
 
         with patch(
             "deep_agent.src.personalization.repository.psycopg.AsyncConnection.connect",


### PR DESCRIPTION
## Summary

Two features: **thread deletion cleanup** and **personalization CRUD API**.

### 1. Thread Deletion Cleanup

When a user deletes a chat, Aegra's built-in `DELETE /threads/{id}` only removes the thread row — leaving orphaned checkpoints, feedback, and token-usage records. This PR adds a custom delete endpoint that cleans up everything in a single transaction.

**What gets deleted per thread:**

| Table | What it stores | Scoped by |
|-------|---------------|-----------|
| `checkpoint_writes` | LangGraph message writes | `thread_id` |
| `checkpoint_blobs` | Serialized checkpoint data | `thread_id` |
| `checkpoints` | Conversation state snapshots | `thread_id` |
| `message_feedback` | User thumbs-up/down ratings | `thread_id` |
| `runs` | LangGraph execution runs | `thread_id` + `user_id` |
| `thread` | The thread row itself | `thread_id` + `user_id` |
| MongoDB `thread_token_usage` | LLM token counts (optional) | `thread_id` |

All PostgreSQL deletes run in **one transaction** with `SELECT ... FOR UPDATE` row locking — ownership check and cleanup are atomic. MongoDB cleanup runs after the PG commit as best-effort.

**Delete flow:**
```
DELETE /threads/{id}
  1. Validate UUID format
  2. SELECT ... FOR UPDATE (verify ownership + lock row)
  3. Single PG transaction: delete checkpoints → feedback → runs → thread
  4. Best-effort: delete MongoDB token-usage records
  5. Return {"status": "deleted"}
```

### 2. Personalization CRUD API

Memories and custom rules were only stored in the browser's localStorage — never persisted to the backend. Added REST endpoints so the UI can persist them to Postgres immediately on add/delete.

**Endpoints:**
| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/personalization/memories` | List user's memories |
| `POST` | `/personalization/memories` | Create memory (accepts client UUID) |
| `DELETE` | `/personalization/memories/{id}` | Delete memory |
| `GET` | `/personalization/rules` | List user's rules |
| `POST` | `/personalization/rules` | Create rule (accepts client UUID) |
| `DELETE` | `/personalization/rules/{id}` | Delete rule |

The UI sends its own UUID in the POST body; the backend uses it as the record ID. This ensures delete calls always match — no ID sync issues.

### Additional changes

- **`auth_helpers.py`** — Shared `authenticated_user_id()` with `reject_anonymous` support
- **`http_app.py`** — Route registration + startup verification that custom DELETE route takes priority over Aegra's built-in
- **`feedback.py`** — `reject_anonymous=True` on feedback/token-usage + thread-owner authorization
- **`personalization_cache.py`** — `asyncio.to_thread` for Redis I/O + fallback expire on failed delete
- **`repository.py`** — Accept client-provided `memory_id`, Guardian safety check preserved

### Auth behavior

| Mode | Thread delete | Personalization |
|------|--------------|-----------------|
| `ENABLE_AUTH=true` | Ownership check with `user_id` from JWT | Scoped to JWT `sub` claim |
| `ENABLE_AUTH=false` | Deletes any thread (no user scoping) | Scoped to `dev-user` |
| Anonymous request | 401 rejected | 401 rejected |

## Test plan

- [x] 24 unit tests pass (thread cleanup, auth helpers, feedback)
- [x] Direct `curl DELETE` against agent returns `{"status": "deleted"}`
- [x] Delete via BFF proxy succeeds
- [x] PG failure mid-transaction rolls back (no partial deletion)
- [x] MongoDB failure after PG commit still returns success
- [x] Ownership check blocks delete for non-owner (auth enabled)
- [x] Auth-disabled mode skips ownership check
- [x] Memories/rules persist to Postgres on add from UI
- [x] Memories/rules deleted from Postgres on remove from UI
- [x] Guardian safety check runs on memory creation
- [x] All personalization endpoints reject anonymous requests

Closes #236