### PR TITLE
fix: propagate mcp error logs

### DIFF
--- a/deep_agent/aegra/mcp_tool_auth.py
+++ b/deep_agent/aegra/mcp_tool_auth.py
@@ -87,6 +87,7 @@ def _make_safe_ainvoke(target_tool: Any) -> Any:
     async def safe_ainvoke(tool_input: Any, config: Any = None, **kwargs: Any) -> Any:
         """Wrap ainvoke to catch auth interrupts and MCP errors."""
         from langchain_core.messages import ToolMessage
+        from langgraph.errors import GraphBubbleUp
 
         try:
             return await original_ainvoke(tool_input, config, **kwargs)
@@ -97,6 +98,8 @@ def _make_safe_ainvoke(target_tool: Any) -> Any:
             )
             interrupt(_mcp_auth_interrupt_payload(exc))
             return await original_ainvoke(tool_input, config, **kwargs)
+        except GraphBubbleUp:
+            raise
         except Exception as exc:
             tool_name = getattr(target_tool, "name", "unknown")
             tool_call_id = ""

--- a/deep_agent/aegra/mcp_tool_auth.py
+++ b/deep_agent/aegra/mcp_tool_auth.py
@@ -81,8 +81,37 @@ def wrap_mcp_tools_for_auth(tools: list[Any]) -> list[Any]:
 
 
 def _wrap_single_tool(tool: Any) -> Any:
+    original_ainvoke = tool.ainvoke
     coroutine = getattr(tool, "coroutine", None)
     func = getattr(tool, "func", None)
+
+    async def safe_ainvoke(input: Any, config: Any = None, **kwargs: Any) -> Any:
+        """Wrap ainvoke to catch auth interrupts and MCP errors."""
+        from langchain_core.messages import ToolMessage
+
+        try:
+            return await original_ainvoke(input, config, **kwargs)
+        except NeedsAuthorization as exc:
+            logger.info(
+                "MCP auth required for '%s' — interrupting run",
+                exc.mcp_name,
+            )
+            interrupt(_mcp_auth_interrupt_payload(exc))
+            return await original_ainvoke(input, config, **kwargs)
+        except Exception as exc:
+            tool_name = getattr(tool, "name", "unknown")
+            tool_call_id = ""
+            if isinstance(input, dict):
+                tool_call_id = str(input.get("id", ""))
+            logger.warning("MCP tool '%s' failed: %s", tool_name, exc)
+            return ToolMessage(
+                content=f"[TOOL_ERROR] {tool_name} failed: {exc}",
+                name=tool_name,
+                tool_call_id=tool_call_id,
+                status="error",
+            )
+
+    object.__setattr__(tool, "ainvoke", safe_ainvoke)
 
     if inspect.iscoroutinefunction(coroutine):
 

--- a/deep_agent/aegra/mcp_tool_auth.py
+++ b/deep_agent/aegra/mcp_tool_auth.py
@@ -80,29 +80,28 @@ def wrap_mcp_tools_for_auth(tools: list[Any]) -> list[Any]:
     return wrapped
 
 
-def _wrap_single_tool(tool: Any) -> Any:
-    original_ainvoke = tool.ainvoke
-    coroutine = getattr(tool, "coroutine", None)
-    func = getattr(tool, "func", None)
+def _make_safe_ainvoke(target_tool: Any) -> Any:
+    """Build an ainvoke wrapper that catches MCP errors for *target_tool*."""
+    original_ainvoke = target_tool.ainvoke
 
-    async def safe_ainvoke(input: Any, config: Any = None, **kwargs: Any) -> Any:
+    async def safe_ainvoke(tool_input: Any, config: Any = None, **kwargs: Any) -> Any:
         """Wrap ainvoke to catch auth interrupts and MCP errors."""
         from langchain_core.messages import ToolMessage
 
         try:
-            return await original_ainvoke(input, config, **kwargs)
+            return await original_ainvoke(tool_input, config, **kwargs)
         except NeedsAuthorization as exc:
             logger.info(
                 "MCP auth required for '%s' — interrupting run",
                 exc.mcp_name,
             )
             interrupt(_mcp_auth_interrupt_payload(exc))
-            return await original_ainvoke(input, config, **kwargs)
+            return await original_ainvoke(tool_input, config, **kwargs)
         except Exception as exc:
-            tool_name = getattr(tool, "name", "unknown")
+            tool_name = getattr(target_tool, "name", "unknown")
             tool_call_id = ""
-            if isinstance(input, dict):
-                tool_call_id = str(input.get("id", ""))
+            if isinstance(tool_input, dict):
+                tool_call_id = str(tool_input.get("id", ""))
             logger.warning("MCP tool '%s' failed: %s", tool_name, exc)
             return ToolMessage(
                 content=f"[TOOL_ERROR] {tool_name} failed: {exc}",
@@ -111,7 +110,12 @@ def _wrap_single_tool(tool: Any) -> Any:
                 status="error",
             )
 
-    object.__setattr__(tool, "ainvoke", safe_ainvoke)
+    return safe_ainvoke
+
+
+def _wrap_single_tool(tool: Any) -> Any:
+    coroutine = getattr(tool, "coroutine", None)
+    func = getattr(tool, "func", None)
 
     if inspect.iscoroutinefunction(coroutine):
 
@@ -128,10 +132,12 @@ def _wrap_single_tool(tool: Any) -> Any:
                     interrupt(_mcp_auth_interrupt_payload(exc))
 
         try:
-            return tool.model_copy(update={"coroutine": wrapped_coroutine})
+            wrapped = tool.model_copy(update={"coroutine": wrapped_coroutine})
         except Exception:
             tool.coroutine = wrapped_coroutine
-            return tool
+            wrapped = tool
+        object.__setattr__(wrapped, "ainvoke", _make_safe_ainvoke(wrapped))
+        return wrapped
 
     if func is not None and inspect.isfunction(func):
 
@@ -144,9 +150,12 @@ def _wrap_single_tool(tool: Any) -> Any:
                     interrupt(_mcp_auth_interrupt_payload(exc))
 
         try:
-            return tool.model_copy(update={"func": wrapped_func})
+            wrapped = tool.model_copy(update={"func": wrapped_func})
         except Exception:
             tool.func = wrapped_func
-            return tool
+            wrapped = tool
+        object.__setattr__(wrapped, "ainvoke", _make_safe_ainvoke(wrapped))
+        return wrapped
 
+    object.__setattr__(tool, "ainvoke", _make_safe_ainvoke(tool))
     return tool

--- a/tests/unit/aegra/test_mcp_tool_auth.py
+++ b/tests/unit/aegra/test_mcp_tool_auth.py
@@ -115,8 +115,11 @@ class TestSafeAinvoke:
 class TestWrapMcpToolsForAuth:
     def test_wraps_all_tools(self):
         tools = [_make_mock_tool(name=f"tool_{i}") for i in range(3)]
+        original_ainvokes = [t.ainvoke for t in tools]
         wrapped = wrap_mcp_tools_for_auth(tools)
         assert len(wrapped) == 3
+        for i, tool in enumerate(wrapped):
+            assert tool.ainvoke is not original_ainvokes[i]
 
     def test_empty_list(self):
         assert wrap_mcp_tools_for_auth([]) == []

--- a/tests/unit/aegra/test_mcp_tool_auth.py
+++ b/tests/unit/aegra/test_mcp_tool_auth.py
@@ -111,6 +111,19 @@ class TestSafeAinvoke:
         assert isinstance(result, ToolMessage)
         assert "google_search_docs" in result.content
 
+    @pytest.mark.asyncio
+    async def test_reraises_graph_bubble_up(self):
+        """GraphBubbleUp (including GraphInterrupt) must not be swallowed."""
+        from langgraph.errors import GraphInterrupt
+
+        tool = _make_mock_tool()
+        tool.ainvoke = AsyncMock(side_effect=GraphInterrupt())
+
+        wrapped = _wrap_single_tool(tool)
+
+        with pytest.raises(GraphInterrupt):
+            await wrapped.ainvoke({"id": "call_5"})
+
 
 class TestWrapMcpToolsForAuth:
     def test_wraps_all_tools(self):

--- a/tests/unit/aegra/test_mcp_tool_auth.py
+++ b/tests/unit/aegra/test_mcp_tool_auth.py
@@ -1,0 +1,122 @@
+"""Unit tests for MCP tool auth wrapping and error handling."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from langchain_core.messages import ToolMessage
+
+from deep_agent.aegra.mcp_auth import NeedsAuthorization
+from deep_agent.aegra.mcp_tool_auth import _wrap_single_tool, wrap_mcp_tools_for_auth
+
+
+def _make_mock_tool(*, name: str = "gitlab_list_issues", coroutine=None):
+    """Build a mock tool with the same shape as a StructuredTool."""
+    tool = MagicMock()
+    tool.name = name
+    tool.coroutine = coroutine
+    tool.func = None
+    tool.args = {}
+    tool.ainvoke = AsyncMock(return_value="ok")
+    return tool
+
+
+class TestSafeAinvoke:
+    @pytest.mark.asyncio
+    async def test_passthrough_on_success(self):
+        tool = _make_mock_tool()
+        tool.ainvoke = AsyncMock(return_value="success result")
+        original = tool.ainvoke
+
+        wrapped = _wrap_single_tool(tool)
+
+        result = await wrapped.ainvoke(
+            {"id": "call_1", "name": "gitlab_list_issues", "args": {}}
+        )
+        assert result == "success result"
+
+    @pytest.mark.asyncio
+    async def test_catches_generic_exception(self):
+        tool = _make_mock_tool()
+        tool.ainvoke = AsyncMock(
+            side_effect=RuntimeError("GitLab API error: 403 Forbidden")
+        )
+
+        wrapped = _wrap_single_tool(tool)
+
+        result = await wrapped.ainvoke(
+            {"id": "call_2", "name": "gitlab_list_issues", "args": {}}
+        )
+        assert isinstance(result, ToolMessage)
+        assert result.status == "error"
+        assert "403 Forbidden" in result.content
+        assert "[TOOL_ERROR]" in result.content
+        assert result.tool_call_id == "call_2"
+        assert result.name == "gitlab_list_issues"
+
+    @pytest.mark.asyncio
+    async def test_catches_mcp_error(self):
+        """McpError (transport/protocol failure) is caught like any other exception."""
+        try:
+            from mcp.shared.exceptions import McpError
+            from mcp.types import ErrorData
+
+            exc = McpError(ErrorData(code=-1, message="server returned error"))
+        except ImportError:
+            exc = Exception("server returned error")
+
+        tool = _make_mock_tool()
+        tool.ainvoke = AsyncMock(side_effect=exc)
+
+        wrapped = _wrap_single_tool(tool)
+
+        result = await wrapped.ainvoke(
+            {"id": "call_3", "name": "gitlab_list_issues", "args": {}}
+        )
+        assert isinstance(result, ToolMessage)
+        assert result.status == "error"
+        assert "server returned error" in result.content
+
+    @pytest.mark.asyncio
+    async def test_extracts_tool_call_id_from_input(self):
+        tool = _make_mock_tool()
+        tool.ainvoke = AsyncMock(side_effect=ValueError("bad args"))
+
+        wrapped = _wrap_single_tool(tool)
+
+        result = await wrapped.ainvoke({"id": "tc_abc123"})
+        assert isinstance(result, ToolMessage)
+        assert result.tool_call_id == "tc_abc123"
+
+    @pytest.mark.asyncio
+    async def test_handles_non_dict_input(self):
+        tool = _make_mock_tool()
+        tool.ainvoke = AsyncMock(side_effect=ValueError("bad"))
+
+        wrapped = _wrap_single_tool(tool)
+
+        result = await wrapped.ainvoke("raw string input")
+        assert isinstance(result, ToolMessage)
+        assert result.tool_call_id == ""
+
+    @pytest.mark.asyncio
+    async def test_error_content_includes_tool_name(self):
+        tool = _make_mock_tool(name="google_search_docs")
+        tool.ainvoke = AsyncMock(side_effect=TimeoutError("timed out"))
+
+        wrapped = _wrap_single_tool(tool)
+
+        result = await wrapped.ainvoke({"id": "call_4"})
+        assert isinstance(result, ToolMessage)
+        assert "google_search_docs" in result.content
+
+
+class TestWrapMcpToolsForAuth:
+    def test_wraps_all_tools(self):
+        tools = [_make_mock_tool(name=f"tool_{i}") for i in range(3)]
+        wrapped = wrap_mcp_tools_for_auth(tools)
+        assert len(wrapped) == 3
+
+    def test_empty_list(self):
+        assert wrap_mcp_tools_for_auth([]) == []


### PR DESCRIPTION
## What

Propagate MCP tool call failure's error message to consumer. Also add unit tests for MCP tool authentication flow.

Fixes #283  

## How

detect MCP tool call error, then return ToolMessage with that error message from MCP

## Testing

<!-- How did you verify this works? -->

- [x] Unit tests added/updated
- [x] Ran locally (`uv run pytest tests/unit -x`)
- [x] Manual verification (describe below if applicable)

## Rollback

<!-- How would you revert this if it breaks production? "Revert the commit" is fine for most changes. -->

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `ci:`, etc.)
- [x] No secrets, credentials, or PII in the diff
- [x] No breaking changes (or documented above with a migration path)
- [x] Pre-commit hooks pass (`uv run pre-commit run --all-files`)
