### PR TITLE
fix: flatten mcp_app_enabled

### DIFF
--- a/config/agent/runtime/ui.yaml
+++ b/config/agent/runtime/ui.yaml
@@ -58,8 +58,7 @@ otel:
 
 # --- Features ---
 features:
-  mcp_apps:
-    enabled: true            # Serve /sandbox_proxy.html for MCP Apps host rendering
+  mcp_apps_enabled: true     # Serve /sandbox_proxy.html for MCP Apps host rendering
 
 # --- Announcement Banner ---
 announcement:


### PR DESCRIPTION
Signed-off-by: AtrikGhosh <atrikghosh26@gmail.com>

## What

Flatten `features.mcp_apps.enabled` to `features.mcp_apps_enabled` so the MCP Apps flag matches other feature flags (`auth_enabled`, `mcp_dcr_enabled`). Nested `enabled` was the only sub-key and added config surface without benefit.

Fixes #240

## How

- Schema: drop `McpAppsFeaturesConfig`; `features.mcp_apps_enabled` is a boolean (default `true`).
- YAML, docs, sandbox 404 gate, `config.service`, and `McpAppHost` now read the flat key.
- Env is unchanged: `FEATURE_MCP_APPS_ENABLED`.
- Python `deep_agent.aegra.mcp_apps` / startup `results["mcp_apps"]` are unchanged.

**Trade-off:** this is a breaking YAML rename. Old ConfigMaps that only set `features.mcp_apps.enabled: false` are ignored; `deepMerge` keeps the default `true` (fail-open). In-repo files were updated; we did not dual-read the nested key. Deployments that overrode the nested flag must switch to `features.mcp_apps_enabled`.

## Testing

- [x] Unit tests added/updated
- [x] Ran locally (`uv run pytest tests/unit -x`) — N/A for template-ui; ran related Vitest (`settings`, `mcp-apps-smoke`, `mcp-apps-sandbox`, `McpAppHost`)
- [x] Manual verification (describe below if applicable)

## Rollback

Revert the commit. Restores nested `features.mcp_apps.enabled`. Any ConfigMap already migrated to the flat key must be reverted with it.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `ci:`, etc.)
- [x] No secrets, credentials, or PII in the diff
- [x] No breaking changes (or documented above with a migration path)
- [x] Pre-commit hooks pass (`uv run pre-commit run --all-files`)