### PR TITLE
fix(security): replace guardrails one-way kill switch with circuit breaker

### DIFF
--- a/deep_agent/src/guardrails/__init__.py
+++ b/deep_agent/src/guardrails/__init__.py
@@ -1,15 +1,13 @@
-"""Granite Guardian guardrails — content safety error hierarchy and public API."""
+"""Granite Guardian guardrails -- content safety error hierarchy and public API."""
 
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from deep_agent.src.guardrails.config import GuardrailsConfig
 
-# Sentinel embedded in every BLOCKED_RESULT ToolMessage and used by SafetyAwareRunnable
-# to detect tool blocks in both ainvoke and astream_events.  Defined here so both
-# tool_proxy.py and safety.py reference the same string without implicit coupling.
 TOOL_SAFETY_REFUSAL = (
     "I wasn't able to complete this task due to a content safety policy issue."
 )
@@ -28,7 +26,16 @@ class ToolContentSafetyError(ContentSafetyError):
 
 
 _config: Optional["GuardrailsConfig"] = None
-_runtime_disabled: bool = False
+
+_CIRCUIT_COOLDOWN_SECONDS: float = 300.0
+
+_circuit_state: str = "closed"
+_circuit_opened_at: float = 0.0
+_circuit_reason: str = ""
+
+
+def _time() -> float:
+    return time.monotonic()
 
 
 def init_guardrails(config: "GuardrailsConfig") -> None:
@@ -38,23 +45,70 @@ def init_guardrails(config: "GuardrailsConfig") -> None:
 
 
 def get_guardrails_config() -> Optional["GuardrailsConfig"]:
-    """Return the global GuardrailsConfig, or None if not yet initialised or runtime-disabled."""
-    if _runtime_disabled:
+    """Return the global GuardrailsConfig, or None if not yet initialised or circuit-open."""
+    global _circuit_state  # noqa: PLW0603
+    if _circuit_state == "open":
+        elapsed = _time() - _circuit_opened_at
+        if elapsed >= _CIRCUIT_COOLDOWN_SECONDS:
+            _circuit_state = "half-open"
+            from deep_agent.utils.pylogger import get_python_logger
+
+            get_python_logger().warning(
+                "guardian_circuit_half_open",
+                message="Guardrails circuit breaker entering half-open state -- next call will probe.",
+                cooldown_seconds=_CIRCUIT_COOLDOWN_SECONDS,
+            )
+            return _config
         return None
     return _config
 
 
 def disable_guardrails_runtime(reason: str = "") -> None:
-    """Disable guardrails for the remainder of this process after a configuration error."""
-    global _runtime_disabled  # noqa: PLW0603
-    if _runtime_disabled:
+    """Open the circuit breaker after a configuration error.
+
+    Guardrails are disabled for _CIRCUIT_COOLDOWN_SECONDS, then a probe
+    request is allowed (half-open). A successful probe closes the circuit;
+    another failure re-opens it.
+    """
+    global _circuit_state, _circuit_opened_at, _circuit_reason  # noqa: PLW0603
+    if _circuit_state == "open":
         return
-    _runtime_disabled = True
+    _circuit_state = "open"
+    _circuit_opened_at = _time()
+    _circuit_reason = reason
     from deep_agent.utils.pylogger import get_python_logger
 
     get_python_logger().error(
-        "guardian_runtime_disabled",
+        "guardian_circuit_open",
         reason=reason,
-        message="Granite Guardian disabled for this session due to a configuration error — "
-        "fix GUARDIAN_API_BASE / GUARDIAN_API_KEY or the model name and restart.",
+        cooldown_seconds=_CIRCUIT_COOLDOWN_SECONDS,
+        message="Granite Guardian disabled due to a configuration error -- "
+        "will probe again after cooldown.",
     )
+
+
+def close_guardrails_circuit() -> None:
+    """Close the circuit breaker after a successful probe."""
+    global _circuit_state, _circuit_opened_at, _circuit_reason  # noqa: PLW0603
+    if _circuit_state == "closed":
+        return
+    prev = _circuit_state
+    _circuit_state = "closed"
+    _circuit_opened_at = 0.0
+    _circuit_reason = ""
+    from deep_agent.utils.pylogger import get_python_logger
+
+    get_python_logger().info(
+        "guardian_circuit_closed",
+        previous_state=prev,
+        message="Granite Guardian circuit breaker closed -- guardrails re-enabled.",
+    )
+
+
+def guardrails_circuit_state() -> str:
+    """Return the current circuit state: 'closed', 'open', or 'half-open'."""
+    if _circuit_state == "open":
+        elapsed = _time() - _circuit_opened_at
+        if elapsed >= _CIRCUIT_COOLDOWN_SECONDS:
+            return "half-open"
+    return _circuit_state

--- a/deep_agent/src/guardrails/client.py
+++ b/deep_agent/src/guardrails/client.py
@@ -110,6 +110,12 @@ async def _call_guardian(
     if get_guardrails_config() is None:
         return True, "disabled"
 
+    from deep_agent.src.guardrails import (
+        close_guardrails_circuit,
+        disable_guardrails_runtime,
+        guardrails_circuit_state,
+    )
+
     try:
         response = await litellm.acompletion(
             model=f"openai/{_guardian_model()}",
@@ -122,12 +128,12 @@ async def _call_guardian(
         verdict = _extract_verdict(raw)
         is_safe = not verdict.lower().startswith("yes")
         logger.info("guardian_check", context=context, verdict=verdict, is_safe=is_safe)
+        if guardrails_circuit_state() == "half-open":
+            close_guardrails_circuit()
         return is_safe, verdict
     except Exception as exc:
         if _is_config_error(exc):
             logger.warning("guardian_check_failed", context=context, reason=str(exc))
-            from deep_agent.src.guardrails import disable_guardrails_runtime
-
             disable_guardrails_runtime(reason=str(exc))
         else:
             logger.warning("guardian_check_failed", context=context, exc_info=True)

--- a/tests/unit/guardrails/test_client.py
+++ b/tests/unit/guardrails/test_client.py
@@ -180,8 +180,8 @@ class TestCallGuardian:
             mock_disable.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_config_error_returns_safe_and_disables_guardrail(self):
-        """404/401/403 are permanent misconfigs — guardrail must self-disable after first hit."""
+    async def test_config_error_returns_safe_and_opens_circuit(self):
+        """404/401/403 are permanent misconfigs -- circuit breaker must open."""
 
         class _NotFound(Exception):
             status_code = 404
@@ -207,8 +207,8 @@ class TestCallGuardian:
             mock_disable.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_auth_error_disables_guardrail(self):
-        """401 auth failure must self-disable so bad credentials don't spam logs."""
+    async def test_auth_error_opens_circuit(self):
+        """401 auth failure must open circuit breaker."""
 
         class _AuthError(Exception):
             status_code = 401
@@ -230,6 +230,60 @@ class TestCallGuardian:
                 [{"role": "user", "content": "hi"}], "input"
             )
             assert is_safe is True
+            mock_disable.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_successful_half_open_probe_closes_circuit(self):
+        """After cooldown, a successful call must close the circuit breaker."""
+        mock_response = MagicMock()
+        mock_response.choices[0].message.content = "No"
+
+        with (
+            patch(
+                "deep_agent.src.guardrails.client._guardian_model", return_value="model"
+            ),
+            patch("deep_agent.src.guardrails.client._get_guardian_client"),
+            patch(
+                "deep_agent.src.guardrails.client.litellm.acompletion",
+                new=AsyncMock(return_value=mock_response),
+            ),
+            patch(
+                "deep_agent.src.guardrails.guardrails_circuit_state",
+                return_value="half-open",
+            ),
+            patch("deep_agent.src.guardrails.close_guardrails_circuit") as mock_close,
+        ):
+            is_safe, verdict = await _call_guardian(
+                [{"role": "user", "content": "hi"}], "input"
+            )
+            assert is_safe is True
+            mock_close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_failed_half_open_probe_reopens_circuit(self):
+        """After cooldown, a failed probe must re-open the circuit."""
+
+        class _NotFound(Exception):
+            status_code = 404
+
+        with (
+            patch(
+                "deep_agent.src.guardrails.client._guardian_model", return_value="model"
+            ),
+            patch("deep_agent.src.guardrails.client._get_guardian_client"),
+            patch(
+                "deep_agent.src.guardrails.client.litellm.acompletion",
+                new=AsyncMock(side_effect=_NotFound("still broken")),
+            ),
+            patch(
+                "deep_agent.src.guardrails.disable_guardrails_runtime"
+            ) as mock_disable,
+        ):
+            is_safe, verdict = await _call_guardian(
+                [{"role": "user", "content": "hi"}], "input"
+            )
+            assert is_safe is True
+            assert verdict == "error"
             mock_disable.assert_called_once()
 
 

--- a/tests/unit/guardrails/test_init.py
+++ b/tests/unit/guardrails/test_init.py
@@ -1,5 +1,7 @@
 """Unit tests for deep_agent.src.guardrails __init__ public API."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 import deep_agent.src.guardrails as guardrails_mod
@@ -7,22 +9,30 @@ from deep_agent.src.guardrails import (
     ContentSafetyError,
     InputContentSafetyError,
     ToolContentSafetyError,
+    close_guardrails_circuit,
     disable_guardrails_runtime,
     get_guardrails_config,
+    guardrails_circuit_state,
     init_guardrails,
 )
 
 
 @pytest.fixture(autouse=True)
 def reset_guardrails_state():
-    """Reset global _config and _runtime_disabled between tests."""
+    """Reset global state between tests."""
     original_config = guardrails_mod._config
-    original_disabled = guardrails_mod._runtime_disabled
+    original_state = guardrails_mod._circuit_state
+    original_at = guardrails_mod._circuit_opened_at
+    original_reason = guardrails_mod._circuit_reason
     guardrails_mod._config = None
-    guardrails_mod._runtime_disabled = False
+    guardrails_mod._circuit_state = "closed"
+    guardrails_mod._circuit_opened_at = 0.0
+    guardrails_mod._circuit_reason = ""
     yield
     guardrails_mod._config = original_config
-    guardrails_mod._runtime_disabled = original_disabled
+    guardrails_mod._circuit_state = original_state
+    guardrails_mod._circuit_opened_at = original_at
+    guardrails_mod._circuit_reason = original_reason
 
 
 class TestErrorHierarchy:
@@ -47,53 +57,87 @@ class TestInitGuardrails:
         assert get_guardrails_config() is None
 
     def test_init_guardrails_stores_config(self):
-        from unittest.mock import MagicMock
-
         cfg = MagicMock()
         init_guardrails(cfg)
         assert get_guardrails_config() is cfg
 
     def test_init_guardrails_overwrites_previous(self):
-        from unittest.mock import MagicMock
-
         cfg1, cfg2 = MagicMock(), MagicMock()
         init_guardrails(cfg1)
         init_guardrails(cfg2)
         assert get_guardrails_config() is cfg2
 
 
-class TestDisableGuardrailsRuntime:
-    def test_get_guardrails_config_returns_none_after_disable(self):
-        from unittest.mock import MagicMock
+class TestCircuitBreaker:
+    def test_disable_opens_circuit(self):
+        cfg = MagicMock()
+        init_guardrails(cfg)
+        assert get_guardrails_config() is cfg
+        disable_guardrails_runtime(reason="test")
+        assert get_guardrails_config() is None
+        assert guardrails_circuit_state() == "open"
 
-        init_guardrails(MagicMock())
-        assert get_guardrails_config() is not None
+    def test_disable_is_idempotent(self):
+        disable_guardrails_runtime(reason="first")
+        disable_guardrails_runtime(reason="second")
+        assert guardrails_mod._circuit_state == "open"
+
+    def test_config_not_returned_when_circuit_open(self):
+        cfg = MagicMock(enabled=True)
+        init_guardrails(cfg)
+        guardrails_mod._circuit_state = "open"
+        guardrails_mod._circuit_opened_at = guardrails_mod._time()
+        assert get_guardrails_config() is None
+
+    def test_circuit_transitions_to_half_open_after_cooldown(self):
+        cfg = MagicMock(enabled=True)
+        init_guardrails(cfg)
         disable_guardrails_runtime(reason="test")
         assert get_guardrails_config() is None
 
-    def test_disable_is_idempotent(self):
-        """Second call must not raise and must not log again."""
-        disable_guardrails_runtime(reason="first")
-        disable_guardrails_runtime(reason="second")  # must not raise
-        assert guardrails_mod._runtime_disabled is True
+        with patch.object(
+            guardrails_mod,
+            "_time",
+            return_value=guardrails_mod._circuit_opened_at
+            + guardrails_mod._CIRCUIT_COOLDOWN_SECONDS,
+        ):
+            assert guardrails_circuit_state() == "half-open"
+            result = get_guardrails_config()
+            assert result is cfg
+            assert guardrails_mod._circuit_state == "half-open"
 
-    def test_config_not_returned_when_runtime_disabled_even_if_set(self):
-        from unittest.mock import MagicMock
-
+    def test_close_circuit_re_enables_guardrails(self):
         cfg = MagicMock(enabled=True)
         init_guardrails(cfg)
-        guardrails_mod._runtime_disabled = True
+        disable_guardrails_runtime(reason="test")
+        assert get_guardrails_config() is None
+
+        close_guardrails_circuit()
+        assert guardrails_circuit_state() == "closed"
+        assert get_guardrails_config() is cfg
+
+    def test_close_is_idempotent(self):
+        close_guardrails_circuit()
+        assert guardrails_circuit_state() == "closed"
+
+    def test_circuit_reopens_on_second_failure(self):
+        cfg = MagicMock(enabled=True)
+        init_guardrails(cfg)
+
+        disable_guardrails_runtime(reason="first failure")
+        assert guardrails_circuit_state() == "open"
+
+        close_guardrails_circuit()
+        assert guardrails_circuit_state() == "closed"
+
+        disable_guardrails_runtime(reason="second failure")
+        assert guardrails_circuit_state() == "open"
         assert get_guardrails_config() is None
 
     def test_enabled_false_does_not_run_guardian(self):
-        """enabled=False: guardrails never initialised, get_guardrails_config stays None."""
-        # Simulate setup_guardian_guardrails() short-circuit: init_guardrails never called.
         assert get_guardrails_config() is None
 
     def test_enabled_true_runs_guardian(self):
-        """enabled=True: after init_guardrails the config is returned."""
-        from unittest.mock import MagicMock
-
         cfg = MagicMock(enabled=True)
         init_guardrails(cfg)
         assert get_guardrails_config() is cfg


### PR DESCRIPTION
## Summary

Closes #212

- Replace the permanent `_runtime_disabled` boolean with a circuit breaker (open/half-open/closed) that auto-recovers after a 5-minute cooldown
- On config error (401/403/404), circuit opens and guardrails are disabled temporarily
- After cooldown, a probe request is allowed; success closes the circuit and re-enables guardrails
- Successful calls during half-open state close the circuit via `close_guardrails_circuit()`
- Log at ERROR when circuit opens, WARNING on half-open transition, INFO when closed

## Test plan

- [ ] Verify `disable_guardrails_runtime()` opens the circuit (not permanent disable)
- [ ] Verify circuit transitions to half-open after cooldown period
- [ ] Verify successful probe closes the circuit and re-enables guardrails
- [ ] Verify failed probe re-opens the circuit
- [ ] Verify `close_guardrails_circuit()` is idempotent
- [ ] Verify existing callback and tool_proxy tests still pass unchanged
- [ ] Verify full unit test suite passes (1177 tests)