### PR TITLE
fix: parse stringified JSON args for MCP tool calls

### DIFF
--- a/deep_agent/aegra/mcp_tool_auth.py
+++ b/deep_agent/aegra/mcp_tool_auth.py
@@ -25,6 +25,48 @@ def _mcp_auth_interrupt_payload(exc: NeedsAuthorization) -> str:
     )
 
 
+def _fix_stringified_json_args(tool: Any, kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Parse stringified JSON args when the tool schema expects object/array.
+
+    Some models (notably Gemini) serialize nested objects as JSON strings
+    instead of proper dicts when calling tools with complex input schemas.
+    Parses args whose schema type is ``object``, ``array``, or untyped
+    (``Any`` — no ``type`` key in the schema property). Args explicitly
+    typed as ``string`` are never modified.
+    """
+    schema_props: dict[str, Any] = {}
+    try:
+        schema_props = getattr(tool, "args", {}) or {}
+    except Exception:
+        return kwargs
+
+    if not schema_props:
+        return kwargs
+
+    fixed = dict(kwargs)
+    for key, value in fixed.items():
+        if not isinstance(value, str):
+            continue
+        prop = schema_props.get(key, {})
+        expected_type = prop.get("type", "")
+        if expected_type == "string":
+            continue
+        stripped = value.strip()
+        if stripped and stripped[0] in ("{", "["):
+            try:
+                parsed = json.loads(stripped)
+                if isinstance(parsed, (dict, list)):
+                    fixed[key] = parsed
+                    logger.debug(
+                        "Fixed stringified JSON arg '%s' for tool '%s'",
+                        key,
+                        getattr(tool, "name", "?"),
+                    )
+            except (json.JSONDecodeError, ValueError):
+                pass
+    return fixed
+
+
 def wrap_mcp_tools_for_auth(tools: list[Any]) -> list[Any]:
     """Wrap MCP tools so ``NeedsAuthorization`` becomes a resumable interrupt."""
     wrapped: list[Any] = []
@@ -42,6 +84,7 @@ def _wrap_single_tool(tool: Any) -> Any:
         async def wrapped_coroutine(**kwargs: Any) -> Any:
             while True:
                 try:
+                    kwargs = _fix_stringified_json_args(tool, kwargs)
                     return await coroutine(**kwargs)
                 except NeedsAuthorization as exc:
                     logger.info(
@@ -61,6 +104,7 @@ def _wrap_single_tool(tool: Any) -> Any:
         def wrapped_func(**kwargs: Any) -> Any:
             while True:
                 try:
+                    kwargs = _fix_stringified_json_args(tool, kwargs)
                     return func(**kwargs)
                 except NeedsAuthorization as exc:
                     interrupt(_mcp_auth_interrupt_payload(exc))

--- a/deep_agent/aegra/mcp_tool_auth.py
+++ b/deep_agent/aegra/mcp_tool_auth.py
@@ -49,7 +49,14 @@ def _fix_stringified_json_args(tool: Any, kwargs: dict[str, Any]) -> dict[str, A
             continue
         prop = schema_props.get(key, {})
         expected_type = prop.get("type", "")
-        if expected_type == "string":
+        if expected_type == "string" or (
+            isinstance(expected_type, list) and "string" in expected_type
+        ):
+            continue
+        if any(
+            "string" in str(s.get("type", ""))
+            for s in prop.get("anyOf", prop.get("oneOf", []))
+        ):
             continue
         stripped = value.strip()
         if stripped and stripped[0] in ("{", "["):
@@ -62,7 +69,7 @@ def _fix_stringified_json_args(tool: Any, kwargs: dict[str, Any]) -> dict[str, A
                         key,
                         getattr(tool, "name", "?"),
                     )
-            except (json.JSONDecodeError, ValueError):
+            except (json.JSONDecodeError, ValueError, RecursionError):
                 pass
     return fixed
 

--- a/deep_agent/aegra/mcp_tool_auth.py
+++ b/deep_agent/aegra/mcp_tool_auth.py
@@ -53,10 +53,8 @@ def _fix_stringified_json_args(tool: Any, kwargs: dict[str, Any]) -> dict[str, A
             isinstance(expected_type, list) and "string" in expected_type
         ):
             continue
-        if any(
-            "string" in str(s.get("type", ""))
-            for s in prop.get("anyOf", prop.get("oneOf", []))
-        ):
+        union_schemas = prop.get("anyOf", []) + prop.get("oneOf", [])
+        if any("string" in str(s.get("type", "")) for s in union_schemas):
             continue
         stripped = value.strip()
         if stripped and stripped[0] in ("{", "["):


### PR DESCRIPTION
## Summary

Fixes #249

Gemini and some other models serialize nested objects as JSON strings when calling MCP tools with complex input schemas (e.g. `editJiraIssue` `fields` parameter). This causes MCP servers to reject the call with `Expected object, received string`.

## Changes

- Added `_fix_stringified_json_args()` to `deep_agent/aegra/mcp_tool_auth.py`
- Called before every MCP tool invocation in both async and sync wrappers
- Only parses string args that:
  - Are NOT explicitly typed as `string` in the tool schema
  - Start with `{` or `[` (look like JSON)
  - Are valid JSON that parses to a dict or list

## How it works

```
Model outputs: {"fields": "{\"description\": \"...\"}"}   ← string
                         ↓ _fix_stringified_json_args()
MCP receives:  {"fields": {"description": "..."}}          ← object
```

Args explicitly typed as `string` in the tool schema are never modified, preventing false positives.

## Testing

- Reproduced locally on Kind cluster with Gemini 2.5 Pro + Atlassian Jira MCP
- `editJiraIssue` failed before fix, succeeds after
- Other tools with flat string args (`searchJiraIssuesUsingJql`, `getJiraIssue`) unaffected
- Verified the fix does not modify args where `tool.args` schema says `type: "string"`

## Test plan

- [x] `editJiraIssue` with nested `fields` object — was failing, now works
- [x] `searchJiraIssuesUsingJql` with string `jql` arg — still works, not modified
- [x] `calculate_bmi` with numeric args — unaffected
- [x] String arg containing valid JSON but typed as string — not modified