### PR TITLE
fix(pylogger): restore INFO-level log visibility by preserving root handler.

### DIFF
--- a/deep_agent/utils/pylogger.py
+++ b/deep_agent/utils/pylogger.py
@@ -198,7 +198,6 @@ def _setup_logger(logger_name: str, level: str) -> None:
 
 def _configure_third_party_loggers(log_level: str) -> None:
     """Apply structured logging to selected third-party loggers."""
-    logging.getLogger().handlers.clear()
     for name in THIRD_PARTY_LOGGERS:
         _setup_logger(name, log_level)
 
@@ -261,79 +260,3 @@ def get_python_logger(log_level: str = "INFO") -> structlog.BoundLogger:
 
     _configure_third_party_loggers(log_level)
     return structlog.get_logger()
-
-
-def get_uvicorn_log_config(log_level: str = "INFO") -> dict[str, Any]:
-    """Return a Uvicorn-compatible logging config that integrates with structlog."""
-    log_level = log_level.upper()
-    renderer = _get_renderer()
-
-    default_formatter = {
-        "()": "structlog.stdlib.ProcessorFormatter",
-        "processor": renderer,
-        "foreign_pre_chain": [
-            structlog.stdlib.add_log_level,
-            structlog.processors.TimeStamper(fmt="iso"),
-            _inject_request_context,
-            structlog.processors.StackInfoRenderer(),
-            structlog.processors.format_exc_info,
-            structlog.processors.UnicodeDecoder(),
-        ],
-    }
-
-    def make_logger_config(names: list[str], level: str) -> dict[str, Any]:
-        return {
-            name: {
-                "handlers": ["default"],
-                "level": level,
-                "propagate": False,
-            }
-            for name in names
-        }
-
-    passthrough_formatter = {"format": "%(message)s"}
-
-    uvicorn_loggers = ["uvicorn", "uvicorn.error", "uvicorn.asgi", "uvicorn.protocols"]
-    access_loggers = ["uvicorn.access"]
-
-    return {
-        "version": 1,
-        "disable_existing_loggers": False,
-        "formatters": {
-            "default": default_formatter,
-            "access": default_formatter,
-            "passthrough": passthrough_formatter,
-        },
-        "handlers": {
-            "default": {
-                "formatter": "default",
-                "class": "logging.StreamHandler",
-                "stream": "ext://sys.stdout",
-            },
-            "access": {
-                "formatter": "access",
-                "class": "logging.StreamHandler",
-                "stream": "ext://sys.stdout",
-            },
-            "passthrough": {
-                "formatter": "passthrough",
-                "class": "logging.StreamHandler",
-                "stream": "ext://sys.stdout",
-            },
-        },
-        "loggers": {
-            "": {
-                "handlers": ["passthrough"],
-                "level": log_level,
-                "propagate": False,
-            },
-            **make_logger_config(uvicorn_loggers, log_level),
-            **make_logger_config(access_loggers, log_level),
-            **make_logger_config(
-                list(THIRD_PARTY_LOGGERS - ERROR_ONLY_LOGGERS - SILENT_LOGGERS),
-                log_level,
-            ),
-            **make_logger_config(list(ERROR_ONLY_LOGGERS), "ERROR"),
-            **make_logger_config(list(SILENT_LOGGERS), "CRITICAL"),
-        },
-    }

--- a/tests/unit/test_pylogger.py
+++ b/tests/unit/test_pylogger.py
@@ -8,7 +8,6 @@ from deep_agent.utils.pylogger import (
     clear_request_context,
     force_reconfigure_all_loggers,
     get_python_logger,
-    get_uvicorn_log_config,
 )
 
 
@@ -87,16 +86,3 @@ class TestConsoleRenderer:
 
             renderer = _get_renderer()
             assert "Console" in type(renderer).__name__
-
-
-class TestUvicornLogConfig:
-    def test_returns_valid_config(self):
-        config = get_uvicorn_log_config("INFO")
-        assert config["version"] == 1
-        assert "formatters" in config
-        assert "handlers" in config
-        assert "loggers" in config
-
-    def test_respects_log_level(self):
-        config = get_uvicorn_log_config("DEBUG")
-        assert config["loggers"][""]["level"] == "DEBUG"


### PR DESCRIPTION
## What

- Fix: _configure_third_party_loggers() was calling logging.getLogger().handlers.clear() which destroyed the root logger's StreamHandler. Without any handlers, Python's built-in lastResort handler (hardcoded at WARNING) took over, silently dropping all INFO and DEBUG structlog messages across every module.
- Cleanup: Removes get_uvicorn_log_config() — dead code not imported by any production module — and its corresponding tests.

Closes #295 

## How

_configure_third_party_loggers() is called every time get_python_logger() runs (once per module import). It was intended to suppress noisy third-party loggers, but the first line wiped the root handler that logging.basicConfig() had set up. With no root handler, log events from deep_agent.* modules had nowhere to go — Python's lastResort caught WARNING+ on stderr, but INFO was silently discarded.

## Testing

- Verified locally: INFO-level structlog messages from deep_agent.aegra.mcp, mcp_auth, mcp_token_store now visible in pod logs
-  WARNING and ERROR logs continue to work as before
-  Third-party logger suppression (httpx, httpcore, etc.) still functions correctly
-  Existing unit tests pass (pytest tests/unit/test_pylogger.py)

## Rollback

<!-- How would you revert this if it breaks production? "Revert the commit" is fine for most changes. -->

## Checklist

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `ci:`, etc.)
- [ ] No secrets, credentials, or PII in the diff
- [ ] No breaking changes (or documented above with a migration path)
- [ ] Pre-commit hooks pass (`uv run pre-commit run --all-files`)
