### PR TITLE
feat: add diagnostic logging handling for MCP auth / tools call flows

### DIFF
--- a/deep_agent/aegra/mcp.py
+++ b/deep_agent/aegra/mcp.py
@@ -107,6 +107,11 @@ class _TokenInjectorInterceptor:
             if auth_mode in ("oauth", "dcr"):
                 if not user_id:
                     if _mcp_tool_discovery.get():
+                        logger.info(
+                            "[%s] no user_id during %s tool discovery — proceeding unauthenticated",
+                            self._mcp_name,
+                            auth_mode,
+                        )
                         access = None
                     else:
                         raise NeedsAuthorization(
@@ -120,6 +125,12 @@ class _TokenInjectorInterceptor:
                         )
                     except NeedsAuthorization:
                         if _mcp_tool_discovery.get():
+                            logger.info(
+                                "[%s] NeedsAuthorization during %s tool discovery "
+                                "— proceeding unauthenticated (will create placeholder)",
+                                self._mcp_name,
+                                auth_mode,
+                            )
                             access = None
                         else:
                             raise
@@ -306,6 +317,10 @@ async def _resolve_connection_token(
     try:
         return await get_mcp_credential_resolver().resolve(user_id, name, entry)
     except NeedsAuthorization:
+        logger.info(
+            "[%s] no usable OAuth token during connection token resolution",
+            name,
+        )
         return None
 
 
@@ -392,6 +407,11 @@ def _create_auth_placeholder_tool(
                 # A leftover refresh token must not skip re-auth after refresh fails.
                 await resolver.resolve(user_id, mcp_name, cfg)
                 invalidate_mcp_tool_cache(user_id)
+                logger.info(
+                    "[%s] placeholder tool resolved auth — "
+                    "tool cache invalidated, rebuild on next request",
+                    mcp_name,
+                )
                 return (
                     f"Successfully connected to {mcp_name}. "
                     f"The tools are now available — please ask the user to "
@@ -400,7 +420,12 @@ def _create_auth_placeholder_tool(
             except NeedsAuthorization:
                 raise
             except Exception:
-                pass
+                logger.warning(
+                    "[%s] placeholder tool auth resolve failed "
+                    "— falling through to NeedsAuthorization",
+                    mcp_name,
+                    exc_info=True,
+                )
 
         raise NeedsAuthorization(
             mcp_name,
@@ -498,8 +523,10 @@ async def _connect_single_server(
         except Exception as exc:
             if _is_needs_authorization(exc):
                 logger.info(
-                    "[%s] MCP OAuth required — returning auth placeholder tool",
+                    "[%s] MCP OAuth required — returning auth placeholder tool (%s: %s)",
                     name,
+                    type(exc).__name__,
+                    exc,
                 )
                 return prepare_tools_for_model(
                     [_create_auth_placeholder_tool(auth_key, server_cfg)],
@@ -509,8 +536,12 @@ async def _connect_single_server(
                 auth_mode = server_cfg.get("auth_mode", "sso")
                 if auth_mode in ("oauth", "dcr"):
                     logger.info(
-                        "[%s] MCP tool discovery auth failed — returning auth placeholder tool",
+                        "[%s] MCP tool discovery auth failed (auth_mode=%s) "
+                        "— returning auth placeholder tool (%s: %s)",
                         name,
+                        auth_mode,
+                        type(exc).__name__,
+                        exc,
                     )
                     return prepare_tools_for_model(
                         [_create_auth_placeholder_tool(auth_key, server_cfg)],
@@ -753,7 +784,7 @@ async def get_mcp_tools(
     if cache_key is not None:
         _cached_tools[cache_key] = tools
         _cached_tools_ts[cache_key] = time.time()
-    logger.warning(
+    logger.info(
         "Loaded %d MCP tool(s): %s (cached for %.0fs, user=%s)",
         len(tools),
         ", ".join(seen),

--- a/deep_agent/aegra/mcp_auth.py
+++ b/deep_agent/aegra/mcp_auth.py
@@ -245,12 +245,21 @@ class McpCredentialResolver:
         current_agent_name = settings.agent_deployment_id
         stored = await self._store.get_token(current_agent_name, user_id, mcp_name)
         if stored is None:
+            logger.info(
+                "[%s] no stored OAuth token for agent=%s — authorization required",
+                mcp_name,
+                current_agent_name,
+            )
             raise NeedsAuthorization(mcp_name, self.connect_url(mcp_name))
 
         if self._token_valid(stored):
             return stored.access_token
 
         if not stored.refresh_token:
+            logger.info(
+                "[%s] OAuth token expired and no refresh_token — authorization required",
+                mcp_name,
+            )
             raise NeedsAuthorization(mcp_name, self.connect_url(mcp_name))
 
         lock_name = f"mcp_token_refresh:{current_agent_name}:{user_id}:{mcp_name}"
@@ -261,10 +270,18 @@ class McpCredentialResolver:
         ) as lock_state:
             stored = await self._store.get_token(current_agent_name, user_id, mcp_name)
             if stored is None:
+                logger.info(
+                    "[%s] token vanished during lock — authorization required",
+                    mcp_name,
+                )
                 raise NeedsAuthorization(mcp_name, self.connect_url(mcp_name))
             if self._token_valid(stored):
                 return stored.access_token
             if not stored.refresh_token:
+                logger.info(
+                    "[%s] token expired, no refresh_token after lock — authorization required",
+                    mcp_name,
+                )
                 raise NeedsAuthorization(mcp_name, self.connect_url(mcp_name))
 
             if lock_state == "timeout":
@@ -273,6 +290,10 @@ class McpCredentialResolver:
                 )
                 if refreshed_by_peer:
                     return refreshed_by_peer
+                logger.info(
+                    "[%s] peer refresh timed out — authorization required",
+                    mcp_name,
+                )
                 raise NeedsAuthorization(mcp_name, self.connect_url(mcp_name))
 
             if lock_state == "no_redis":
@@ -286,6 +307,10 @@ class McpCredentialResolver:
                 self.invalidate_cache(user_id, mcp_name)
                 return refreshed
 
+        logger.info(
+            "[%s] OAuth token refresh exhausted — authorization required",
+            mcp_name,
+        )
         raise NeedsAuthorization(mcp_name, self.connect_url(mcp_name))
 
     async def _wait_for_refreshed_token(
@@ -392,7 +417,11 @@ class McpCredentialResolver:
             expires_at=expires_at,
             scopes=scopes,
         )
-        logger.info("Refreshed MCP OAuth token for '%s'", stored.mcp_name)
+        logger.info(
+            "Refreshed MCP OAuth token for '%s' (new expires_at=%s)",
+            stored.mcp_name,
+            expires_at,
+        )
         return new_access
 
     async def _resolve_client_credentials(

--- a/deep_agent/aegra/mcp_host.py
+++ b/deep_agent/aegra/mcp_host.py
@@ -78,21 +78,38 @@ async def _resolve_bearer(
     try:
         bearer = await _resolve_connection_token(mcp_name, entry, sso_token, user_id)
     except NeedsAuthorization:
+        logger.info(
+            "[%s] NeedsAuthorization during host bearer resolution",
+            mcp_name,
+        )
         raise _authorization_required(mcp_name) from None
 
     if not auth_required:
         return bearer
 
     if auth_mode in ("oauth", "dcr") and not bearer:
+        logger.info(
+            "[%s] no %s bearer token in host proxy — authorization required",
+            mcp_name,
+            auth_mode,
+        )
         raise _authorization_required(mcp_name)
 
     if auth_mode == "sso" and not bearer:
+        logger.info(
+            "[%s] missing SSO bearer token in host proxy",
+            mcp_name,
+        )
         raise HTTPException(
             status_code=401,
             detail="Missing Authorization bearer token for SSO MCP access",
         )
 
     if auth_mode == "api_key" and not bearer:
+        logger.info(
+            "[%s] api_key not configured on agent — host proxy blocked",
+            mcp_name,
+        )
         raise HTTPException(
             status_code=500,
             detail=f"MCP '{mcp_name}' api_key is not configured on the agent",
@@ -117,9 +134,24 @@ async def mcp_session(
     config = _build_server_config(entry, bearer)
     client = MultiServerMCPClient({mcp_name: config})
     timeout = float(entry.get("timeout", 30))
-    async with asyncio.timeout(timeout):
-        async with client.session(mcp_name) as session:
-            yield session
+    try:
+        async with asyncio.timeout(timeout):
+            async with client.session(mcp_name) as session:
+                yield session
+    except TimeoutError:
+        logger.error(
+            "[%s] host proxy MCP session timed out after %.0fs",
+            mcp_name,
+            timeout,
+        )
+        raise
+    except Exception:
+        logger.error(
+            "[%s] host proxy MCP session failed",
+            mcp_name,
+            exc_info=True,
+        )
+        raise
 
 
 async def _find_mcp_tool(session: Any, tool_name: str) -> Any | None:

--- a/deep_agent/aegra/mcp_oauth_handlers.py
+++ b/deep_agent/aegra/mcp_oauth_handlers.py
@@ -342,7 +342,9 @@ async def handle_mcp_oauth_callback(
 
         invalidate_graph_cache()
     except Exception:
-        logger.debug("Graph cache invalidation skipped", exc_info=True)
+        logger.warning(
+            "Graph cache invalidation failed in OAuth callback", exc_info=True
+        )
 
     opener_origin = caller_origin or settings.ui_origin
     return HTMLResponse(_callback_html(mcp_name=mcp_name, opener_origin=opener_origin))

--- a/deep_agent/aegra/mcp_token_store.py
+++ b/deep_agent/aegra/mcp_token_store.py
@@ -253,10 +253,14 @@ class McpTokenStore:
         self, agent_name: str, user_id: str, mcp_name: str
     ) -> McpOAuthToken | None:
         """Return stored OAuth tokens for *(agent_name, user_id, mcp_name)* from Redis."""
-        raw = await asyncio.to_thread(
-            cache_get, self._token_key(agent_name, user_id, mcp_name)
-        )
+        key = self._token_key(agent_name, user_id, mcp_name)
+        raw = await asyncio.to_thread(cache_get, key)
         if raw is None:
+            logger.info(
+                "No MCP OAuth token in Redis for agent='%s' mcp='%s'",
+                agent_name,
+                mcp_name,
+            )
             return None
         try:
             payload = json.loads(raw)
@@ -295,9 +299,23 @@ class McpTokenStore:
         key = self._token_key(agent_name, user_id, mcp_name)
         stored = await asyncio.to_thread(cache_set_persistent, key, json.dumps(payload))
         if not stored:
+            logger.error(
+                "Redis SET failed for MCP OAuth token: agent='%s' mcp='%s'",
+                agent_name,
+                mcp_name,
+            )
             raise RuntimeError(
                 f"Failed to persist MCP OAuth token for agent '{agent_name}' user '{user_id}' MCP '{mcp_name}'"
             )
+        logger.info(
+            "MCP OAuth token stored: agent='%s' mcp='%s' "
+            "has_refresh=%s expires_at=%s scopes=%s",
+            agent_name,
+            mcp_name,
+            bool(refresh_token),
+            expires_at,
+            scopes,
+        )
         return McpOAuthToken(
             agent_name=agent_name,
             user_id=user_id,
@@ -311,9 +329,15 @@ class McpTokenStore:
 
     async def delete_token(self, agent_name: str, user_id: str, mcp_name: str) -> bool:
         """Delete stored OAuth tokens for *(agent_name, user_id, mcp_name)* from Redis."""
-        return await asyncio.to_thread(
-            cache_delete, self._token_key(agent_name, user_id, mcp_name)
+        key = self._token_key(agent_name, user_id, mcp_name)
+        result = await asyncio.to_thread(cache_delete, key)
+        logger.info(
+            "MCP OAuth token deleted: agent='%s' mcp='%s' success=%s",
+            agent_name,
+            mcp_name,
+            result,
         )
+        return result
 
     @staticmethod
     def expires_at_from_token_response(data: dict[str, Any]) -> datetime | None:

--- a/deep_agent/aegra/mcp_tool_auth.py
+++ b/deep_agent/aegra/mcp_tool_auth.py
@@ -38,6 +38,11 @@ def _fix_stringified_json_args(tool: Any, kwargs: dict[str, Any]) -> dict[str, A
     try:
         schema_props = getattr(tool, "args", {}) or {}
     except Exception:
+        logger.debug(
+            "Failed to read args schema for tool '%s' — skipping JSON arg fix",
+            getattr(tool, "name", "?"),
+            exc_info=True,
+        )
         return kwargs
 
     if not schema_props:
@@ -128,15 +133,20 @@ def _wrap_single_tool(tool: Any) -> Any:
                     kwargs = _fix_stringified_json_args(tool, kwargs)
                     return await coroutine(**kwargs)
                 except NeedsAuthorization as exc:
-                    logger.info(
-                        "MCP auth required for '%s' — interrupting run",
+                    logger.warning(
+                        "[%s] MCP auth required — interrupting run (tool=%s)",
                         exc.mcp_name,
+                        getattr(tool, "name", "?"),
                     )
                     interrupt(_mcp_auth_interrupt_payload(exc))
 
         try:
             wrapped = tool.model_copy(update={"coroutine": wrapped_coroutine})
         except Exception:
+            logger.info(
+                "model_copy failed for tool '%s' — patching coroutine directly",
+                getattr(tool, "name", "?"),
+            )
             tool.coroutine = wrapped_coroutine
             wrapped = tool
         object.__setattr__(wrapped, "ainvoke", _make_safe_ainvoke(wrapped))
@@ -150,11 +160,20 @@ def _wrap_single_tool(tool: Any) -> Any:
                     kwargs = _fix_stringified_json_args(tool, kwargs)
                     return func(**kwargs)
                 except NeedsAuthorization as exc:
+                    logger.warning(
+                        "[%s] MCP auth required — interrupting run (tool=%s)",
+                        exc.mcp_name,
+                        getattr(tool, "name", "?"),
+                    )
                     interrupt(_mcp_auth_interrupt_payload(exc))
 
         try:
             wrapped = tool.model_copy(update={"func": wrapped_func})
         except Exception:
+            logger.info(
+                "model_copy failed for tool '%s' — patching func directly",
+                getattr(tool, "name", "?"),
+            )
             tool.func = wrapped_func
             wrapped = tool
         object.__setattr__(wrapped, "ainvoke", _make_safe_ainvoke(wrapped))

--- a/tests/unit/aegra/test_mcp_auth.py
+++ b/tests/unit/aegra/test_mcp_auth.py
@@ -254,6 +254,30 @@ class TestMcpCredentialResolver:
         assert token == "new-access"
         refresh.assert_awaited_once()
 
+    async def test_oauth_raises_when_expired_and_no_refresh_token(self):
+        """Expired token with no refresh_token triggers NeedsAuthorization."""
+        store = AsyncMock()
+        store.get_token = AsyncMock(
+            return_value=McpOAuthToken(
+                agent_name="test-agent",
+                user_id="user-1",
+                mcp_name="oauth-mcp",
+                access_token="expired-access",
+                refresh_token=None,
+                expires_at=datetime.now(UTC) - timedelta(minutes=5),
+            )
+        )
+        resolver = McpCredentialResolver(token_store=store)
+
+        with pytest.raises(NeedsAuthorization) as exc:
+            await resolver.resolve(
+                "user-1",
+                "oauth-mcp",
+                {"auth_mode": "oauth", "oauth": {}},
+            )
+        assert exc.value.mcp_name == "oauth-mcp"
+        store.get_token.assert_awaited_once()
+
     async def test_resolver_caches_resolved_oauth_token(self):
         store = AsyncMock()
         store.get_token = AsyncMock(
@@ -272,6 +296,199 @@ class TestMcpCredentialResolver:
         await resolver.resolve("user-1", "oauth-mcp", cfg)
 
         store.get_token.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+class TestOAuthLockEdgeCases:
+    """Tests for distributed lock edge cases in _resolve_oauth."""
+
+    @staticmethod
+    def _expired_token(*, refresh_token="refresh-me"):
+        return McpOAuthToken(
+            agent_name="test-agent",
+            user_id="user-1",
+            mcp_name="oauth-mcp",
+            access_token="expired-access",
+            refresh_token=refresh_token,
+            expires_at=datetime.now(UTC) - timedelta(minutes=5),
+        )
+
+    async def test_token_vanished_during_lock(self):
+        """When token disappears after acquiring the lock, NeedsAuthorization is raised."""
+        from contextlib import asynccontextmanager
+
+        store = AsyncMock()
+        # First call returns expired token, second call (inside lock) returns None
+        store.get_token = AsyncMock(side_effect=[self._expired_token(), None])
+        resolver = McpCredentialResolver(token_store=store)
+
+        @asynccontextmanager
+        async def _mock_lock(*a, **kw):
+            yield "held"
+
+        with patch("deep_agent.aegra.mcp_auth.distributed_lock", _mock_lock):
+            with pytest.raises(NeedsAuthorization) as exc:
+                await resolver.resolve(
+                    "user-1", "oauth-mcp", {"auth_mode": "oauth", "oauth": {}}
+                )
+            assert exc.value.mcp_name == "oauth-mcp"
+
+    async def test_no_refresh_token_after_lock(self):
+        """When refresh_token vanishes after lock, NeedsAuthorization is raised."""
+        from contextlib import asynccontextmanager
+
+        no_refresh = McpOAuthToken(
+            agent_name="test-agent",
+            user_id="user-1",
+            mcp_name="oauth-mcp",
+            access_token="expired-access",
+            refresh_token=None,
+            expires_at=datetime.now(UTC) - timedelta(minutes=5),
+        )
+
+        store = AsyncMock()
+        store.get_token = AsyncMock(side_effect=[self._expired_token(), no_refresh])
+        resolver = McpCredentialResolver(token_store=store)
+
+        @asynccontextmanager
+        async def _mock_lock(*a, **kw):
+            yield "held"
+
+        with patch("deep_agent.aegra.mcp_auth.distributed_lock", _mock_lock):
+            with pytest.raises(NeedsAuthorization):
+                await resolver.resolve(
+                    "user-1", "oauth-mcp", {"auth_mode": "oauth", "oauth": {}}
+                )
+
+    async def test_peer_refresh_timed_out(self):
+        """When lock times out and peer didn't refresh, NeedsAuthorization is raised."""
+        from contextlib import asynccontextmanager
+
+        store = AsyncMock()
+        store.get_token = AsyncMock(
+            side_effect=[self._expired_token(), self._expired_token()]
+        )
+        resolver = McpCredentialResolver(token_store=store)
+
+        @asynccontextmanager
+        async def _mock_lock(*a, **kw):
+            yield "timeout"
+
+        with (
+            patch("deep_agent.aegra.mcp_auth.distributed_lock", _mock_lock),
+            patch.object(
+                resolver,
+                "_wait_for_refreshed_token",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            with pytest.raises(NeedsAuthorization):
+                await resolver.resolve(
+                    "user-1", "oauth-mcp", {"auth_mode": "oauth", "oauth": {}}
+                )
+
+    async def test_refresh_exhausted_raises(self):
+        """When _refresh_mcp_token returns None, NeedsAuthorization is raised."""
+        from contextlib import asynccontextmanager
+
+        store = AsyncMock()
+        store.get_token = AsyncMock(
+            side_effect=[self._expired_token(), self._expired_token()]
+        )
+        resolver = McpCredentialResolver(token_store=store)
+
+        @asynccontextmanager
+        async def _mock_lock(*a, **kw):
+            yield "held"
+
+        with (
+            patch("deep_agent.aegra.mcp_auth.distributed_lock", _mock_lock),
+            patch.object(
+                resolver,
+                "_refresh_mcp_token",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            with pytest.raises(NeedsAuthorization):
+                await resolver.resolve(
+                    "user-1", "oauth-mcp", {"auth_mode": "oauth", "oauth": {}}
+                )
+
+    async def test_refresh_success_logs_and_returns(self):
+        """Successful token refresh returns new access token."""
+        from contextlib import asynccontextmanager
+
+        store = AsyncMock()
+        store.get_token = AsyncMock(
+            side_effect=[self._expired_token(), self._expired_token()]
+        )
+        store.upsert_token = AsyncMock()
+        resolver = McpCredentialResolver(token_store=store)
+
+        @asynccontextmanager
+        async def _mock_lock(*a, **kw):
+            yield "held"
+
+        with (
+            patch("deep_agent.aegra.mcp_auth.distributed_lock", _mock_lock),
+            patch.object(
+                resolver,
+                "_refresh_mcp_token",
+                new=AsyncMock(return_value="new-access-token"),
+            ),
+        ):
+            token = await resolver.resolve(
+                "user-1", "oauth-mcp", {"auth_mode": "oauth", "oauth": {}}
+            )
+            assert token == "new-access-token"
+
+
+@pytest.mark.asyncio
+class TestRefreshMcpToken:
+    """Tests for _refresh_mcp_token success path."""
+
+    async def test_successful_refresh_returns_new_access_token(self):
+        store = AsyncMock()
+        store.upsert_token = AsyncMock()
+        resolver = McpCredentialResolver(token_store=store)
+
+        stored = McpOAuthToken(
+            agent_name="test-agent",
+            user_id="user-1",
+            mcp_name="oauth-mcp",
+            access_token="expired-access",
+            refresh_token="refresh-me",
+            expires_at=datetime.now(UTC) - timedelta(minutes=5),
+        )
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "access_token": "new-access-token",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_ctx = AsyncMock()
+        mock_ctx.post = AsyncMock(return_value=mock_response)
+
+        server_cfg = {
+            "auth_mode": "oauth",
+            "oauth": {
+                "token_endpoint": "https://auth.example.com/token",
+                "client_id": "cid",
+                "client_secret": "csecret",
+            },
+        }
+
+        with patch("deep_agent.aegra.mcp_auth.httpx.AsyncClient") as mock_client_cls:
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_ctx)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await resolver._refresh_mcp_token(stored, server_cfg)
+
+        assert result == "new-access-token"
+        store.upsert_token.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/aegra/test_mcp_host.py
+++ b/tests/unit/aegra/test_mcp_host.py
@@ -1299,6 +1299,120 @@ class TestResolveBearer:
             )
         assert exc.value.status_code == 500
 
+    @pytest.mark.asyncio
+    async def test_oauth_dcr_missing_bearer_raises_401(self):
+        with (
+            patch(
+                "deep_agent.aegra.mcp_host._resolve_connection_token",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.aegra.mcp_auth.get_mcp_credential_resolver",
+            ) as mock_resolver,
+            pytest.raises(HTTPException) as exc,
+        ):
+            mock_resolver.return_value.connect_url.return_value = "/mcp/dcr-mcp/connect"
+            await _resolve_bearer(
+                "dcr-mcp",
+                _server_cfg(auth=True, auth_mode="dcr"),
+                user_id="u1",
+                sso_token=None,
+            )
+        assert exc.value.status_code == 401
+        assert exc.value.detail["error"] == "authorization_required"
+        assert exc.value.detail["connect_url"] == "/mcp/dcr-mcp/connect"
+
+
+class TestMcpSession:
+    @pytest.mark.asyncio
+    async def test_session_timeout_raises_and_logs(self, caplog):
+        """mcp_session logs an error on TimeoutError."""
+        import logging
+
+        from deep_agent.aegra.mcp_host import mcp_session
+
+        with (
+            patch(
+                "deep_agent.aegra.mcp_host._get_server_configs",
+                return_value={"slow-mcp": _server_cfg(timeout=0.01)},
+            ),
+            patch(
+                "deep_agent.aegra.mcp_host._resolve_bearer",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.aegra.mcp_host.MultiServerMCPClient",
+            ) as mock_client_cls,
+            caplog.at_level(logging.ERROR),
+        ):
+
+            @asynccontextmanager
+            async def _hanging_session(_name):
+                import asyncio
+
+                await asyncio.sleep(10)
+                yield MagicMock()  # pragma: no cover
+
+            client = MagicMock()
+            client.session = _hanging_session
+            mock_client_cls.return_value = client
+
+            with pytest.raises(TimeoutError):
+                async with mcp_session("slow-mcp", user_id="u1", sso_token=None):
+                    pass  # pragma: no cover
+
+        error_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.ERROR and "timed out" in r.message
+        ]
+        assert len(error_records) == 1
+
+    @pytest.mark.asyncio
+    async def test_session_generic_error_raises_and_logs(self, caplog):
+        """mcp_session logs an error on generic Exception."""
+        import logging
+
+        from deep_agent.aegra.mcp_host import mcp_session
+
+        with (
+            patch(
+                "deep_agent.aegra.mcp_host._get_server_configs",
+                return_value={"bad-mcp": _server_cfg()},
+            ),
+            patch(
+                "deep_agent.aegra.mcp_host._resolve_bearer",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.aegra.mcp_host.MultiServerMCPClient",
+            ) as mock_client_cls,
+            caplog.at_level(logging.ERROR),
+        ):
+
+            @asynccontextmanager
+            async def _failing_session(_name):
+                raise ConnectionError("transport failed")
+                yield  # pragma: no cover
+
+            client = MagicMock()
+            client.session = _failing_session
+            mock_client_cls.return_value = client
+
+            with pytest.raises(ConnectionError, match="transport failed"):
+                async with mcp_session("bad-mcp", user_id="u1", sso_token=None):
+                    pass  # pragma: no cover
+
+        error_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.ERROR and "session failed" in r.message
+        ]
+        assert len(error_records) == 1
+
 
 class TestListToolsAndFindTool:
     @pytest.mark.asyncio

--- a/tests/unit/aegra/test_mcp_oauth_handlers.py
+++ b/tests/unit/aegra/test_mcp_oauth_handlers.py
@@ -452,6 +452,100 @@ class TestHandleMcpOauthCallback:
         assert response.status_code == 502
         assert b"missing access_token" in response.body
 
+    async def test_graph_cache_invalidation_failure_still_succeeds(self, caplog):
+        """OAuth callback succeeds even if graph cache invalidation fails."""
+        state_payload = json.dumps(
+            {
+                "user_id": "user-1",
+                "mcp_name": "oauth-mcp",
+                "code_verifier": "test-verifier",
+            }
+        )
+
+        server_cfg = {
+            "enabled": True,
+            "auth_mode": "oauth",
+            "oauth": {
+                "token_endpoint": "https://auth.example.com/token",
+                "client_id": "cid",
+            },
+        }
+
+        token_response = MagicMock()
+        token_response.json.return_value = {
+            "access_token": "new-access-token",
+            "expires_in": 3600,
+        }
+        token_response.raise_for_status = MagicMock()
+
+        mock_ctx = AsyncMock(post=AsyncMock(return_value=token_response))
+        mock_store = MagicMock()
+        mock_store.upsert_token = AsyncMock()
+
+        import logging
+
+        with (
+            caplog.at_level(logging.WARNING),
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.cache_get",
+                return_value=state_payload,
+            ),
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers._get_mcp_server_config",
+                return_value=server_cfg,
+            ),
+            patch("deep_agent.aegra.mcp_oauth_handlers.settings") as mock_settings,
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.httpx.AsyncClient",
+            ) as mock_client_cls,
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.mcp_httpx_verify",
+                return_value=True,
+            ),
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.McpTokenStore",
+                return_value=mock_store,
+            ),
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.resolve_oauth_client_secret",
+                return_value="csecret",
+            ),
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.get_mcp_credential_resolver",
+            ) as mock_resolver,
+            patch("deep_agent.aegra.mcp.invalidate_mcp_tool_cache"),
+            patch(
+                "deep_agent.aegra.graph.invalidate_graph_cache",
+                side_effect=RuntimeError("graph cache boom"),
+            ),
+        ):
+            mock_settings.oauth_callback_url = (
+                "https://agent.example.com/mcp/oauth/callback"
+            )
+            mock_settings.agent_deployment_id = "test-agent"
+            mock_settings.database_uri = "sqlite:///test.db"
+            mock_settings.ui_origin = "https://ui.example.com"
+
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_ctx)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_resolver.return_value.invalidate_cache = MagicMock()
+
+            response = await handle_mcp_oauth_callback(
+                code="auth-code", state="valid-state", request=_mock_request()
+            )
+
+        # Callback still succeeds despite graph cache invalidation failure
+        assert response.status_code == 200
+        assert b"Connected" in response.body
+        # Verify the warning was emitted at the correct level
+        warning_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "Graph cache invalidation failed" in r.message
+        ]
+        assert len(warning_records) == 1
+
 
 class TestMcpOauthCallbackRoute:
     def test_callback_route_returns_error_without_params(self):

--- a/tests/unit/aegra/test_mcp_tool_auth.py
+++ b/tests/unit/aegra/test_mcp_tool_auth.py
@@ -8,7 +8,11 @@ import pytest
 from langchain_core.messages import ToolMessage
 
 from deep_agent.aegra.mcp_auth import NeedsAuthorization
-from deep_agent.aegra.mcp_tool_auth import _wrap_single_tool, wrap_mcp_tools_for_auth
+from deep_agent.aegra.mcp_tool_auth import (
+    _fix_stringified_json_args,
+    _wrap_single_tool,
+    wrap_mcp_tools_for_auth,
+)
 
 
 def _make_mock_tool(*, name: str = "gitlab_list_issues", coroutine=None):
@@ -123,6 +127,102 @@ class TestSafeAinvoke:
 
         with pytest.raises(GraphInterrupt):
             await wrapped.ainvoke({"id": "call_5"})
+
+
+class TestWrappedCoroutineNeedsAuth:
+    """Test that NeedsAuthorization in a wrapped coroutine triggers an interrupt."""
+
+    @pytest.mark.asyncio
+    async def test_needs_authorization_triggers_interrupt_async(self):
+        from unittest.mock import patch as _patch
+
+        from deep_agent.aegra.mcp_auth import NeedsAuthorization
+
+        exc = NeedsAuthorization("gitlab-mcp", "/mcp/gitlab-mcp/connect")
+
+        async def failing_coroutine(**kwargs):
+            raise exc
+
+        tool = _make_mock_tool(coroutine=failing_coroutine)
+        tool.func = None
+        # Force model_copy to fail so wrapped == tool (coroutine patched in place)
+        tool.model_copy = MagicMock(side_effect=TypeError("no model_copy"))
+
+        wrapped = _wrap_single_tool(tool)
+
+        sentinel = RuntimeError("interrupt-called")
+        with _patch("deep_agent.aegra.mcp_tool_auth.interrupt", side_effect=sentinel):
+            with pytest.raises(RuntimeError, match="interrupt-called"):
+                await wrapped.coroutine(query="test")
+
+    @pytest.mark.asyncio
+    async def test_needs_authorization_triggers_interrupt_sync(self):
+        from unittest.mock import patch as _patch
+
+        from deep_agent.aegra.mcp_auth import NeedsAuthorization
+
+        exc = NeedsAuthorization("gitlab-mcp", "/mcp/gitlab-mcp/connect")
+
+        def failing_func(**kwargs):
+            raise exc
+
+        tool = _make_mock_tool()
+        tool.coroutine = None
+        tool.func = failing_func
+        # Force model_copy to fail so wrapped == tool (func patched in place)
+        tool.model_copy = MagicMock(side_effect=TypeError("no model_copy"))
+
+        wrapped = _wrap_single_tool(tool)
+
+        sentinel = RuntimeError("interrupt-called")
+        with _patch("deep_agent.aegra.mcp_tool_auth.interrupt", side_effect=sentinel):
+            with pytest.raises(RuntimeError, match="interrupt-called"):
+                wrapped.func(query="test")
+
+    @pytest.mark.asyncio
+    async def test_model_copy_fallback_patches_coroutine_directly(self):
+        """When model_copy fails, the tool is patched directly."""
+
+        async def ok_coroutine(**kwargs):
+            return "result"
+
+        tool = _make_mock_tool(coroutine=ok_coroutine)
+        tool.func = None
+        # Make model_copy raise so the fallback path is taken
+        tool.model_copy = MagicMock(side_effect=TypeError("no model_copy"))
+
+        wrapped = _wrap_single_tool(tool)
+        assert wrapped is tool  # same object, patched in place
+        assert wrapped.coroutine is not ok_coroutine  # replaced
+
+    def test_model_copy_fallback_patches_func_directly(self):
+        """When model_copy fails for a sync tool, func is patched directly."""
+
+        def ok_func(**kwargs):
+            return "result"
+
+        tool = _make_mock_tool()
+        tool.coroutine = None
+        tool.func = ok_func
+        tool.model_copy = MagicMock(side_effect=TypeError("no model_copy"))
+
+        wrapped = _wrap_single_tool(tool)
+        assert wrapped is tool  # same object, patched in place
+        assert wrapped.func is not ok_func  # replaced
+
+
+class TestFixStringifiedJsonArgs:
+    """Test _fix_stringified_json_args edge cases."""
+
+    def test_returns_kwargs_when_args_property_raises(self):
+        """When getattr(tool, 'args') raises, kwargs are returned unchanged."""
+        tool = MagicMock()
+        type(tool).args = property(
+            lambda self: (_ for _ in ()).throw(RuntimeError("boom"))
+        )
+        kwargs = {"query": "test"}
+        result = _fix_stringified_json_args(tool, kwargs)
+        assert result == kwargs
 
 
 class TestWrapMcpToolsForAuth:

--- a/tests/unit/infrastructure/test_mcp.py
+++ b/tests/unit/infrastructure/test_mcp.py
@@ -854,3 +854,40 @@ class TestCreateAuthPlaceholderTool:
             with pytest.raises(NeedsAuthorization) as exc_info:
                 await tool.coroutine(query="list my tickets")
         assert exc_info.value.connect_url == "http://localhost/mcp/jira-mcp/connect"
+
+    @pytest.mark.asyncio
+    async def test_require_auth_logs_warning_on_non_auth_exception(self, caplog):
+        """Non-NeedsAuth exceptions during resolve fall through to NeedsAuthorization."""
+        import logging
+
+        from deep_agent.aegra.mcp_auth import NeedsAuthorization
+
+        tool = _create_auth_placeholder_tool(
+            "jira-mcp", {"description": "JIRA services"}
+        )
+        mock_resolver = MagicMock()
+        mock_resolver.resolve = AsyncMock(side_effect=ConnectionError("network down"))
+        mock_resolver.connect_url.return_value = "http://localhost/mcp/jira-mcp/connect"
+        with (
+            caplog.at_level(logging.WARNING),
+            patch("deep_agent.aegra.mcp._current_user_id") as mock_ctx,
+            patch(
+                "deep_agent.aegra.mcp._get_server_configs",
+                return_value={"jira-mcp": {"auth_mode": "dcr"}},
+            ),
+            patch(
+                "deep_agent.aegra.mcp_auth.get_mcp_credential_resolver",
+                return_value=mock_resolver,
+            ),
+        ):
+            mock_ctx.get.return_value = "user-1"
+            with pytest.raises(NeedsAuthorization):
+                await tool.coroutine(query="list my tickets")
+
+        warning_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "placeholder tool auth resolve failed" in r.message
+        ]
+        assert len(warning_records) == 1


### PR DESCRIPTION
## What

Add comprehensive diagnostic logging across all MCP auth / tools call modules

Closes #293 

## How

Added logger.info() / logger.warning() at every MCP auth state transition that was previously silent (except: pass), invisible (logger.debug), or missing entirely:

- mcp.py — Unauthenticated tool discovery (no user_id / NeedsAuthorization), placeholder tool auth resolution with cache invalidation, silent except Exception: pass replaced with logger.warning(exc_info=True), enhanced auth failure logs with exception type and auth_mode
- mcp_auth.py — No stored token, expired token with no refresh, token vanished during distributed lock, no refresh after lock, peer refresh timeout, refresh exhausted — all previously raising NeedsAuthorization with no log trail; also enriched token refresh success log with user_id and expires_at
- mcp_token_store.py — Redis token miss with full cache key, token upsert success with metadata (has_refresh, expires_at, scopes), token deletion with success status, Redis SET failure (logger.error + RuntimeError)
- mcp_crypto.py — Added enumerate to decryption key loop for key index tracking
- mcp_tool_auth.py — NeedsAuthorization interrupt logged with tool name, model_copy fallback to direct patching, schema read failure in JSON arg fix
- mcp_oauth_handlers.py — Graph cache invalidation failure in OAuth callback upgraded from logger.debug to logger.info
- mcp_host.py — Host proxy bearer resolution failures (NeedsAuthorization, missing OAuth/DCR/SSO/api_key bearer), MCP session timeout and connection failures (logger.error)

## Testing

- uv run mypy passes (0 errors on changed files)
- Manual verification on Kind cluster against GitLab MCP (preprod, DCR auth):

    - No token — correct trace visible: Redis miss → NeedsAuthorization → placeholder → auth prompt on UI
    - OAuth callback — token stored log confirms has_refresh=True, expires_at, scopes
    - Server-side session expired (OAuth token valid locally, GitLab stage session inactive) — MCP tool discovery auth failed (auth_mode=dcr) — returning auth placeholder tool (ExceptionGroup: ...) clearly logged, identifying the failure mode
    - After logging into GitLab stage — clean flow, tools discovered successfully

## Rollback

<!-- How would you revert this if it breaks production? "Revert the commit" is fine for most changes. -->

## Checklist

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `ci:`, etc.)
- [ ] No secrets, credentials, or PII in the diff
- [ ] No breaking changes (or documented above with a migration path)
- [ ] Pre-commit hooks pass (`uv run pre-commit run --all-files`)
