### PR TITLE
fix: trigger MCP re-auth when OAuth token refresh fails. Closes #277

### DIFF
--- a/deep_agent/aegra/mcp.py
+++ b/deep_agent/aegra/mcp.py
@@ -354,9 +354,10 @@ def _create_auth_placeholder_tool(
     """Create a stub tool that triggers NeedsAuthorization when called.
 
     When an MCP server requires OAuth/DCR but the user hasn't authenticated yet,
-    we inject this placeholder. When the LLM calls it, NeedsAuthorization fires,
-    which mcp_tool_auth wraps into a LangGraph interrupt, and the UI shows the
-    connect button.
+    we inject this placeholder. When the LLM calls it, the stub tries to resolve
+    a token (including refresh). Failed refresh raises NeedsAuthorization, which
+    mcp_tool_auth wraps into a LangGraph interrupt so the UI shows the connect
+    button.
     """
     from langchain_core.tools import StructuredTool
     from pydantic import BaseModel
@@ -379,12 +380,17 @@ def _create_auth_placeholder_tool(
             resolver = get_mcp_credential_resolver()
             cfg = _get_server_configs().get(mcp_name, {})
             try:
-                if await resolver.has_valid_token(user_id, mcp_name, cfg):
-                    return (
-                        f"Successfully connected to {mcp_name}. "
-                        f"The tools are now available — please ask the user to "
-                        f"repeat their request so the updated tools can be loaded."
-                    )
+                # Resolve (and refresh if needed) instead of has_valid_token().
+                # A leftover refresh token must not skip re-auth after refresh fails.
+                await resolver.resolve(user_id, mcp_name, cfg)
+                invalidate_mcp_tool_cache(user_id)
+                return (
+                    f"Successfully connected to {mcp_name}. "
+                    f"The tools are now available — please ask the user to "
+                    f"repeat their request so the updated tools can be loaded."
+                )
+            except NeedsAuthorization:
+                raise
             except Exception:
                 pass
 

--- a/tests/unit/infrastructure/test_mcp.py
+++ b/tests/unit/infrastructure/test_mcp.py
@@ -765,13 +765,13 @@ class TestCreateAuthPlaceholderTool:
             assert exc_info.value.mcp_name == "jira-mcp"
 
     @pytest.mark.asyncio
-    async def test_require_auth_returns_success_when_token_valid(self):
-        """Calling the placeholder with a valid token returns success message."""
+    async def test_require_auth_returns_success_when_resolve_succeeds(self):
+        """Calling the placeholder after a usable token is resolved returns success."""
         tool = _create_auth_placeholder_tool(
             "jira-mcp", {"description": "JIRA services"}
         )
         mock_resolver = MagicMock()
-        mock_resolver.has_valid_token = AsyncMock(return_value=True)
+        mock_resolver.resolve = AsyncMock(return_value="fresh-access-token")
         with (
             patch("deep_agent.aegra.mcp._current_user_id") as mock_ctx,
             patch(
@@ -786,17 +786,57 @@ class TestCreateAuthPlaceholderTool:
             mock_ctx.get.return_value = "user-1"
             result = await tool.coroutine(query="list my tickets")
         assert "Successfully connected to jira-mcp" in result
+        mock_resolver.resolve.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_require_auth_raises_when_token_invalid(self):
-        """Calling the placeholder with no valid token raises NeedsAuthorization."""
+    async def test_require_auth_raises_when_refresh_failed(self):
+        """A leftover refresh token must not skip re-auth after refresh fails."""
         from deep_agent.aegra.mcp_auth import NeedsAuthorization
 
         tool = _create_auth_placeholder_tool(
             "jira-mcp", {"description": "JIRA services"}
         )
         mock_resolver = MagicMock()
-        mock_resolver.has_valid_token = AsyncMock(return_value=False)
+        # has_valid_token is True whenever a refresh token remains in Redis —
+        # that must not hide a failed refresh from the UI.
+        mock_resolver.has_valid_token = AsyncMock(return_value=True)
+        mock_resolver.resolve = AsyncMock(
+            side_effect=NeedsAuthorization(
+                "jira-mcp", "http://localhost/mcp/jira-mcp/connect"
+            )
+        )
+        mock_resolver.connect_url.return_value = "http://localhost/mcp/jira-mcp/connect"
+        with (
+            patch("deep_agent.aegra.mcp._current_user_id") as mock_ctx,
+            patch(
+                "deep_agent.aegra.mcp._get_server_configs",
+                return_value={"jira-mcp": {"auth_mode": "oauth"}},
+            ),
+            patch(
+                "deep_agent.aegra.mcp_auth.get_mcp_credential_resolver",
+                return_value=mock_resolver,
+            ),
+        ):
+            mock_ctx.get.return_value = "user-1"
+            with pytest.raises(NeedsAuthorization) as exc_info:
+                await tool.coroutine(query="list my tickets")
+        assert exc_info.value.mcp_name == "jira-mcp"
+        mock_resolver.resolve.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_require_auth_raises_when_token_invalid(self):
+        """Calling the placeholder with no usable token raises NeedsAuthorization."""
+        from deep_agent.aegra.mcp_auth import NeedsAuthorization
+
+        tool = _create_auth_placeholder_tool(
+            "jira-mcp", {"description": "JIRA services"}
+        )
+        mock_resolver = MagicMock()
+        mock_resolver.resolve = AsyncMock(
+            side_effect=NeedsAuthorization(
+                "jira-mcp", "http://localhost/mcp/jira-mcp/connect"
+            )
+        )
         mock_resolver.connect_url.return_value = "http://localhost/mcp/jira-mcp/connect"
         with (
             patch("deep_agent.aegra.mcp._current_user_id") as mock_ctx,

--- a/tests/unit/infrastructure/test_mcp.py
+++ b/tests/unit/infrastructure/test_mcp.py
@@ -821,6 +821,7 @@ class TestCreateAuthPlaceholderTool:
             with pytest.raises(NeedsAuthorization) as exc_info:
                 await tool.coroutine(query="list my tickets")
         assert exc_info.value.mcp_name == "jira-mcp"
+        assert exc_info.value.connect_url == "http://localhost/mcp/jira-mcp/connect"
         mock_resolver.resolve.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -850,5 +851,6 @@ class TestCreateAuthPlaceholderTool:
             ),
         ):
             mock_ctx.get.return_value = "user-1"
-            with pytest.raises(NeedsAuthorization):
+            with pytest.raises(NeedsAuthorization) as exc_info:
                 await tool.coroutine(query="list my tickets")
+        assert exc_info.value.connect_url == "http://localhost/mcp/jira-mcp/connect"


### PR DESCRIPTION
The auth placeholder treated a leftover refresh token as connected, so a failed refresh never raised NeedsAuthorization and the UI skipped reconnect.

What
Failed MCP OAuth refresh no longer looks like a successful connection. The auth placeholder now raises NeedsAuthorization so the UI can send the user through re-auth.

Fixes #

How
The placeholder used has_valid_token(), which is true whenever a refresh token remains in Redis. After Slack refresh failed (returned no access_token), that leftover refresh token made the stub return “Successfully connected…” and skip the interrupt.

The placeholder now calls resolve(), which refreshes if needed. Failed refresh raises NeedsAuthorization (mcp_auth_required). Successful resolve still asks the user to retry and clears the per-user MCP tool cache so the next turn loads real tools.

Alternative considered: deleting Redis tokens on refresh failure. That would also force re-auth, but would wipe tokens on a transient token-endpoint error. resolve() keeps refresh-on-retry and only interrupts when refresh actually fails.

Testing
Unit tests added/updated
Ran locally (uv run pytest tests/unit -x) — TestCreateAuthPlaceholderTool and test_mcp_auth.py (27 passed)
Manual verification: with access token removed and refresh token kept, Slack refresh failed and the UI did not show re-auth (old path). After this change, failed refresh raises NeedsAuthorization. Clearing both tokens still requires connect.
Rollback
Revert the commit.

Checklist
PR title follows Conventional Commits (fix:)
No secrets, credentials, or PII in the diff
No breaking changes
Pre-commit hooks pass (uv run pre-commit run --all-files)

Closes #277
