### PR TITLE
fix(health): separate liveness probe from readiness checks

### DIFF
--- a/deep_agent/aegra/health.py
+++ b/deep_agent/aegra/health.py
@@ -230,8 +230,39 @@ async def get_health_status() -> dict[str, Any]:
     }
 
 
-async def health_response() -> tuple[int, dict[str, Any]]:
-    """Return (status_code, body) for the health endpoint."""
+def liveness_response() -> tuple[int, dict[str, Any]]:
+    """Return (status_code, body) for liveness probes.
+
+    Liveness probes answer "is the process alive?" -- no dependency checks.
+    Returning 503 here causes Kubernetes to restart the pod, so only fail
+    when the process is genuinely stuck or shutting down.
+    """
+    from deep_agent.aegra.shutdown import is_shutting_down
+
+    if is_shutting_down():
+        return 503, {
+            "status": "shutting_down",
+            "version": __version__,
+            "uptime_seconds": round(time.monotonic() - _start_time, 1),
+        }
+
+    return 200, {
+        "status": "alive",
+        "version": __version__,
+        "uptime_seconds": round(time.monotonic() - _start_time, 1),
+    }
+
+
+async def health_response(path: str = "/health") -> tuple[int, dict[str, Any]]:
+    """Return (status_code, body) for health and readiness endpoints.
+
+    When *path* is ``/livez`` the response is a lightweight liveness check
+    with no dependency probing.  All other paths run full dependency checks
+    suitable for readiness probes.
+    """
+    if path in LIVENESS_PATHS:
+        return liveness_response()
+
     from deep_agent.aegra.shutdown import is_shutting_down
 
     if is_shutting_down():
@@ -246,4 +277,5 @@ async def health_response() -> tuple[int, dict[str, Any]]:
     return code, result
 
 
+LIVENESS_PATHS = frozenset({"/livez"})
 HEALTH_PATHS = frozenset({"/health", "/healthz", "/readyz", "/livez"})

--- a/tests/unit/aegra/test_health.py
+++ b/tests/unit/aegra/test_health.py
@@ -11,6 +11,7 @@ from deep_agent.aegra.health import (
     check_redis,
     get_health_status,
     health_response,
+    liveness_response,
 )
 
 
@@ -256,3 +257,43 @@ class TestHealthResponse:
         ):
             code, body = await health_response()
         assert code == 503
+
+    async def test_livez_skips_dependency_checks(self):
+        """Liveness probe must not run get_health_status (no DB/Redis/OPA checks)."""
+        with patch(
+            "deep_agent.aegra.health.get_health_status",
+            new_callable=AsyncMock,
+        ) as mock_health:
+            code, body = await health_response(path="/livez")
+        mock_health.assert_not_called()
+        assert code == 200
+        assert body["status"] == "alive"
+
+    async def test_readyz_runs_dependency_checks(self):
+        """Readiness probe must run full dependency checks."""
+        with patch(
+            "deep_agent.aegra.health.get_health_status",
+            new_callable=AsyncMock,
+            return_value={"status": "unhealthy"},
+        ) as mock_health:
+            code, body = await health_response(path="/readyz")
+        mock_health.assert_called_once()
+        assert code == 503
+
+
+class TestLivenessResponse:
+    def test_alive_when_not_shutting_down(self):
+        code, body = liveness_response()
+        assert code == 200
+        assert body["status"] == "alive"
+        assert "uptime_seconds" in body
+        assert "version" in body
+
+    def test_503_when_shutting_down(self):
+        with patch(
+            "deep_agent.aegra.shutdown.is_shutting_down",
+            return_value=True,
+        ):
+            code, body = liveness_response()
+        assert code == 503
+        assert body["status"] == "shutting_down"


### PR DESCRIPTION
## Summary

- Add `liveness_response()` that returns a lightweight "process alive" check (uptime, version, shutdown state) with no dependency probing
- Route `/livez` through `liveness_response()` so Kubernetes only restarts the pod when the process is genuinely stuck or shutting down
- All other probe paths (`/health`, `/healthz`, `/readyz`) continue running full dependency checks

Closes #224

## Test plan

- [x] `test_livez_skips_dependency_checks` -- verifies `/livez` does not call `get_health_status()`
- [x] `test_readyz_runs_dependency_checks` -- verifies `/readyz` still runs full checks and returns 503 on failure
- [x] `test_alive_when_not_shutting_down` -- verifies liveness returns 200 with `"alive"` status
- [x] `test_503_when_shutting_down` -- verifies liveness returns 503 during graceful shutdown
- [x] All 22 existing health tests continue to pass