### PR TITLE
fix: handle expired DCR client_id and auto re-register

### DIFF
--- a/deep_agent/aegra/mcp_auth.py
+++ b/deep_agent/aegra/mcp_auth.py
@@ -350,6 +350,21 @@ class McpCredentialResolver:
         try:
             async with httpx.AsyncClient(verify=mcp_httpx_verify(server_cfg)) as client:
                 resp = await client.post(token_endpoint, data=data, timeout=30)
+                if resp.status_code in (401, 403) or (
+                    resp.status_code == 400 and "invalid_client" in resp.text.lower()
+                ):
+                    logger.warning(
+                        "MCP token refresh rejected for '%s' (status %s) — "
+                        "deleting stale DCR client so next connect re-registers",
+                        stored.mcp_name,
+                        resp.status_code,
+                    )
+                    auth_mode = server_cfg.get("auth_mode", "sso")
+                    if auth_mode == "dcr":
+                        await self._store.delete_client(
+                            stored.agent_name, stored.mcp_name
+                        )
+                    return None
                 resp.raise_for_status()
                 body: dict[str, Any] = resp.json()
         except Exception:

--- a/deep_agent/aegra/mcp_oauth_handlers.py
+++ b/deep_agent/aegra/mcp_oauth_handlers.py
@@ -123,6 +123,45 @@ async def _register_dcr_client(
     return client_id, client_secret
 
 
+async def _validate_dcr_client(
+    client_id: str,
+    oauth_cfg: dict[str, Any],
+    server_cfg: dict[str, Any],
+) -> bool:
+    """Check if a DCR client_id is still accepted by the MCP server.
+
+    Sends a lightweight GET to the authorization_endpoint with the client_id.
+    Stateless MCP servers reject expired signed client_ids immediately.
+    Returns False if the server rejects the client_id, True otherwise.
+    """
+    auth_endpoint = oauth_cfg.get("authorization_endpoint")
+    if not auth_endpoint:
+        return True
+
+    try:
+        async with httpx.AsyncClient(
+            verify=mcp_httpx_verify(server_cfg)
+        ) as http_client:
+            resp = await http_client.get(
+                auth_endpoint,
+                params={
+                    "response_type": "code",
+                    "client_id": client_id,
+                    "redirect_uri": settings.oauth_callback_url,
+                },
+                follow_redirects=False,
+                timeout=10,
+            )
+            if resp.status_code in (302, 200):
+                return True
+            if "invalid_client" in resp.text.lower():
+                return False
+            return True
+    except Exception:
+        logger.debug("DCR client validation probe failed", exc_info=True)
+        return True
+
+
 async def handle_mcp_connect(
     user_id: str, mcp_name: str, *, caller_origin: str | None = None
 ) -> dict[str, str]:
@@ -155,6 +194,17 @@ async def handle_mcp_connect(
     store = McpTokenStore(settings.database_uri)
     if auth_mode == "dcr":
         client = await store.get_client(current_agent_name, mcp_name)
+        if client is not None:
+            is_valid = await _validate_dcr_client(
+                client.client_id, oauth_cfg, server_cfg
+            )
+            if not is_valid:
+                logger.warning(
+                    "DCR client_id expired/rejected for '%s' — re-registering",
+                    mcp_name,
+                )
+                await store.delete_client(current_agent_name, mcp_name)
+                client = None
         if client is None:
             await _register_dcr_client(
                 current_agent_name, mcp_name, oauth_cfg, server_cfg

--- a/deep_agent/aegra/mcp_token_store.py
+++ b/deep_agent/aegra/mcp_token_store.py
@@ -249,6 +249,24 @@ class McpTokenStore:
             registration_data=registration_data,
         )
 
+    async def delete_client(self, agent_name: str, mcp_name: str) -> bool:
+        """Delete the DCR client record for *(agent_name, mcp_name)*."""
+        await self.ensure_tables()
+        async with await psycopg.AsyncConnection.connect(self._uri) as conn:
+            cur = await conn.execute(
+                "DELETE FROM mcp_oauth_clients WHERE agent_name = %s AND mcp_name = %s",
+                (agent_name, mcp_name),
+            )
+            await conn.commit()
+            deleted: bool = (cur.rowcount or 0) > 0
+            if deleted:
+                logger.info(
+                    "Deleted stale DCR client for agent '%s' MCP '%s'",
+                    agent_name,
+                    mcp_name,
+                )
+            return deleted
+
     async def get_token(
         self, agent_name: str, user_id: str, mcp_name: str
     ) -> McpOAuthToken | None:

--- a/tests/unit/aegra/test_mcp_auth.py
+++ b/tests/unit/aegra/test_mcp_auth.py
@@ -466,3 +466,212 @@ class TestClientCredentialsGrant:
         call_kwargs = mock_ctx.post.call_args
         data = call_kwargs.kwargs.get("data", call_kwargs[1].get("data", {}))
         assert data["scope"] == "read write"
+
+
+@pytest.mark.asyncio
+class TestRefreshTokenInvalidClient:
+    """Tests for _refresh_mcp_token handling of invalid/expired DCR client_id."""
+
+    async def test_refresh_deletes_dcr_client_on_401(self):
+        store = AsyncMock()
+        store.delete_client = AsyncMock()
+        resolver = McpCredentialResolver(token_store=store)
+
+        stored = McpOAuthToken(
+            agent_name="test-agent",
+            user_id="user-1",
+            mcp_name="dcr-mcp",
+            access_token="old-access",
+            refresh_token="refresh-me",
+        )
+        server_cfg = {
+            "auth_mode": "dcr",
+            "oauth": {
+                "token_endpoint": "https://mcp.example.com/token",
+            },
+        }
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = "Unauthorized"
+
+        with (
+            patch.object(
+                resolver,
+                "_resolve_client_credentials",
+                new=AsyncMock(return_value=("cid", "csecret")),
+            ),
+            patch("deep_agent.aegra.mcp_auth.httpx.AsyncClient") as mock_client,
+        ):
+            mock_ctx = AsyncMock(post=AsyncMock(return_value=mock_response))
+            mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_ctx)
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await resolver._refresh_mcp_token(stored, server_cfg)
+
+        assert result is None
+        store.delete_client.assert_awaited_once_with("test-agent", "dcr-mcp")
+
+    async def test_refresh_deletes_dcr_client_on_400_invalid_client(self):
+        store = AsyncMock()
+        store.delete_client = AsyncMock()
+        resolver = McpCredentialResolver(token_store=store)
+
+        stored = McpOAuthToken(
+            agent_name="test-agent",
+            user_id="user-1",
+            mcp_name="dcr-mcp",
+            access_token="old-access",
+            refresh_token="refresh-me",
+        )
+        server_cfg = {
+            "auth_mode": "dcr",
+            "oauth": {
+                "token_endpoint": "https://mcp.example.com/token",
+            },
+        }
+
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.text = '{"error": "invalid_client"}'
+
+        with (
+            patch.object(
+                resolver,
+                "_resolve_client_credentials",
+                new=AsyncMock(return_value=("cid", "csecret")),
+            ),
+            patch("deep_agent.aegra.mcp_auth.httpx.AsyncClient") as mock_client,
+        ):
+            mock_ctx = AsyncMock(post=AsyncMock(return_value=mock_response))
+            mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_ctx)
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await resolver._refresh_mcp_token(stored, server_cfg)
+
+        assert result is None
+        store.delete_client.assert_awaited_once_with("test-agent", "dcr-mcp")
+
+    async def test_refresh_skips_delete_for_non_dcr_auth_mode(self):
+        store = AsyncMock()
+        store.delete_client = AsyncMock()
+        resolver = McpCredentialResolver(token_store=store)
+
+        stored = McpOAuthToken(
+            agent_name="test-agent",
+            user_id="user-1",
+            mcp_name="oauth-mcp",
+            access_token="old-access",
+            refresh_token="refresh-me",
+        )
+        server_cfg = {
+            "auth_mode": "oauth",
+            "oauth": {
+                "token_endpoint": "https://mcp.example.com/token",
+                "client_id": "cid",
+            },
+        }
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = "Unauthorized"
+
+        with (
+            patch.object(
+                resolver,
+                "_resolve_client_credentials",
+                new=AsyncMock(return_value=("cid", "csecret")),
+            ),
+            patch("deep_agent.aegra.mcp_auth.httpx.AsyncClient") as mock_client,
+        ):
+            mock_ctx = AsyncMock(post=AsyncMock(return_value=mock_response))
+            mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_ctx)
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await resolver._refresh_mcp_token(stored, server_cfg)
+
+        assert result is None
+        store.delete_client.assert_not_awaited()
+
+    async def test_refresh_deletes_dcr_client_on_403(self):
+        store = AsyncMock()
+        store.delete_client = AsyncMock()
+        resolver = McpCredentialResolver(token_store=store)
+
+        stored = McpOAuthToken(
+            agent_name="test-agent",
+            user_id="user-1",
+            mcp_name="dcr-mcp",
+            access_token="old-access",
+            refresh_token="refresh-me",
+        )
+        server_cfg = {
+            "auth_mode": "dcr",
+            "oauth": {
+                "token_endpoint": "https://mcp.example.com/token",
+            },
+        }
+
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.text = "Forbidden"
+
+        with (
+            patch.object(
+                resolver,
+                "_resolve_client_credentials",
+                new=AsyncMock(return_value=("cid", "csecret")),
+            ),
+            patch("deep_agent.aegra.mcp_auth.httpx.AsyncClient") as mock_client,
+        ):
+            mock_ctx = AsyncMock(post=AsyncMock(return_value=mock_response))
+            mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_ctx)
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await resolver._refresh_mcp_token(stored, server_cfg)
+
+        assert result is None
+        store.delete_client.assert_awaited_once_with("test-agent", "dcr-mcp")
+
+    async def test_refresh_400_without_invalid_client_raises(self):
+        store = AsyncMock()
+        resolver = McpCredentialResolver(token_store=store)
+
+        stored = McpOAuthToken(
+            agent_name="test-agent",
+            user_id="user-1",
+            mcp_name="dcr-mcp",
+            access_token="old-access",
+            refresh_token="refresh-me",
+        )
+        server_cfg = {
+            "auth_mode": "dcr",
+            "oauth": {
+                "token_endpoint": "https://mcp.example.com/token",
+            },
+        }
+
+        import httpx as real_httpx
+
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.text = '{"error": "invalid_grant"}'
+        mock_response.raise_for_status.side_effect = real_httpx.HTTPStatusError(
+            "Bad Request", request=MagicMock(), response=mock_response
+        )
+
+        with (
+            patch.object(
+                resolver,
+                "_resolve_client_credentials",
+                new=AsyncMock(return_value=("cid", "csecret")),
+            ),
+            patch("deep_agent.aegra.mcp_auth.httpx.AsyncClient") as mock_client,
+        ):
+            mock_ctx = AsyncMock(post=AsyncMock(return_value=mock_response))
+            mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_ctx)
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await resolver._refresh_mcp_token(stored, server_cfg)
+
+        assert result is None

--- a/tests/unit/aegra/test_mcp_oauth_handlers.py
+++ b/tests/unit/aegra/test_mcp_oauth_handlers.py
@@ -481,3 +481,271 @@ class TestCallbackHtml:
         result = _callback_html(error='<script>alert("xss")</script>')
         assert "<script>" not in result
         assert "&lt;script&gt;" in result
+
+
+@pytest.mark.asyncio
+class TestValidateDcrClient:
+    """Tests for _validate_dcr_client helper."""
+
+    async def test_returns_true_on_302_redirect(self):
+        from deep_agent.aegra.mcp_oauth_handlers import _validate_dcr_client
+
+        mock_response = MagicMock()
+        mock_response.status_code = 302
+        mock_response.text = ""
+
+        mock_ctx = AsyncMock(get=AsyncMock(return_value=mock_response))
+
+        with (
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.httpx.AsyncClient"
+            ) as mock_client,
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.mcp_httpx_verify",
+                return_value=True,
+            ),
+            patch("deep_agent.aegra.mcp_oauth_handlers.settings") as mock_settings,
+        ):
+            mock_settings.oauth_callback_url = (
+                "https://agent.example.com/mcp/oauth/callback"
+            )
+            mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_ctx)
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _validate_dcr_client(
+                "valid-client-id",
+                {"authorization_endpoint": "https://mcp.example.com/authorize"},
+                {"enabled": True},
+            )
+
+        assert result is True
+
+    async def test_returns_false_on_invalid_client_error(self):
+        from deep_agent.aegra.mcp_oauth_handlers import _validate_dcr_client
+
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.text = (
+            '{"error": "invalid_client", "error_description": "client_id expired"}'
+        )
+
+        mock_ctx = AsyncMock(get=AsyncMock(return_value=mock_response))
+
+        with (
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.httpx.AsyncClient"
+            ) as mock_client,
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.mcp_httpx_verify",
+                return_value=True,
+            ),
+            patch("deep_agent.aegra.mcp_oauth_handlers.settings") as mock_settings,
+        ):
+            mock_settings.oauth_callback_url = (
+                "https://agent.example.com/mcp/oauth/callback"
+            )
+            mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_ctx)
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _validate_dcr_client(
+                "expired-client-id",
+                {"authorization_endpoint": "https://mcp.example.com/authorize"},
+                {"enabled": True},
+            )
+
+        assert result is False
+
+    async def test_returns_true_when_no_authorization_endpoint(self):
+        from deep_agent.aegra.mcp_oauth_handlers import _validate_dcr_client
+
+        result = await _validate_dcr_client(
+            "some-client-id",
+            {},
+            {"enabled": True},
+        )
+        assert result is True
+
+    async def test_returns_true_on_network_error(self):
+        from deep_agent.aegra.mcp_oauth_handlers import _validate_dcr_client
+
+        mock_ctx = AsyncMock(get=AsyncMock(side_effect=Exception("connection refused")))
+
+        with (
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.httpx.AsyncClient"
+            ) as mock_client,
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.mcp_httpx_verify",
+                return_value=True,
+            ),
+            patch("deep_agent.aegra.mcp_oauth_handlers.settings") as mock_settings,
+        ):
+            mock_settings.oauth_callback_url = (
+                "https://agent.example.com/mcp/oauth/callback"
+            )
+            mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_ctx)
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _validate_dcr_client(
+                "some-client-id",
+                {"authorization_endpoint": "https://mcp.example.com/authorize"},
+                {"enabled": True},
+            )
+
+        assert result is True
+
+    async def test_returns_true_on_unknown_error_status(self):
+        from deep_agent.aegra.mcp_oauth_handlers import _validate_dcr_client
+
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+
+        mock_ctx = AsyncMock(get=AsyncMock(return_value=mock_response))
+
+        with (
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.httpx.AsyncClient"
+            ) as mock_client,
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.mcp_httpx_verify",
+                return_value=True,
+            ),
+            patch("deep_agent.aegra.mcp_oauth_handlers.settings") as mock_settings,
+        ):
+            mock_settings.oauth_callback_url = (
+                "https://agent.example.com/mcp/oauth/callback"
+            )
+            mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_ctx)
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _validate_dcr_client(
+                "some-client-id",
+                {"authorization_endpoint": "https://mcp.example.com/authorize"},
+                {"enabled": True},
+            )
+
+        assert result is True
+
+
+@pytest.mark.asyncio
+class TestHandleMcpConnectDcrValidation:
+    """Tests for handle_mcp_connect DCR client_id validation and re-registration."""
+
+    async def test_expired_client_triggers_reregistration(self):
+        from deep_agent.aegra.mcp_token_store import McpOAuthClient
+
+        existing_client = McpOAuthClient(
+            agent_name="test-agent",
+            mcp_name="dcr-mcp",
+            client_id="expired-cid",
+            client_secret="old-secret",
+        )
+        new_client = McpOAuthClient(
+            agent_name="test-agent",
+            mcp_name="dcr-mcp",
+            client_id="fresh-cid",
+            client_secret="new-secret",
+        )
+
+        server_cfg = {
+            "enabled": True,
+            "auth_mode": "dcr",
+            "oauth": {
+                "authorization_endpoint": "https://mcp.example.com/authorize",
+                "token_endpoint": "https://mcp.example.com/token",
+                "registration_endpoint": "https://mcp.example.com/register",
+            },
+        }
+
+        mock_store = MagicMock()
+        get_client_calls = [existing_client, new_client]
+        mock_store.get_client = AsyncMock(side_effect=get_client_calls)
+        mock_store.delete_client = AsyncMock()
+
+        with (
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers._get_mcp_server_config",
+                return_value=server_cfg,
+            ),
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers._validate_dcr_client",
+                new=AsyncMock(return_value=False),
+            ),
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers._register_dcr_client",
+                new=AsyncMock(return_value=("fresh-cid", "new-secret")),
+            ),
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.McpTokenStore",
+                return_value=mock_store,
+            ),
+            patch("deep_agent.aegra.mcp_oauth_handlers.settings") as mock_settings,
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.cache_set",
+                return_value=True,
+            ),
+        ):
+            mock_settings.oauth_callback_url = (
+                "https://agent.example.com/mcp/oauth/callback"
+            )
+            mock_settings.agent_deployment_id = "test-agent"
+
+            result = await handle_mcp_connect("user-1", "dcr-mcp")
+
+        assert "authorize_url" in result
+        mock_store.delete_client.assert_awaited_once_with("test-agent", "dcr-mcp")
+
+    async def test_valid_client_skips_reregistration(self):
+        from deep_agent.aegra.mcp_token_store import McpOAuthClient
+
+        existing_client = McpOAuthClient(
+            agent_name="test-agent",
+            mcp_name="dcr-mcp",
+            client_id="valid-cid",
+            client_secret="secret",
+        )
+
+        server_cfg = {
+            "enabled": True,
+            "auth_mode": "dcr",
+            "oauth": {
+                "authorization_endpoint": "https://mcp.example.com/authorize",
+                "token_endpoint": "https://mcp.example.com/token",
+                "registration_endpoint": "https://mcp.example.com/register",
+            },
+        }
+
+        mock_store = MagicMock()
+        mock_store.get_client = AsyncMock(return_value=existing_client)
+        mock_store.delete_client = AsyncMock()
+
+        with (
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers._get_mcp_server_config",
+                return_value=server_cfg,
+            ),
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers._validate_dcr_client",
+                new=AsyncMock(return_value=True),
+            ),
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.McpTokenStore",
+                return_value=mock_store,
+            ),
+            patch("deep_agent.aegra.mcp_oauth_handlers.settings") as mock_settings,
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.cache_set",
+                return_value=True,
+            ),
+        ):
+            mock_settings.oauth_callback_url = (
+                "https://agent.example.com/mcp/oauth/callback"
+            )
+            mock_settings.agent_deployment_id = "test-agent"
+
+            result = await handle_mcp_connect("user-1", "dcr-mcp")
+
+        assert "authorize_url" in result
+        assert "valid-cid" in result["authorize_url"]
+        mock_store.delete_client.assert_not_awaited()

--- a/tests/unit/aegra/test_mcp_token_store.py
+++ b/tests/unit/aegra/test_mcp_token_store.py
@@ -208,3 +208,62 @@ class TestMcpTokenStoreRedis:
             assert await store.delete_token("default", "user-1", "oauth-mcp") is True
 
         assert deleted_keys == ["mcp_oauth_token:default:user-1:oauth-mcp"]
+
+    async def test_delete_client_returns_true_when_row_deleted(self, store):
+        mock_cur = AsyncMock()
+        mock_cur.rowcount = 1
+        mock_conn = AsyncMock()
+        mock_conn.execute.return_value = mock_cur
+        mock_conn.commit = AsyncMock()
+
+        with (
+            patch.object(store, "ensure_tables"),
+            patch("deep_agent.aegra.mcp_token_store.psycopg") as mock_psycopg,
+        ):
+            mock_psycopg.AsyncConnection.connect = AsyncMock(return_value=mock_conn)
+            mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+            mock_conn.__aexit__ = AsyncMock(return_value=False)
+
+            result = await store.delete_client("default", "dcr-mcp")
+
+        assert result is True
+        mock_conn.execute.assert_awaited_once()
+        mock_conn.commit.assert_awaited_once()
+
+    async def test_delete_client_returns_false_when_no_row(self, store):
+        mock_cur = AsyncMock()
+        mock_cur.rowcount = 0
+        mock_conn = AsyncMock()
+        mock_conn.execute.return_value = mock_cur
+        mock_conn.commit = AsyncMock()
+
+        with (
+            patch.object(store, "ensure_tables"),
+            patch("deep_agent.aegra.mcp_token_store.psycopg") as mock_psycopg,
+        ):
+            mock_psycopg.AsyncConnection.connect = AsyncMock(return_value=mock_conn)
+            mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+            mock_conn.__aexit__ = AsyncMock(return_value=False)
+
+            result = await store.delete_client("default", "dcr-mcp")
+
+        assert result is False
+
+    async def test_delete_client_returns_false_when_rowcount_none(self, store):
+        mock_cur = AsyncMock()
+        mock_cur.rowcount = None
+        mock_conn = AsyncMock()
+        mock_conn.execute.return_value = mock_cur
+        mock_conn.commit = AsyncMock()
+
+        with (
+            patch.object(store, "ensure_tables"),
+            patch("deep_agent.aegra.mcp_token_store.psycopg") as mock_psycopg,
+        ):
+            mock_psycopg.AsyncConnection.connect = AsyncMock(return_value=mock_conn)
+            mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+            mock_conn.__aexit__ = AsyncMock(return_value=False)
+
+            result = await store.delete_client("default", "dcr-mcp")
+
+        assert result is False


### PR DESCRIPTION
## Summary
- Add `McpTokenStore.delete_client()` to remove stale DCR records from Postgres
- Detect `401`/`403`/`invalid_client` during token refresh in `_refresh_mcp_token` and delete the stale client so the next connect flow re-registers
- Validate existing `client_id` against the MCP `authorization_endpoint` before starting a new OAuth flow in `handle_mcp_connect`; re-register if rejected
- 
Fixes #284

## Test plan
- [x] All 1413 existing unit tests pass
- [x] Deploy GitLab MCP with `OAUTH_STATELESS_MODE=true` and a short `OAUTH_STATELESS_CLIENT_TTL_SECONDS` (e.g. 60s)
- [x] Complete DCR + OAuth authorization, verify tools load
- [x] Wait for client_id to expire, trigger a tool call — verify agent auto re-registers and recovers
- [x] Verify non-DCR auth modes (oauth, sso) are unaffected