### PR TITLE
fix: build-base-image job to trigger on pushes to main

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - '*'
     branches:
-      # - main
+      - main
       - deep-agent
   pull_request:
     branches: [ main, deep-agent ]


### PR DESCRIPTION
## What

change build-base-image job to trigger on pushes to main

Fixes #257 

## How

uncomment main branch from job list 

## Testing

<!-- How did you verify this works? -->

- [x] Unit tests added/updated
- [x] Ran locally (`uv run pytest tests/unit -x`)
- [x] Manual verification (describe below if applicable)

## Rollback

<!-- How would you revert this if it breaks production? "Revert the commit" is fine for most changes. -->

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `ci:`, etc.)
- [x] No secrets, credentials, or PII in the diff
- [x] No breaking changes (or documented above with a migration path)
- [x] Pre-commit hooks pass (`uv run pre-commit run --all-files`)
