### PR TITLE
fix: dataset empty incorrect status code

### DIFF
--- a/deep_agent/aegra/eval_routes.py
+++ b/deep_agent/aegra/eval_routes.py
@@ -1362,7 +1362,7 @@ async def get_dataset() -> dict[str, Any]:
         result = await row.fetchone()
 
     if not result:
-        raise HTTPException(status_code=404, detail="no dataset found")
+        return {"dataset": {"test_cases": []}, "judge_model": None, "created_at": None}
 
     dataset, judge_model, created_at = result
     if isinstance(dataset, str):

--- a/deep_agent/aegra/eval_routes.py
+++ b/deep_agent/aegra/eval_routes.py
@@ -1351,8 +1351,6 @@ async def upsert_dataset(body: DatasetUpsertRequest) -> dict[str, Any]:
 @eval_mgmt_router.get("/dataset")
 async def get_dataset() -> dict[str, Any]:
     """Return the stored eval dataset for this agent."""
-    from fastapi import HTTPException
-
     await _ensure_datasets_table_once()
 
     async with await _pg_conn() as conn:

--- a/deep_agent/aegra/eval_routes.py
+++ b/deep_agent/aegra/eval_routes.py
@@ -1360,7 +1360,7 @@ async def get_dataset() -> dict[str, Any]:
         result = await row.fetchone()
 
     if not result:
-        return {"dataset": {"test_cases": []}, "judge_model": None, "created_at": None}
+        return {"dataset": {"cases": []}, "judge_model": None, "created_at": None}
 
     dataset, judge_model, created_at = result
     if isinstance(dataset, str):

--- a/tests/unit/aegra/test_eval_routes.py
+++ b/tests/unit/aegra/test_eval_routes.py
@@ -1745,7 +1745,7 @@ class TestGetDataset:
         ):
             result = await er.get_dataset()
         assert result == {
-            "dataset": {"test_cases": []},
+            "dataset": {"cases": []},
             "judge_model": None,
             "created_at": None,
         }

--- a/tests/unit/aegra/test_eval_routes.py
+++ b/tests/unit/aegra/test_eval_routes.py
@@ -1736,18 +1736,19 @@ class TestGetDataset:
         assert result["judge_model"] == "gpt-4"
         er._datasets_table_ensured = False
 
-    async def test_404_when_no_dataset(self):
-        from fastapi import HTTPException
-
+    async def test_empty_dataset_returns_default(self):
         er._datasets_table_ensured = True
         cursor = _make_cursor(rows=[])
         conn, _ = _make_conn(cursor)
         with patch(
             "deep_agent.aegra.eval_routes._pg_conn", AsyncMock(return_value=conn)
         ):
-            with pytest.raises(HTTPException) as exc:
-                await er.get_dataset()
-        assert exc.value.status_code == 404
+            result = await er.get_dataset()
+        assert result == {
+            "dataset": {"test_cases": []},
+            "judge_model": None,
+            "created_at": None,
+        }
         er._datasets_table_ensured = False
 
     async def test_parses_string_dataset(self):


### PR DESCRIPTION
## What

Return an empty dataset response instead of a 404 error when no evaluation dataset exists yet.

Fixes #

## How

Changed get_dataset() in eval_routes.py to return a default empty response ({"dataset": {"test_cases": []}, "judge_model": None, "created_at": None}) instead of raising an HTTPException(404) when no dataset is found. A missing dataset is a valid initial state, not an error — the frontend should receive an empty structure it can render rather than a 404 it must handle as a failure.

## Testing

<!-- How did you verify this works? -->

- [x] Unit tests added/updated
- [x] Ran locally (`uv run pytest tests/unit -x`)
- [x] Manual verification (describe below if applicable)

## Rollback

Revert the commit.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `ci:`, etc.)
- [x] No secrets, credentials, or PII in the diff
- [x] No breaking changes (or documented above with a migration path)
- [x] Pre-commit hooks pass (`uv run pre-commit run --all-files`)
