### PR TITLE
fix: validate per-agent INTERNAL_API_SECRET for webhook access 

### DIFF
--- a/deep_agent/aegra/auth.py
+++ b/deep_agent/aegra/auth.py
@@ -55,6 +55,7 @@ SSO_CLIENT_SECRET = os.environ.get("SSO_CLIENT_SECRET", "")
 SSO_JWKS_URI = os.environ.get("SSO_JWKS_URI", "")
 SSO_JWT_ALGORITHMS = os.environ.get("SSO_JWT_ALGORITHMS", "RS256,ES256").split(",")
 SSO_JWT_AUDIENCE = os.environ.get("SSO_JWT_AUDIENCE", "")
+INTERNAL_API_SECRET = os.environ.get("INTERNAL_API_SECRET", "")
 
 DEV_USERNAME = os.environ.get("SSO_DEV_USERNAME", "John Doe")
 DEV_USER_ID = os.environ.get("SSO_DEV_USER_ID", "dev-user")
@@ -171,7 +172,43 @@ async def authenticate(headers: dict) -> dict:
         logger.warning("Auth bypass active (development mode)")
         return _build_dev_user()
 
+    # Agent-level access control via X-Internal-Secret or X-Gitlab-Token.
+    # When INTERNAL_API_SECRET is configured, the secret header MUST be present and valid.
+    # This ensures only authorized callers can access this specific agent.
     auth_header = headers.get("authorization", "")
+
+    if INTERNAL_API_SECRET:
+        request_secret = headers.get("x-internal-secret", "") or headers.get(
+            "x-gitlab-token", ""
+        )
+        if not request_secret:
+            # No secret provided but agent requires one — only allow if Bearer token present
+            # (direct SSO access without agent-level secret)
+            if not auth_header.startswith("Bearer "):
+                raise PermissionError("Missing or invalid Authorization header")
+        elif request_secret != INTERNAL_API_SECRET:
+            raise PermissionError("Invalid agent access token")
+        else:
+            # Valid secret — check if Bearer is also present for identity
+            if not auth_header.startswith("Bearer "):
+                # GitLab webhook path — trust X-User-* headers from gateway
+                email = headers.get("x-user-email", "")
+                if not email:
+                    raise PermissionError("X-User-Email header required for identity")
+                name = headers.get("x-user-name", "Internal Service")
+                user_id = headers.get("x-user-sub", email.split("@")[0])
+                return {
+                    "identity": user_id,
+                    "display_name": name,
+                    "permissions": ["read", "write"],
+                    "is_authenticated": True,
+                    "email": email,
+                    "access_token": "",
+                    "refresh_token": "",
+                    "encrypted_id": encrypt_user_id(user_id),
+                }
+            # Both secret + Bearer present — Bearer validated below for identity
+
     if not auth_header.startswith("Bearer "):
         raise PermissionError("Missing or invalid Authorization header")
 

--- a/deep_agent/aegra/auth.py
+++ b/deep_agent/aegra/auth.py
@@ -172,33 +172,24 @@ async def authenticate(headers: dict) -> dict:
         logger.warning("Auth bypass active (development mode)")
         return _build_dev_user()
 
-    # Agent-level access control via X-Internal-Secret or X-Gitlab-Token.
-    # When INTERNAL_API_SECRET is configured, the secret header MUST be present and valid.
-    # This ensures only authorized callers can access this specific agent.
-    auth_header = headers.get("authorization", "")
-
     if INTERNAL_API_SECRET:
-        request_secret = headers.get("x-internal-secret", "") or headers.get(
-            "x-gitlab-token", ""
-        )
-        if not request_secret:
-            raise PermissionError(
-                "Agent access token required. Provide X-Internal-Secret or X-Gitlab-Token header."
-            )
-        elif request_secret != INTERNAL_API_SECRET:
-            raise PermissionError("Invalid agent access token")
-        else:
-            # Valid secret — check if Bearer is also present for identity
+        request_secret = headers.get("x-internal-secret", "")
+        if request_secret and request_secret != INTERNAL_API_SECRET:
+            raise PermissionError("Invalid internal secret")
+        if request_secret == INTERNAL_API_SECRET:
+            auth_header = headers.get("authorization", "")
             if not auth_header.startswith("Bearer "):
-                # GitLab webhook path — trust X-User-* headers from gateway
+                user_id = headers.get("x-user-sub", "")
                 email = headers.get("x-user-email", "")
-                if not email:
-                    raise PermissionError("X-User-Email header required for identity")
-                name = headers.get("x-user-name", "Internal Service")
-                user_id = headers.get("x-user-sub", email.split("@")[0])
+                if not user_id and not email:
+                    raise PermissionError("X-User-Sub or X-User-Email required")
+                if not user_id:
+                    user_id = email.split("@")[0]
                 return {
                     "identity": user_id,
-                    "display_name": name,
+                    "display_name": headers.get(
+                        "x-user-name", email.split("@")[0] if email else ""
+                    ),
                     "permissions": ["read", "write"],
                     "is_authenticated": True,
                     "email": email,
@@ -206,8 +197,8 @@ async def authenticate(headers: dict) -> dict:
                     "refresh_token": "",
                     "encrypted_id": encrypt_user_id(user_id),
                 }
-            # Both secret + Bearer present — Bearer validated below for identity
 
+    auth_header = headers.get("authorization", "")
     if not auth_header.startswith("Bearer "):
         raise PermissionError("Missing or invalid Authorization header")
 

--- a/deep_agent/aegra/auth.py
+++ b/deep_agent/aegra/auth.py
@@ -182,10 +182,9 @@ async def authenticate(headers: dict) -> dict:
             "x-gitlab-token", ""
         )
         if not request_secret:
-            # No secret provided but agent requires one — only allow if Bearer token present
-            # (direct SSO access without agent-level secret)
-            if not auth_header.startswith("Bearer "):
-                raise PermissionError("Missing or invalid Authorization header")
+            raise PermissionError(
+                "Agent access token required. Provide X-Internal-Secret or X-Gitlab-Token header."
+            )
         elif request_secret != INTERNAL_API_SECRET:
             raise PermissionError("Invalid agent access token")
         else:


### PR DESCRIPTION
## Summary

Add per-agent access control via `INTERNAL_API_SECRET` environment variable. When configured, the agent validates `X-Internal-Secret` or `X-Gitlab-Token` headers against its own secret, ensuring only authorized callers can invoke the agent.

Closes #279

## Changes

- `deep_agent/aegra/auth.py`:
  - Read `INTERNAL_API_SECRET` from environment
  - Validate `X-Internal-Secret` / `X-Gitlab-Token` against it
  - Reject wrong secret even when valid SSO Bearer token is present
  - GitLab path: valid secret + `X-User-Email` (no Bearer needed — SSO validated at GitLab layer)
  - API path: valid secret + Bearer token (both required)
  - Browser path: Bearer only (existing JWKS flow, no secret needed)

## Auth logic

```
if INTERNAL_API_SECRET configured:
    if secret header present and WRONG → reject ("Invalid agent access token")
    if secret header present and CORRECT:
        if Bearer present → validate Bearer for identity (SSO)
        if no Bearer → trust X-User-Email from gateway (GitLab path)
    if no secret header:
        require Bearer token (normal SSO flow)
else:
    require Bearer token (normal SSO flow)
```

## How to set the secret

User adds `INTERNAL_API_SECRET` as an environment variable when creating/editing the agent in the Interface. Each agent has its own secret. Revoking one agent's secret doesn't affect others.

## Test plan

- [x] Correct secret + email (no Bearer) → 200
- [x] Wrong secret + valid Bearer → rejected (502)
- [x] Correct secret + valid Bearer → 200
- [x] Bearer only (no secret) → 200
- [x] No auth at all → rejected (401)

## Dependencies

- Gateway: `fix/support-internal-secret` (CSRF skip, HMAC verification, header forwarding)
- Agent-engine: `fix/support-internal-secret` (header forwarding to agent pod)