### PR TITLE
feat: add MCP OAuth settings tab for connect, re-auth, and disconnect

### DIFF
--- a/deep_agent/aegra/mcp_oauth_handlers.py
+++ b/deep_agent/aegra/mcp_oauth_handlers.py
@@ -411,6 +411,8 @@ async def handle_mcp_connections(user_id: str) -> dict[str, Any]:
 async def handle_mcp_disconnect(user_id: str, mcp_name: str) -> dict[str, Any]:
     """Clear stored OAuth tokens for *mcp_name* for the current user."""
     server_cfg = _get_mcp_server_config(mcp_name)
+    if server_cfg.get("auth_mode") == "dcr" and not settings.MCP_DCR_ENABLED:
+        raise HTTPException(status_code=403, detail="DCR is disabled")
     _require_interactive_oauth(mcp_name, server_cfg)
 
     store = McpTokenStore(settings.database_uri)

--- a/deep_agent/aegra/mcp_oauth_handlers.py
+++ b/deep_agent/aegra/mcp_oauth_handlers.py
@@ -128,19 +128,9 @@ async def handle_mcp_connect(
 ) -> dict[str, str]:
     """Start the OAuth authorization flow for *mcp_name*."""
     server_cfg = _get_mcp_server_config(mcp_name)
+    _require_interactive_oauth(mcp_name, server_cfg)
     auth_mode = server_cfg.get("auth_mode", "sso")
-    if auth_mode not in ("oauth", "dcr"):
-        raise HTTPException(
-            status_code=400,
-            detail=f"MCP '{mcp_name}' does not use OAuth/DCR authentication",
-        )
-
     oauth_cfg = server_cfg.get("oauth") or {}
-    if oauth_cfg.get("grant_type") == "client_credentials":
-        raise HTTPException(
-            status_code=400,
-            detail=f"MCP '{mcp_name}' uses client_credentials grant — manual authorization is not required",
-        )
 
     for field in ("authorization_endpoint", "token_endpoint"):
         if not oauth_cfg.get(field):
@@ -358,12 +348,84 @@ async def handle_mcp_oauth_callback(
     return HTMLResponse(_callback_html(mcp_name=mcp_name, opener_origin=opener_origin))
 
 
+def _interactive_oauth_servers() -> list[tuple[str, dict[str, Any]]]:
+    """Enabled OAuth/DCR servers that require a user authorization-code flow."""
+    servers = agent_config.get_mcp_servers()
+    allowed_auth_modes = {"oauth", "dcr"} if settings.MCP_DCR_ENABLED else {"oauth"}
+    result: list[tuple[str, dict[str, Any]]] = []
+    for name, cfg in sorted(servers.items()):
+        if not isinstance(cfg, dict) or not cfg.get("enabled"):
+            continue
+        if cfg.get("auth_mode") not in allowed_auth_modes:
+            continue
+        if (cfg.get("oauth") or {}).get("grant_type") == "client_credentials":
+            continue
+        result.append((name, cfg))
+    return result
+
+
+def _require_interactive_oauth(mcp_name: str, server_cfg: dict[str, Any]) -> None:
+    """Reject MCP servers that cannot be user-connected or disconnected."""
+    auth_mode = server_cfg.get("auth_mode", "sso")
+    if auth_mode not in ("oauth", "dcr"):
+        raise HTTPException(
+            status_code=400,
+            detail=f"MCP '{mcp_name}' does not use OAuth/DCR authentication",
+        )
+    if (server_cfg.get("oauth") or {}).get("grant_type") == "client_credentials":
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"MCP '{mcp_name}' uses client_credentials grant — "
+                "manual authorization is not required"
+            ),
+        )
+
+
 async def handle_mcp_status(user_id: str, mcp_name: str) -> dict[str, Any]:
     """Return whether the user has a usable token for *mcp_name*."""
     server_cfg = _get_mcp_server_config(mcp_name)
     resolver = get_mcp_credential_resolver()
     connected = await resolver.has_valid_token(user_id, mcp_name, server_cfg)
     return {"mcp_name": mcp_name, "connected": connected}
+
+
+async def handle_mcp_connections(user_id: str) -> dict[str, Any]:
+    """Return OAuth/DCR MCP connection status for the current user."""
+    resolver = get_mcp_credential_resolver()
+    connections: list[dict[str, Any]] = []
+    for mcp_name, server_cfg in _interactive_oauth_servers():
+        description = server_cfg.get("description")
+        connected = await resolver.has_valid_token(user_id, mcp_name, server_cfg)
+        connections.append(
+            {
+                "mcp_name": mcp_name,
+                "auth_mode": server_cfg.get("auth_mode"),
+                "description": description if isinstance(description, str) else "",
+                "connected": connected,
+            }
+        )
+    return {"connections": connections}
+
+
+async def handle_mcp_disconnect(user_id: str, mcp_name: str) -> dict[str, Any]:
+    """Clear stored OAuth tokens for *mcp_name* for the current user."""
+    server_cfg = _get_mcp_server_config(mcp_name)
+    _require_interactive_oauth(mcp_name, server_cfg)
+
+    store = McpTokenStore(settings.database_uri)
+    await store.delete_token(settings.agent_deployment_id, user_id, mcp_name)
+    get_mcp_credential_resolver().invalidate_cache(user_id, mcp_name)
+    from deep_agent.aegra.mcp import invalidate_mcp_tool_cache
+
+    invalidate_mcp_tool_cache(user_id=user_id)
+    try:
+        from deep_agent.aegra.graph import invalidate_graph_cache
+
+        invalidate_graph_cache()
+    except Exception:
+        logger.debug("Graph cache invalidation skipped", exc_info=True)
+    return {"mcp_name": mcp_name, "connected": False}
 
 
 def _callback_html(

--- a/deep_agent/aegra/mcp_routes.py
+++ b/deep_agent/aegra/mcp_routes.py
@@ -1,4 +1,4 @@
-"""HTTP routes for per-MCP OAuth/DCR connect, callback, status, and Apps host proxy."""
+"""HTTP routes for per-MCP OAuth/DCR connect, callback, status, disconnect, and Apps host proxy."""
 
 from __future__ import annotations
 
@@ -97,6 +97,16 @@ async def mcp_oauth_callback(
     return await handle_mcp_oauth_callback(code, state, request)
 
 
+@router.get("/mcp/oauth/connections")
+async def mcp_connections(request: Request) -> JSONResponse:
+    """Return OAuth/DCR MCP connection status for the current user."""
+    from deep_agent.aegra.mcp_oauth_handlers import handle_mcp_connections
+
+    user_id = await _authenticated_user_id(request)
+    result = await handle_mcp_connections(user_id)
+    return JSONResponse(content=result)
+
+
 @router.get("/mcp/{mcp_name}/status")
 async def mcp_status(mcp_name: str, request: Request) -> JSONResponse:
     """Return whether the current user has a valid token for the MCP."""
@@ -107,20 +117,22 @@ async def mcp_status(mcp_name: str, request: Request) -> JSONResponse:
     return JSONResponse(content=result)
 
 
+@router.delete("/mcp/{mcp_name}/disconnect")
+async def mcp_disconnect(mcp_name: str, request: Request) -> JSONResponse:
+    """Clear stored OAuth tokens for an MCP server for the current user."""
+    from deep_agent.aegra.mcp_oauth_handlers import handle_mcp_disconnect
+
+    user_id = await _authenticated_user_id(request)
+    result = await handle_mcp_disconnect(user_id, mcp_name)
+    return JSONResponse(content=result)
+
+
 @router.get("/info")
 async def get_agent_info() -> dict[str, Any]:
     """Return agent identity metadata from config."""
-    servers = agent_config.get_mcp_servers()
-    from deep_agent.src.settings import settings
+    from deep_agent.aegra.mcp_oauth_handlers import _interactive_oauth_servers
 
-    allowed_auth_modes = {"oauth", "dcr"} if settings.MCP_DCR_ENABLED else {"oauth"}
-    oauth_mcps = sorted(
-        name
-        for name, cfg in servers.items()
-        if cfg.get("enabled")
-        and cfg.get("auth_mode") in allowed_auth_modes
-        and (cfg.get("oauth") or {}).get("grant_type") != "client_credentials"
-    )
+    oauth_mcps = [name for name, _ in _interactive_oauth_servers()]
     return {"name": agent_config.get_name(), "oauth_mcps": oauth_mcps}
 
 

--- a/tests/unit/aegra/test_mcp_host.py
+++ b/tests/unit/aegra/test_mcp_host.py
@@ -1019,6 +1019,64 @@ class TestRouteWiring:
         mock_status.assert_awaited_once_with("user-1", "charts")
 
     @pytest.mark.asyncio
+    async def test_mcp_connections_route(self):
+        from deep_agent.aegra import mcp_routes
+
+        request = MagicMock()
+        request.headers = {}
+        payload = {
+            "connections": [
+                {
+                    "mcp_name": "charts",
+                    "auth_mode": "oauth",
+                    "description": "Charts",
+                    "connected": True,
+                }
+            ]
+        }
+
+        with (
+            patch(
+                "deep_agent.aegra.mcp_routes._authenticated_user_id",
+                new_callable=AsyncMock,
+                return_value="user-1",
+            ),
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.handle_mcp_connections",
+                new_callable=AsyncMock,
+                return_value=payload,
+            ) as mock_connections,
+        ):
+            response = await mcp_routes.mcp_connections(request)
+
+        assert response.status_code == 200
+        mock_connections.assert_awaited_once_with("user-1")
+
+    @pytest.mark.asyncio
+    async def test_mcp_disconnect_route(self):
+        from deep_agent.aegra import mcp_routes
+
+        request = MagicMock()
+        request.headers = {}
+
+        with (
+            patch(
+                "deep_agent.aegra.mcp_routes._authenticated_user_id",
+                new_callable=AsyncMock,
+                return_value="user-1",
+            ),
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.handle_mcp_disconnect",
+                new_callable=AsyncMock,
+                return_value={"mcp_name": "charts", "connected": False},
+            ) as mock_disconnect,
+        ):
+            response = await mcp_routes.mcp_disconnect("charts", request)
+
+        assert response.status_code == 200
+        mock_disconnect.assert_awaited_once_with("user-1", "charts")
+
+    @pytest.mark.asyncio
     async def test_mcp_oauth_callback_route(self):
         from deep_agent.aegra import mcp_routes
         from fastapi.responses import HTMLResponse
@@ -1042,7 +1100,7 @@ class TestRouteWiring:
 
         with (
             patch(
-                "deep_agent.aegra.mcp_routes.agent_config.get_mcp_servers",
+                "deep_agent.aegra.mcp_oauth_handlers.agent_config.get_mcp_servers",
                 return_value={
                     "charts": {"enabled": True, "auth_mode": "oauth"},
                     "off": {"enabled": False, "auth_mode": "oauth"},
@@ -1050,11 +1108,13 @@ class TestRouteWiring:
                     "dcr": {"enabled": True, "auth_mode": "dcr"},
                 },
             ),
+            patch("deep_agent.aegra.mcp_oauth_handlers.settings") as mock_settings,
             patch(
                 "deep_agent.aegra.mcp_routes.agent_config.get_name",
                 return_value="demo-agent",
             ),
         ):
+            mock_settings.MCP_DCR_ENABLED = True
             info = await mcp_routes.get_agent_info()
 
         assert info["name"] == "demo-agent"

--- a/tests/unit/aegra/test_mcp_oauth_handlers.py
+++ b/tests/unit/aegra/test_mcp_oauth_handlers.py
@@ -653,6 +653,76 @@ class TestHandleMcpDisconnect:
         store.delete_token.assert_awaited_once_with("test-agent", "user-1", "oauth-mcp")
         resolver.invalidate_cache.assert_called_once_with("user-1", "oauth-mcp")
 
+    async def test_rejects_dcr_when_feature_disabled(self):
+        store = MagicMock()
+        store.delete_token = AsyncMock()
+        resolver = MagicMock()
+        resolver.invalidate_cache = MagicMock()
+
+        with (
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers._get_mcp_server_config",
+                return_value={
+                    "enabled": True,
+                    "auth_mode": "dcr",
+                    "oauth": {"grant_type": "authorization_code"},
+                },
+            ),
+            patch("deep_agent.aegra.mcp_oauth_handlers.settings") as mock_settings,
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.McpTokenStore",
+                return_value=store,
+            ),
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.get_mcp_credential_resolver",
+                return_value=resolver,
+            ),
+        ):
+            mock_settings.MCP_DCR_ENABLED = False
+            with pytest.raises(HTTPException) as exc:
+                await handle_mcp_disconnect("user-1", "dcr-mcp")
+
+        assert exc.value.status_code == 403
+        assert "DCR is disabled" in str(exc.value.detail)
+        store.delete_token.assert_not_awaited()
+        resolver.invalidate_cache.assert_not_called()
+
+    async def test_disconnects_dcr_when_feature_enabled(self):
+        store = MagicMock()
+        store.delete_token = AsyncMock(return_value=True)
+        resolver = MagicMock()
+        resolver.invalidate_cache = MagicMock()
+        server_cfg = {
+            "enabled": True,
+            "auth_mode": "dcr",
+            "oauth": {"grant_type": "authorization_code"},
+        }
+
+        with (
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers._get_mcp_server_config",
+                return_value=server_cfg,
+            ),
+            patch("deep_agent.aegra.mcp_oauth_handlers.settings") as mock_settings,
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.McpTokenStore",
+                return_value=store,
+            ),
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.get_mcp_credential_resolver",
+                return_value=resolver,
+            ),
+            patch("deep_agent.aegra.mcp.invalidate_mcp_tool_cache"),
+            patch("deep_agent.aegra.graph.invalidate_graph_cache"),
+        ):
+            mock_settings.MCP_DCR_ENABLED = True
+            mock_settings.database_uri = "postgresql://test"
+            mock_settings.agent_deployment_id = "test-agent"
+            result = await handle_mcp_disconnect("user-1", "dcr-mcp")
+
+        assert result == {"mcp_name": "dcr-mcp", "connected": False}
+        store.delete_token.assert_awaited_once_with("test-agent", "user-1", "dcr-mcp")
+
     async def test_rejects_non_oauth_auth_mode(self):
         with patch(
             "deep_agent.aegra.mcp_oauth_handlers._get_mcp_server_config",

--- a/tests/unit/aegra/test_mcp_oauth_handlers.py
+++ b/tests/unit/aegra/test_mcp_oauth_handlers.py
@@ -15,6 +15,8 @@ from deep_agent.aegra.mcp_oauth_handlers import (
     _callback_html,
     _register_dcr_client,
     handle_mcp_connect,
+    handle_mcp_connections,
+    handle_mcp_disconnect,
     handle_mcp_oauth_callback,
 )
 
@@ -457,6 +459,184 @@ class TestMcpOauthCallbackRoute:
         resp = client.get("/mcp/oauth/callback")
         assert resp.status_code == 400
         assert "Missing" in resp.text
+
+
+_INTERACTIVE_SERVERS = {
+    "alpha-oauth": {
+        "enabled": True,
+        "auth_mode": "oauth",
+        "description": "Alpha tools",
+        "oauth": {"grant_type": "authorization_code"},
+    },
+    "bravo-dcr": {
+        "enabled": True,
+        "auth_mode": "dcr",
+        "description": "Bravo DCR",
+        "oauth": {"grant_type": "authorization_code"},
+    },
+    "cc-mcp": {
+        "enabled": True,
+        "auth_mode": "oauth",
+        "oauth": {"grant_type": "client_credentials"},
+    },
+    "off-oauth": {
+        "enabled": False,
+        "auth_mode": "oauth",
+        "description": "Disabled",
+    },
+    "sso-mcp": {"enabled": True, "auth_mode": "sso"},
+}
+
+
+@pytest.mark.asyncio
+class TestHandleMcpConnections:
+    async def test_lists_interactive_oauth_and_dcr_with_status(self):
+        resolver = MagicMock()
+        resolver.has_valid_token = AsyncMock(side_effect=[True, False])
+
+        with (
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.agent_config.get_mcp_servers",
+                return_value=_INTERACTIVE_SERVERS,
+            ),
+            patch("deep_agent.aegra.mcp_oauth_handlers.settings") as mock_settings,
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.get_mcp_credential_resolver",
+                return_value=resolver,
+            ),
+        ):
+            mock_settings.MCP_DCR_ENABLED = True
+            result = await handle_mcp_connections("user-1")
+
+        assert result == {
+            "connections": [
+                {
+                    "mcp_name": "alpha-oauth",
+                    "auth_mode": "oauth",
+                    "description": "Alpha tools",
+                    "connected": True,
+                },
+                {
+                    "mcp_name": "bravo-dcr",
+                    "auth_mode": "dcr",
+                    "description": "Bravo DCR",
+                    "connected": False,
+                },
+            ]
+        }
+
+    async def test_omits_dcr_when_feature_disabled(self):
+        resolver = MagicMock()
+        resolver.has_valid_token = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.agent_config.get_mcp_servers",
+                return_value=_INTERACTIVE_SERVERS,
+            ),
+            patch("deep_agent.aegra.mcp_oauth_handlers.settings") as mock_settings,
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.get_mcp_credential_resolver",
+                return_value=resolver,
+            ),
+        ):
+            mock_settings.MCP_DCR_ENABLED = False
+            result = await handle_mcp_connections("user-1")
+
+        names = [row["mcp_name"] for row in result["connections"]]
+        assert names == ["alpha-oauth"]
+
+    async def test_defaults_missing_description_to_empty_string(self):
+        resolver = MagicMock()
+        resolver.has_valid_token = AsyncMock(return_value=True)
+        servers = {
+            "plain": {
+                "enabled": True,
+                "auth_mode": "oauth",
+                "oauth": {"grant_type": "authorization_code"},
+            }
+        }
+
+        with (
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.agent_config.get_mcp_servers",
+                return_value=servers,
+            ),
+            patch("deep_agent.aegra.mcp_oauth_handlers.settings") as mock_settings,
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.get_mcp_credential_resolver",
+                return_value=resolver,
+            ),
+        ):
+            mock_settings.MCP_DCR_ENABLED = True
+            result = await handle_mcp_connections("user-1")
+
+        assert result["connections"][0]["description"] == ""
+
+
+@pytest.mark.asyncio
+class TestHandleMcpDisconnect:
+    async def test_clears_token_and_returns_disconnected(self):
+        store = MagicMock()
+        store.delete_token = AsyncMock(return_value=True)
+        resolver = MagicMock()
+        resolver.invalidate_cache = MagicMock()
+        server_cfg = {
+            "enabled": True,
+            "auth_mode": "oauth",
+            "oauth": {"grant_type": "authorization_code"},
+        }
+
+        with (
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers._get_mcp_server_config",
+                return_value=server_cfg,
+            ),
+            patch("deep_agent.aegra.mcp_oauth_handlers.settings") as mock_settings,
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.McpTokenStore",
+                return_value=store,
+            ),
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.get_mcp_credential_resolver",
+                return_value=resolver,
+            ),
+            patch("deep_agent.aegra.mcp.invalidate_mcp_tool_cache") as mock_tools,
+            patch("deep_agent.aegra.graph.invalidate_graph_cache") as mock_graph,
+        ):
+            mock_settings.database_uri = "postgresql://test"
+            mock_settings.agent_deployment_id = "test-agent"
+            result = await handle_mcp_disconnect("user-1", "oauth-mcp")
+
+        assert result == {"mcp_name": "oauth-mcp", "connected": False}
+        store.delete_token.assert_awaited_once_with("test-agent", "user-1", "oauth-mcp")
+        resolver.invalidate_cache.assert_called_once_with("user-1", "oauth-mcp")
+        mock_tools.assert_called_once_with(user_id="user-1")
+        mock_graph.assert_called_once_with()
+
+    async def test_rejects_non_oauth_auth_mode(self):
+        with patch(
+            "deep_agent.aegra.mcp_oauth_handlers._get_mcp_server_config",
+            return_value={"enabled": True, "auth_mode": "sso"},
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await handle_mcp_disconnect("user-1", "sso-mcp")
+        assert exc.value.status_code == 400
+        assert "does not use OAuth" in exc.value.detail
+
+    async def test_rejects_client_credentials(self):
+        with patch(
+            "deep_agent.aegra.mcp_oauth_handlers._get_mcp_server_config",
+            return_value={
+                "enabled": True,
+                "auth_mode": "oauth",
+                "oauth": {"grant_type": "client_credentials"},
+            },
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await handle_mcp_disconnect("user-1", "cc-mcp")
+        assert exc.value.status_code == 400
+        assert "client_credentials" in exc.value.detail
 
 
 class TestCallbackHtml:

--- a/tests/unit/aegra/test_mcp_oauth_handlers.py
+++ b/tests/unit/aegra/test_mcp_oauth_handlers.py
@@ -614,6 +614,45 @@ class TestHandleMcpDisconnect:
         mock_tools.assert_called_once_with(user_id="user-1")
         mock_graph.assert_called_once_with()
 
+    async def test_disconnect_succeeds_when_graph_cache_invalidation_fails(self):
+        store = MagicMock()
+        store.delete_token = AsyncMock(return_value=True)
+        resolver = MagicMock()
+        resolver.invalidate_cache = MagicMock()
+        server_cfg = {
+            "enabled": True,
+            "auth_mode": "oauth",
+            "oauth": {"grant_type": "authorization_code"},
+        }
+
+        with (
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers._get_mcp_server_config",
+                return_value=server_cfg,
+            ),
+            patch("deep_agent.aegra.mcp_oauth_handlers.settings") as mock_settings,
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.McpTokenStore",
+                return_value=store,
+            ),
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.get_mcp_credential_resolver",
+                return_value=resolver,
+            ),
+            patch("deep_agent.aegra.mcp.invalidate_mcp_tool_cache"),
+            patch(
+                "deep_agent.aegra.graph.invalidate_graph_cache",
+                side_effect=RuntimeError("cache down"),
+            ),
+        ):
+            mock_settings.database_uri = "postgresql://test"
+            mock_settings.agent_deployment_id = "test-agent"
+            result = await handle_mcp_disconnect("user-1", "oauth-mcp")
+
+        assert result == {"mcp_name": "oauth-mcp", "connected": False}
+        store.delete_token.assert_awaited_once_with("test-agent", "user-1", "oauth-mcp")
+        resolver.invalidate_cache.assert_called_once_with("user-1", "oauth-mcp")
+
     async def test_rejects_non_oauth_auth_mode(self):
         with patch(
             "deep_agent.aegra.mcp_oauth_handlers._get_mcp_server_config",


### PR DESCRIPTION
## What

Add authenticated MCP OAuth connection list and disconnect so Settings can show per-user status and clear tokens without starting a chat.

Fixes #286

## How

- `GET /mcp/oauth/connections` returns enabled interactive OAuth/DCR MCPs for the current user (`mcp_name`, `auth_mode`, `description`, `connected`).
- `DELETE /mcp/{mcp_name}/disconnect` deletes stored tokens and invalidates credential, tool, and graph caches. Provider revocation is out of scope.
- Reuse the same filter as `GET /info`: `oauth`/`dcr`, enabled, skip `client_credentials`, omit DCR when `MCP_DCR_ENABLED=false`.
- Connect still uses the existing popup OAuth flow.

Companion UI PR: `redhat-data-and-ai/template-ui` branch `feat/settings-mcp-oauth-connections`.

## Testing

- [x] Unit tests added/updated
- [x] Ran locally (`uv run pytest tests/unit -x`)
- [x] Manual verification (describe below if applicable)
  - `GET /mcp/oauth/connections` lists only OAuth/DCR MCPs and reflects token presence
  - `DELETE /mcp/{name}/disconnect` clears the token; the next tool call requires auth
  - SSO and `client_credentials` MCPs are omitted

## Rollback

Revert the commit.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `ci:`, etc.)
- [x] No secrets, credentials, or PII in the diff
- [x] No breaking changes (or documented above with a migration path)
- [x] Pre-commit hooks pass (`uv run pre-commit run --all-files`)