### PR TITLE
fix: Guardian still runs on agent/subagent when enabled: false

### DIFF
--- a/deep_agent/aegra/graph.py
+++ b/deep_agent/aegra/graph.py
@@ -326,7 +326,10 @@ async def agent(runtime: ServerRuntime) -> Any:
 
     from deep_agent.src.settings import settings as app_settings
 
-    if app_settings.GUARDIAN_API_BASE:
+    guardrail_cfg = agent_config.get_guardrails_config()
+    guardian_active = guardrail_cfg.enabled and bool(app_settings.GUARDIAN_API_BASE)
+
+    if guardian_active:
         from deep_agent.src.guardrails.tool_proxy import wrap_tools
 
         tools = wrap_tools(tools)
@@ -387,7 +390,7 @@ async def agent(runtime: ServerRuntime) -> Any:
         compiled = PIIAwareRunnable(compiled)
         logger.info("graph_pii_enabled: wrapped with PIIAwareRunnable")
 
-    if app_settings.GUARDIAN_API_BASE:
+    if guardian_active:
         from deep_agent.aegra.safety import SafetyAwareRunnable
 
         compiled = SafetyAwareRunnable(compiled, outermost=True)

--- a/deep_agent/src/infrastructure/subagents.py
+++ b/deep_agent/src/infrastructure/subagents.py
@@ -417,7 +417,10 @@ def _build_default_subagent(
 
     from deep_agent.src.settings import settings as app_settings
 
-    if app_settings.GUARDIAN_API_BASE:
+    guardrail_cfg = agent_config.get_guardrails_config()
+    guardian_active = guardrail_cfg.enabled and bool(app_settings.GUARDIAN_API_BASE)
+
+    if guardian_active:
         from deep_agent.src.guardrails.tool_proxy import wrap_tools
 
         resolved_tools = wrap_tools(resolved_tools)
@@ -490,7 +493,10 @@ def _build_compiled_subagent(
 
     from deep_agent.src.settings import settings as app_settings
 
-    if app_settings.GUARDIAN_API_BASE:
+    guardrail_cfg = agent_config.get_guardrails_config()
+    guardian_active = guardrail_cfg.enabled and bool(app_settings.GUARDIAN_API_BASE)
+
+    if guardian_active:
         from deep_agent.src.guardrails.tool_proxy import wrap_tools
 
         resolved_tools = wrap_tools(resolved_tools)
@@ -520,7 +526,7 @@ def _build_compiled_subagent(
         runnable = PIIAwareRunnable(runnable)
         logger.info("subagent '%s' [compiled] wrapped with PIIAwareRunnable", name)
 
-    if app_settings.GUARDIAN_API_BASE:
+    if guardian_active:
         from deep_agent.aegra.safety import SafetyAwareRunnable
 
         runnable = SafetyAwareRunnable(runnable)

--- a/tests/unit/aegra/test_graph.py
+++ b/tests/unit/aegra/test_graph.py
@@ -615,7 +615,9 @@ class TestGuardianActivationGate:
             "tools": [],
         }
         mock_config.resolve_tools.return_value = []
-        mock_config.resolve_agent_middleware.return_value = MagicMock(skills_enabled=True)
+        mock_config.resolve_agent_middleware.return_value = MagicMock(
+            skills_enabled=True
+        )
         guardrail_cfg = MagicMock()
         guardrail_cfg.enabled = guardrails_enabled
         mock_config.get_guardrails_config.return_value = guardrail_cfg
@@ -685,12 +687,19 @@ class TestGuardianActivationGate:
         with contextlib.ExitStack() as stack:
             for p in self._base_patches(mock_config, mock_settings):
                 stack.enter_context(p)
-            stack.enter_context(patch("deepagents.create_deep_agent", return_value=mock_compiled))
+            stack.enter_context(
+                patch("deepagents.create_deep_agent", return_value=mock_compiled)
+            )
             mock_wrap = stack.enter_context(
-                patch("deep_agent.src.guardrails.tool_proxy.wrap_tools", return_value=[])
+                patch(
+                    "deep_agent.src.guardrails.tool_proxy.wrap_tools", return_value=[]
+                )
             )
             mock_safety_cls = stack.enter_context(
-                patch("deep_agent.aegra.safety.SafetyAwareRunnable", return_value=mock_safety)
+                patch(
+                    "deep_agent.aegra.safety.SafetyAwareRunnable",
+                    return_value=mock_safety,
+                )
             )
 
             from deep_agent.aegra.graph import agent
@@ -719,7 +728,9 @@ class TestGuardianActivationGate:
         with contextlib.ExitStack() as stack:
             for p in self._base_patches(mock_config, mock_settings):
                 stack.enter_context(p)
-            stack.enter_context(patch("deepagents.create_deep_agent", return_value=mock_compiled))
+            stack.enter_context(
+                patch("deepagents.create_deep_agent", return_value=mock_compiled)
+            )
             mock_wrap = stack.enter_context(
                 patch("deep_agent.src.guardrails.tool_proxy.wrap_tools")
             )
@@ -753,7 +764,9 @@ class TestGuardianActivationGate:
         with contextlib.ExitStack() as stack:
             for p in self._base_patches(mock_config, mock_settings):
                 stack.enter_context(p)
-            stack.enter_context(patch("deepagents.create_deep_agent", return_value=mock_compiled))
+            stack.enter_context(
+                patch("deepagents.create_deep_agent", return_value=mock_compiled)
+            )
             mock_wrap = stack.enter_context(
                 patch("deep_agent.src.guardrails.tool_proxy.wrap_tools")
             )

--- a/tests/unit/aegra/test_graph.py
+++ b/tests/unit/aegra/test_graph.py
@@ -600,3 +600,171 @@ class TestGraphCacheHit:
 
         assert result is mock_cached_graph
         mock_create.assert_not_called()
+
+
+class TestGuardianActivationGate:
+    """Guardian wrapping requires BOTH guardrail config.enabled AND GUARDIAN_API_BASE."""
+
+    def _build_mock_config(self, guardrails_enabled: bool) -> MagicMock:
+        mock_config = MagicMock()
+        mock_config.get_orchestrator_config.return_value = {
+            "name": "orchestrator",
+            "model": "gemini-2.5-flash",
+            "body": "test prompt",
+            "skill_paths": [],
+            "tools": [],
+        }
+        mock_config.resolve_tools.return_value = []
+        mock_config.resolve_agent_middleware.return_value = MagicMock(skills_enabled=True)
+        guardrail_cfg = MagicMock()
+        guardrail_cfg.enabled = guardrails_enabled
+        mock_config.get_guardrails_config.return_value = guardrail_cfg
+        return mock_config
+
+    def _base_patches(self, mock_config, mock_settings):
+        return [
+            patch("deep_agent.src.agent.config.agent_config", mock_config),
+            patch("deep_agent.src.settings.settings", mock_settings),
+            patch(
+                "deep_agent.src.infrastructure.providers.register_profiles_from_config",
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.src.agent.config.model.parse_model_config",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.src.cache.model_cache.get_or_create_model_from_spec",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.aegra.mcp.get_mcp_tools",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.load_subagents",
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.src.infrastructure.backend.get_configured_backend",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.async_tasks.build_async_middleware",
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.src.infrastructure.middleware.build_middleware_list",
+                return_value=[],
+            ),
+            patch(
+                "deep_agent.src.infrastructure.middleware.resolve_memory_param",
+                return_value=None,
+            ),
+            patch("deep_agent.aegra.graph._ensure_startup", new_callable=AsyncMock),
+            patch("deep_agent.src.pii.get_scrubber", return_value=None),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_guardian_active_when_config_enabled_and_api_base_set(self):
+        """Both guardrail.enabled=True and GUARDIAN_API_BASE set → wrap_tools + SafetyAwareRunnable."""
+        import contextlib
+
+        mock_compiled = MagicMock()
+        mock_safety = MagicMock()
+        mock_config = self._build_mock_config(guardrails_enabled=True)
+        mock_settings = MagicMock()
+        mock_settings.GUARDIAN_API_BASE = "http://guardian.internal"
+        mock_settings.LIFECYCLE_PERSISTENCE_ENABLED = False
+
+        mock_runtime = MagicMock()
+        mock_runtime.user = None
+        _reset_graph_state()
+
+        with contextlib.ExitStack() as stack:
+            for p in self._base_patches(mock_config, mock_settings):
+                stack.enter_context(p)
+            stack.enter_context(patch("deepagents.create_deep_agent", return_value=mock_compiled))
+            mock_wrap = stack.enter_context(
+                patch("deep_agent.src.guardrails.tool_proxy.wrap_tools", return_value=[])
+            )
+            mock_safety_cls = stack.enter_context(
+                patch("deep_agent.aegra.safety.SafetyAwareRunnable", return_value=mock_safety)
+            )
+
+            from deep_agent.aegra.graph import agent
+
+            result = await agent(mock_runtime)
+
+        mock_wrap.assert_called_once()
+        mock_safety_cls.assert_called_once_with(mock_compiled, outermost=True)
+        assert result is mock_safety
+
+    @pytest.mark.asyncio
+    async def test_guardian_inactive_when_config_disabled(self):
+        """guardrail.enabled=False + GUARDIAN_API_BASE set → no wrapping applied."""
+        import contextlib
+
+        mock_compiled = MagicMock()
+        mock_config = self._build_mock_config(guardrails_enabled=False)
+        mock_settings = MagicMock()
+        mock_settings.GUARDIAN_API_BASE = "http://guardian.internal"
+        mock_settings.LIFECYCLE_PERSISTENCE_ENABLED = False
+
+        mock_runtime = MagicMock()
+        mock_runtime.user = None
+        _reset_graph_state()
+
+        with contextlib.ExitStack() as stack:
+            for p in self._base_patches(mock_config, mock_settings):
+                stack.enter_context(p)
+            stack.enter_context(patch("deepagents.create_deep_agent", return_value=mock_compiled))
+            mock_wrap = stack.enter_context(
+                patch("deep_agent.src.guardrails.tool_proxy.wrap_tools")
+            )
+            mock_safety_cls = stack.enter_context(
+                patch("deep_agent.aegra.safety.SafetyAwareRunnable")
+            )
+
+            from deep_agent.aegra.graph import agent
+
+            result = await agent(mock_runtime)
+
+        mock_wrap.assert_not_called()
+        mock_safety_cls.assert_not_called()
+        assert result is mock_compiled
+
+    @pytest.mark.asyncio
+    async def test_guardian_inactive_when_api_base_absent(self):
+        """guardrail.enabled=True + no GUARDIAN_API_BASE → no wrapping applied."""
+        import contextlib
+
+        mock_compiled = MagicMock()
+        mock_config = self._build_mock_config(guardrails_enabled=True)
+        mock_settings = MagicMock()
+        mock_settings.GUARDIAN_API_BASE = ""
+        mock_settings.LIFECYCLE_PERSISTENCE_ENABLED = False
+
+        mock_runtime = MagicMock()
+        mock_runtime.user = None
+        _reset_graph_state()
+
+        with contextlib.ExitStack() as stack:
+            for p in self._base_patches(mock_config, mock_settings):
+                stack.enter_context(p)
+            stack.enter_context(patch("deepagents.create_deep_agent", return_value=mock_compiled))
+            mock_wrap = stack.enter_context(
+                patch("deep_agent.src.guardrails.tool_proxy.wrap_tools")
+            )
+            mock_safety_cls = stack.enter_context(
+                patch("deep_agent.aegra.safety.SafetyAwareRunnable")
+            )
+
+            from deep_agent.aegra.graph import agent
+
+            result = await agent(mock_runtime)
+
+        mock_wrap.assert_not_called()
+        mock_safety_cls.assert_not_called()
+        assert result is mock_compiled

--- a/tests/unit/aegra/test_graph.py
+++ b/tests/unit/aegra/test_graph.py
@@ -687,7 +687,7 @@ class TestGuardianActivationGate:
         with contextlib.ExitStack() as stack:
             for p in self._base_patches(mock_config, mock_settings):
                 stack.enter_context(p)
-            stack.enter_context(
+            mock_create = stack.enter_context(
                 patch("deepagents.create_deep_agent", return_value=mock_compiled)
             )
             mock_wrap = stack.enter_context(
@@ -709,6 +709,8 @@ class TestGuardianActivationGate:
         mock_wrap.assert_called_once()
         mock_safety_cls.assert_called_once_with(mock_compiled, outermost=True)
         assert result is mock_safety
+        system_prompt_used = mock_create.call_args.kwargs["system_prompt"]
+        assert "STOP ALL WORK" in system_prompt_used
 
     @pytest.mark.asyncio
     async def test_guardian_inactive_when_config_disabled(self):
@@ -728,7 +730,7 @@ class TestGuardianActivationGate:
         with contextlib.ExitStack() as stack:
             for p in self._base_patches(mock_config, mock_settings):
                 stack.enter_context(p)
-            stack.enter_context(
+            mock_create = stack.enter_context(
                 patch("deepagents.create_deep_agent", return_value=mock_compiled)
             )
             mock_wrap = stack.enter_context(
@@ -745,6 +747,8 @@ class TestGuardianActivationGate:
         mock_wrap.assert_not_called()
         mock_safety_cls.assert_not_called()
         assert result is mock_compiled
+        system_prompt_used = mock_create.call_args.kwargs["system_prompt"]
+        assert "STOP ALL WORK" not in system_prompt_used
 
     @pytest.mark.asyncio
     async def test_guardian_inactive_when_api_base_absent(self):
@@ -764,7 +768,7 @@ class TestGuardianActivationGate:
         with contextlib.ExitStack() as stack:
             for p in self._base_patches(mock_config, mock_settings):
                 stack.enter_context(p)
-            stack.enter_context(
+            mock_create = stack.enter_context(
                 patch("deepagents.create_deep_agent", return_value=mock_compiled)
             )
             mock_wrap = stack.enter_context(
@@ -781,3 +785,5 @@ class TestGuardianActivationGate:
         mock_wrap.assert_not_called()
         mock_safety_cls.assert_not_called()
         assert result is mock_compiled
+        system_prompt_used = mock_create.call_args.kwargs["system_prompt"]
+        assert "STOP ALL WORK" not in system_prompt_used

--- a/tests/unit/infrastructure/test_subagents.py
+++ b/tests/unit/infrastructure/test_subagents.py
@@ -932,6 +932,10 @@ class TestGuardianActivationGate:
                 "deep_agent.src.infrastructure.subagents.build_audit_middleware",
                 return_value=None,
             ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.build_opa_middleware",
+                return_value=None,
+            ),
             patch("deep_agent.src.settings.settings", mock_settings),
             patch(
                 "deep_agent.src.guardrails.tool_proxy.wrap_tools",
@@ -940,11 +944,12 @@ class TestGuardianActivationGate:
             patch(
                 "deep_agent.src.infrastructure.subagents.SubAgent",
                 return_value=MagicMock(),
-            ),
+            ) as mock_sa_cls,
         ):
             load_subagents(tools=[mock_tool])
 
         mock_wrap.assert_called_once_with([mock_tool])
+        assert mock_sa_cls.call_args.kwargs["tools"] == [mock_tool]
 
     def test_default_subagent_skips_wrapping_when_config_disabled(self):
         """enabled=False + GUARDIAN_API_BASE set → wrap_tools not called."""
@@ -982,6 +987,10 @@ class TestGuardianActivationGate:
             ),
             patch(
                 "deep_agent.src.infrastructure.subagents.build_audit_middleware",
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.build_opa_middleware",
                 return_value=None,
             ),
             patch("deep_agent.src.settings.settings", mock_settings),
@@ -1031,6 +1040,10 @@ class TestGuardianActivationGate:
             ),
             patch(
                 "deep_agent.src.infrastructure.subagents.build_audit_middleware",
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.build_opa_middleware",
                 return_value=None,
             ),
             patch("deep_agent.src.settings.settings", mock_settings),
@@ -1085,6 +1098,14 @@ class TestGuardianActivationGate:
             patch(
                 "deep_agent.src.infrastructure.subagents.CompiledSubAgent",
                 return_value=MagicMock(),
+            ) as mock_compiled_sa_cls,
+            patch(
+                "deep_agent.src.infrastructure.subagents.build_audit_middleware",
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.build_opa_middleware",
+                return_value=None,
             ),
             patch("deep_agent.src.settings.settings", mock_settings),
             patch("deep_agent.src.pii.get_scrubber", return_value=None),
@@ -1099,6 +1120,7 @@ class TestGuardianActivationGate:
 
         mock_wrap.assert_called_once()
         mock_safety_cls.assert_called_once_with(mock_graph)
+        assert mock_compiled_sa_cls.call_args.kwargs["runnable"] is mock_safety
 
     def test_compiled_subagent_skips_guardian_when_config_disabled(self):
         """enabled=False + GUARDIAN_API_BASE set → no wrap_tools or SafetyAwareRunnable."""
@@ -1138,6 +1160,14 @@ class TestGuardianActivationGate:
             patch(
                 "deep_agent.src.infrastructure.subagents.CompiledSubAgent",
                 return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.build_audit_middleware",
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.build_opa_middleware",
+                return_value=None,
             ),
             patch("deep_agent.src.settings.settings", mock_settings),
             patch("deep_agent.src.pii.get_scrubber", return_value=None),
@@ -1187,6 +1217,14 @@ class TestGuardianActivationGate:
             patch(
                 "deep_agent.src.infrastructure.subagents.CompiledSubAgent",
                 return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.build_audit_middleware",
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.build_opa_middleware",
+                return_value=None,
             ),
             patch("deep_agent.src.settings.settings", mock_settings),
             patch("deep_agent.src.pii.get_scrubber", return_value=None),

--- a/tests/unit/infrastructure/test_subagents.py
+++ b/tests/unit/infrastructure/test_subagents.py
@@ -882,3 +882,318 @@ class TestBuildFallbackMiddleware:
         with patch.dict(sys.modules, {"langchain.agents.middleware": None}):
             result = _build_fallback_middleware(spec)
         assert result == []
+
+
+class TestGuardianActivationGate:
+    """Guardian wrapping requires BOTH guardrail config.enabled AND GUARDIAN_API_BASE."""
+
+    def _guardrail_cfg(self, enabled: bool) -> MagicMock:
+        cfg = MagicMock()
+        cfg.enabled = enabled
+        return cfg
+
+    # ── default subagent ────────────────────────────────────────────────────
+
+    def test_default_subagent_wraps_tools_when_guardian_active(self):
+        """Both enabled=True and GUARDIAN_API_BASE set → wrap_tools called."""
+        mock_tool = MagicMock()
+        mock_settings = MagicMock()
+        mock_settings.GUARDIAN_API_BASE = "http://guardian.internal"
+
+        with (
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_all_subagent_configs",
+                return_value={
+                    "analyst": {
+                        "model": "gemini-2.5-flash",
+                        "description": "A",
+                        "body": "P",
+                        "tools": ["t"],
+                    }
+                },
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_orchestrator_config",
+                return_value={},
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_guardrails_config",
+                return_value=self._guardrail_cfg(enabled=True),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.resolve_tools",
+                return_value=[mock_tool],
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.get_or_create_model_from_spec",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.build_audit_middleware",
+                return_value=None,
+            ),
+            patch("deep_agent.src.settings.settings", mock_settings),
+            patch(
+                "deep_agent.src.guardrails.tool_proxy.wrap_tools",
+                return_value=[mock_tool],
+            ) as mock_wrap,
+            patch(
+                "deep_agent.src.infrastructure.subagents.SubAgent",
+                return_value=MagicMock(),
+            ),
+        ):
+            load_subagents(tools=[mock_tool])
+
+        mock_wrap.assert_called_once_with([mock_tool])
+
+    def test_default_subagent_skips_wrapping_when_config_disabled(self):
+        """enabled=False + GUARDIAN_API_BASE set → wrap_tools not called."""
+        mock_tool = MagicMock()
+        mock_settings = MagicMock()
+        mock_settings.GUARDIAN_API_BASE = "http://guardian.internal"
+
+        with (
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_all_subagent_configs",
+                return_value={
+                    "analyst": {
+                        "model": "gemini-2.5-flash",
+                        "description": "A",
+                        "body": "P",
+                        "tools": ["t"],
+                    }
+                },
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_orchestrator_config",
+                return_value={},
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_guardrails_config",
+                return_value=self._guardrail_cfg(enabled=False),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.resolve_tools",
+                return_value=[mock_tool],
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.get_or_create_model_from_spec",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.build_audit_middleware",
+                return_value=None,
+            ),
+            patch("deep_agent.src.settings.settings", mock_settings),
+            patch("deep_agent.src.guardrails.tool_proxy.wrap_tools") as mock_wrap,
+            patch(
+                "deep_agent.src.infrastructure.subagents.SubAgent",
+                return_value=MagicMock(),
+            ),
+        ):
+            load_subagents(tools=[mock_tool])
+
+        mock_wrap.assert_not_called()
+
+    def test_default_subagent_skips_wrapping_when_api_base_absent(self):
+        """enabled=True + no GUARDIAN_API_BASE → wrap_tools not called."""
+        mock_tool = MagicMock()
+        mock_settings = MagicMock()
+        mock_settings.GUARDIAN_API_BASE = ""
+
+        with (
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_all_subagent_configs",
+                return_value={
+                    "analyst": {
+                        "model": "gemini-2.5-flash",
+                        "description": "A",
+                        "body": "P",
+                        "tools": ["t"],
+                    }
+                },
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_orchestrator_config",
+                return_value={},
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_guardrails_config",
+                return_value=self._guardrail_cfg(enabled=True),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.resolve_tools",
+                return_value=[mock_tool],
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.get_or_create_model_from_spec",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.build_audit_middleware",
+                return_value=None,
+            ),
+            patch("deep_agent.src.settings.settings", mock_settings),
+            patch("deep_agent.src.guardrails.tool_proxy.wrap_tools") as mock_wrap,
+            patch(
+                "deep_agent.src.infrastructure.subagents.SubAgent",
+                return_value=MagicMock(),
+            ),
+        ):
+            load_subagents(tools=[mock_tool])
+
+        mock_wrap.assert_not_called()
+
+    # ── compiled subagent ────────────────────────────────────────────────────
+
+    def test_compiled_subagent_wraps_and_applies_safety_when_guardian_active(self):
+        """Both enabled=True and GUARDIAN_API_BASE set → wrap_tools + SafetyAwareRunnable."""
+        mock_graph = MagicMock()
+        mock_safety = MagicMock()
+        mock_settings = MagicMock()
+        mock_settings.GUARDIAN_API_BASE = "http://guardian.internal"
+
+        with (
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_all_subagent_configs",
+                return_value={
+                    "analyst": {
+                        "type": "compiled",
+                        "model": "gemini-2.5-pro",
+                        "description": "A",
+                        "body": "P",
+                    }
+                },
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_orchestrator_config",
+                return_value={},
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_guardrails_config",
+                return_value=self._guardrail_cfg(enabled=True),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.get_or_create_model_from_spec",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.backend.get_configured_backend",
+                return_value=MagicMock(),
+            ),
+            patch("deepagents.create_deep_agent", return_value=mock_graph),
+            patch(
+                "deep_agent.src.infrastructure.subagents.CompiledSubAgent",
+                return_value=MagicMock(),
+            ),
+            patch("deep_agent.src.settings.settings", mock_settings),
+            patch("deep_agent.src.pii.get_scrubber", return_value=None),
+            patch(
+                "deep_agent.src.guardrails.tool_proxy.wrap_tools", return_value=[]
+            ) as mock_wrap,
+            patch(
+                "deep_agent.aegra.safety.SafetyAwareRunnable", return_value=mock_safety
+            ) as mock_safety_cls,
+        ):
+            load_subagents(tools=[])
+
+        mock_wrap.assert_called_once()
+        mock_safety_cls.assert_called_once_with(mock_graph)
+
+    def test_compiled_subagent_skips_guardian_when_config_disabled(self):
+        """enabled=False + GUARDIAN_API_BASE set → no wrap_tools or SafetyAwareRunnable."""
+        mock_graph = MagicMock()
+        mock_settings = MagicMock()
+        mock_settings.GUARDIAN_API_BASE = "http://guardian.internal"
+
+        with (
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_all_subagent_configs",
+                return_value={
+                    "analyst": {
+                        "type": "compiled",
+                        "model": "gemini-2.5-pro",
+                        "description": "A",
+                        "body": "P",
+                    }
+                },
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_orchestrator_config",
+                return_value={},
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_guardrails_config",
+                return_value=self._guardrail_cfg(enabled=False),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.get_or_create_model_from_spec",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.backend.get_configured_backend",
+                return_value=MagicMock(),
+            ),
+            patch("deepagents.create_deep_agent", return_value=mock_graph),
+            patch(
+                "deep_agent.src.infrastructure.subagents.CompiledSubAgent",
+                return_value=MagicMock(),
+            ),
+            patch("deep_agent.src.settings.settings", mock_settings),
+            patch("deep_agent.src.pii.get_scrubber", return_value=None),
+            patch("deep_agent.src.guardrails.tool_proxy.wrap_tools") as mock_wrap,
+            patch("deep_agent.aegra.safety.SafetyAwareRunnable") as mock_safety_cls,
+        ):
+            load_subagents(tools=[])
+
+        mock_wrap.assert_not_called()
+        mock_safety_cls.assert_not_called()
+
+    def test_compiled_subagent_skips_guardian_when_api_base_absent(self):
+        """enabled=True + no GUARDIAN_API_BASE → no wrap_tools or SafetyAwareRunnable."""
+        mock_graph = MagicMock()
+        mock_settings = MagicMock()
+        mock_settings.GUARDIAN_API_BASE = ""
+
+        with (
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_all_subagent_configs",
+                return_value={
+                    "analyst": {
+                        "type": "compiled",
+                        "model": "gemini-2.5-pro",
+                        "description": "A",
+                        "body": "P",
+                    }
+                },
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_orchestrator_config",
+                return_value={},
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_guardrails_config",
+                return_value=self._guardrail_cfg(enabled=True),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.get_or_create_model_from_spec",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.backend.get_configured_backend",
+                return_value=MagicMock(),
+            ),
+            patch("deepagents.create_deep_agent", return_value=mock_graph),
+            patch(
+                "deep_agent.src.infrastructure.subagents.CompiledSubAgent",
+                return_value=MagicMock(),
+            ),
+            patch("deep_agent.src.settings.settings", mock_settings),
+            patch("deep_agent.src.pii.get_scrubber", return_value=None),
+            patch("deep_agent.src.guardrails.tool_proxy.wrap_tools") as mock_wrap,
+            patch("deep_agent.aegra.safety.SafetyAwareRunnable") as mock_safety_cls,
+        ):
+            load_subagents(tools=[])
+
+        mock_wrap.assert_not_called()
+        mock_safety_cls.assert_not_called()


### PR DESCRIPTION
## What

Guardian tool wrapping in graph.py was tied to the env var alone. Gate it on guardrail_cfg.enabled and GUARDIAN_API_BASE so guardrails stay off unless both the config flag and the Guardian endpoint are present.

Fixes #

## How

Gate it on guardrail_cfg.enabled and GUARDIAN_API_BASE

## Testing

<!-- How did you verify this works? -->

- [x] Unit tests added/updated
- [x] Ran locally (`uv run pytest tests/unit -x`)
- [x] Manual verification (describe below if applicable)

## Rollback

Revert the commit

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `ci:`, etc.)
- [x] No secrets, credentials, or PII in the diff
- [x] No breaking changes (or documented above with a migration path)
- [x] Pre-commit hooks pass (`uv run pre-commit run --all-files`)
