### PR TITLE
feat: mcp resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,13 @@ tools:
 - **Subagent:** add `mcps:` to `config/agent/subagents/<name>.md` frontmatter.
 - **Inheritance:** subagents without `mcps` inherit the orchestrator's list.
 - **Validation:** every name in `mcps` must exist in `mcp.json` with `enabled: true`.
+- **Resources:** optional `resources:` list of URI / `uriTemplate` strings (not resource names). Omit the key to allow all URIs on the agent's MCP servers; list specific URIs to allowlist; `resources: []` disables resource tools. Server scope follows `mcps:` if set, otherwise all enabled servers in `mcp.json`.
+
+```yaml
+resources:
+  - template://about
+  - template://echo/{text}
+```
 
 See `config/agent/mcp.json` for working SSO and DCR examples.
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ tools:
 - **Subagent:** add `mcps:` to `config/agent/subagents/<name>.md` frontmatter.
 - **Inheritance:** subagents without `mcps` inherit the orchestrator's list.
 - **Validation:** every name in `mcps` must exist in `mcp.json` with `enabled: true`.
-- **Resources:** optional `resources:` list of URI / `uriTemplate` strings (not resource names). Omit the key to allow all URIs on the agent's MCP servers; list specific URIs to allowlist; `resources: []` disables resource tools. Server scope follows `mcps:` if set, otherwise all enabled servers in `mcp.json`.
+- **Resources:** optional `resources:` list of URI / `uriTemplate` strings (not resource names). Omit the key (or pass `[]`) to allow all URIs on the agent's MCP servers; list specific URIs to allowlist. Subagents without `resources:` inherit the orchestrator's list. Server scope follows `mcps:` if set, otherwise all enabled servers in `mcp.json`.
 
 ```yaml
 resources:

--- a/deep_agent/aegra/graph.py
+++ b/deep_agent/aegra/graph.py
@@ -102,6 +102,8 @@ def _graph_fingerprint(
     hitl_exclude: list[str] | None = None,
     temperature: float = 0.0,
     max_tokens: int | None = None,
+    mcp_names: list[str] | None = None,
+    resource_uris: list[str] | None = None,
 ) -> str:
     """Stable fingerprint for graph cache keying."""
     hitl_flag = (
@@ -110,7 +112,12 @@ def _graph_fingerprint(
         f",exclude={','.join(sorted(hitl_exclude or []))}"
     )
     model_flag = f"temp={temperature},max_tokens={max_tokens}"
-    raw = f"{model_name}\0{system_prompt}\0{','.join(sorted(tool_names))}\0{hitl_flag}\0{model_flag}"
+    mcp_flag = ",".join(sorted(mcp_names or []))
+    resources_flag = ",".join(sorted(resource_uris or []))
+    raw = (
+        f"{model_name}\0{system_prompt}\0{','.join(sorted(tool_names))}"
+        f"\0{hitl_flag}\0{model_flag}\0{mcp_flag}\0{resources_flag}"
+    )
     return hashlib.sha256(raw.encode()).hexdigest()[:16]
 
 
@@ -202,6 +209,24 @@ async def _active_rule_contents(user_ids: list[str]) -> list[str]:
     return contents
 
 
+def _exclude_resource_read_from_eviction() -> None:
+    """Ensure ``mcp_read_resource`` is on the FilesystemMiddleware eviction skip list.
+
+    The host tool already paginates and char-truncates its output, so
+    FilesystemMiddleware eviction is redundant. Adding to the skip list
+    prevents a double cap if deepagents ever lowers ``tool_token_limit_before_evict``.
+    """
+    from deepagents.middleware import filesystem as _fs
+
+    from deep_agent.aegra.mcp_resource_tools import READ_TOOL
+
+    if READ_TOOL not in _fs.TOOLS_EXCLUDED_FROM_EVICTION:
+        _fs.TOOLS_EXCLUDED_FROM_EVICTION = (
+            *_fs.TOOLS_EXCLUDED_FROM_EVICTION,
+            READ_TOOL,
+        )
+
+
 async def agent(runtime: ServerRuntime) -> Any:
     """Async graph factory — invoked per-request by Aegra.
 
@@ -219,6 +244,7 @@ async def agent(runtime: ServerRuntime) -> Any:
         A compiled deep-agent graph (``CompiledStateGraph``).
     """
     await _ensure_startup()
+    _exclude_resource_read_from_eviction()
 
     from deepagents import create_deep_agent
 
@@ -343,11 +369,7 @@ async def agent(runtime: ServerRuntime) -> Any:
     resource_tools = wrap_mcp_tools_for_auth(
         get_mcp_resource_tools(
             server_names=mcp_server_names or None,
-            allowed_uris=(
-                orchestrator_cfg["resources"]
-                if "resources" in orchestrator_cfg
-                else None
-            ),
+            allowed_uris=orchestrator_cfg.get("resources") or None,
         )
     )
     tools.extend(resource_tools)
@@ -396,6 +418,8 @@ async def agent(runtime: ServerRuntime) -> Any:
         hitl_exclude=hitl.exclude if hitl else [],
         temperature=float(orch_temperature),
         max_tokens=int(orch_max_tokens) if orch_max_tokens else None,
+        mcp_names=mcp_server_names or None,
+        resource_uris=orchestrator_cfg.get("resources") or None,
     )
     now = time.time()
     graph_ttl = float(agent_config.get_cache_config().graph.ttl)

--- a/deep_agent/aegra/graph.py
+++ b/deep_agent/aegra/graph.py
@@ -227,6 +227,7 @@ async def agent(runtime: ServerRuntime) -> Any:
         refresh_access_token,
         set_mcp_auth_context,
     )
+    from deep_agent.aegra.mcp_resource_tools import get_mcp_resource_tools
     from deep_agent.aegra.mcp_tool_auth import wrap_mcp_tools_for_auth
     from deep_agent.src.agent.config import agent_config
     from deep_agent.src.infrastructure.async_tasks import build_async_middleware
@@ -339,6 +340,18 @@ async def agent(runtime: ServerRuntime) -> Any:
             )
             tools.extend(extra)
 
+    resource_tools = wrap_mcp_tools_for_auth(
+        get_mcp_resource_tools(
+            server_names=mcp_server_names or None,
+            allowed_uris=(
+                orchestrator_cfg["resources"]
+                if "resources" in orchestrator_cfg
+                else None
+            ),
+        )
+    )
+    tools.extend(resource_tools)
+
     from deep_agent.src.infrastructure.middleware import (
         build_middleware_list,
         resolve_memory_param,
@@ -401,7 +414,8 @@ async def agent(runtime: ServerRuntime) -> Any:
         resolved_mw,
         model=model,
         backend=backend,
-        mcp_tool_names=frozenset(t.name for t in mcp_tools),
+        mcp_tool_names=frozenset(t.name for t in mcp_tools)
+        | frozenset(t.name for t in resource_tools),
     )
     memory = resolve_memory_param(resolved_mw) if user_memory_enabled else None
 

--- a/deep_agent/aegra/mcp_resource_tools.py
+++ b/deep_agent/aegra/mcp_resource_tools.py
@@ -2,8 +2,10 @@
 
 The model cannot speak JSON-RPC. These tools are the host adapter: they open the
 same request-scoped MCP session as the Apps HTTP proxy. List/templates return
-the catalog JSON unchanged. Read returns text contents and replaces binary
-blobs with a short omitted notice. No catalog cache — safe for multi-pod.
+the catalog JSON unchanged. Read extracts ``contents[].text``, applies
+line-based ``offset``/``limit`` pagination (defaults match ``read_file``:
+offset 0, limit 100), then char-truncates to the eviction token budget.
+Binary blobs are omitted. No catalog cache — safe for multi-pod.
 """
 
 from __future__ import annotations
@@ -29,11 +31,123 @@ from deep_agent.aegra.mcp_host import (
     list_resources,
     read_resource,
 )
+from deep_agent.utils.pylogger import get_python_logger
+
+logger = get_python_logger()
 
 LIST_TOOL = "mcp_list_resources"
 TEMPLATES_TOOL = "mcp_list_resource_templates"
 READ_TOOL = "mcp_read_resource"
-BLOB_OMITTED = "Resource in blob format, omitted"
+
+DEFAULT_READ_OFFSET = 0
+DEFAULT_READ_LIMIT = 100
+_CHARS_PER_TOKEN = 4
+_DEFAULT_TOKEN_LIMIT = 100_000
+
+
+def _get_max_chars() -> int:
+    """Return the char budget for resource reads.
+
+    Independent of FilesystemMiddleware's eviction threshold — resource
+    reads have their own budget sized to fit large guidance documents.
+    """
+    return _CHARS_PER_TOKEN * _DEFAULT_TOKEN_LIMIT
+
+
+def _extract_text(payload: dict[str, Any]) -> str:
+    """Join ``contents[].text`` from an MCP ``resources/read`` result.
+
+    Blob-only items are replaced with a stub so the model knows binary
+    content was present but omitted.
+    """
+    contents = payload.get("contents")
+    if not isinstance(contents, list):
+        return ""
+    parts: list[str] = []
+    for item in contents:
+        if not isinstance(item, dict):
+            continue
+        text = item.get("text")
+        if isinstance(text, str):
+            parts.append(text)
+        elif "blob" in item:
+            mime = item.get("mimeType") or item.get("mime_type") or "unknown"
+            parts.append(f"[Binary content omitted ({mime})]")
+    return "\n".join(parts)
+
+
+def _split_long_lines(lines: list[str], max_chars: int) -> list[str]:
+    r"""Break any line longer than *max_chars* into chunks so every line is pageable.
+
+    Each chunk ends with ``\\n`` so the downstream line-boundary logic works.
+    """
+    chunk_size = max(max_chars - 1, 1)
+    out: list[str] = []
+    for line in lines:
+        while len(line) > max_chars:
+            out.append(line[:chunk_size] + "\n")
+            line = line[chunk_size:]
+        out.append(line)
+    return out
+
+
+def _paginate_text(
+    text: str, uri: str, *, offset: int, limit: int, max_chars: int
+) -> str:
+    """Slice *text* by line offset/limit, then char-truncate to *max_chars*.
+
+    Long lines are pre-split into chunks so every line fits within the
+    char budget. ``next_offset`` is derived from lines actually shown,
+    not from the requested ``limit``, so no lines are skipped on resume.
+    """
+    lines = _split_long_lines(text.splitlines(keepends=True), max_chars)
+    total_lines = len(lines)
+    offset = max(offset, 0)
+    limit = max(limit, 1)
+    page = lines[offset : offset + limit]
+    result = "".join(page)
+
+    if not result and offset > 0:
+        return (
+            f"[No content at offset={offset}. "
+            f"Resource {uri} has {total_lines} lines (offsets 0–{max(total_lines - 1, 0)}).]"
+        )
+
+    truncated_by_lines = offset + limit < total_lines
+    truncated_by_chars = False
+
+    if len(result) > max_chars:
+        cut = result[:max_chars]
+        last_nl = cut.rfind("\n")
+        if last_nl >= 0:
+            result = cut[: last_nl + 1]
+            lines_shown = result.count("\n")
+        else:
+            result = cut
+            lines_shown = 0
+        truncated_by_chars = True
+
+    if truncated_by_chars and lines_shown > 0:
+        next_offset = offset + lines_shown
+    elif truncated_by_lines:
+        next_offset = offset + limit
+    else:
+        next_offset = None
+
+    if next_offset is not None:
+        notice = (
+            f"\n\n[Output truncated. Resource {uri} has {total_lines} lines. "
+            f"Use offset={next_offset} and limit={limit} to read the next page.]"
+        )
+        result += notice
+    elif truncated_by_chars:
+        result += (
+            "\n\n[Output truncated due to size limits. "
+            "The resource content is very large. "
+            "Consider requesting a smaller portion or a different URI.]"
+        )
+
+    return result
 
 
 def get_mcp_resource_tools(
@@ -62,7 +176,7 @@ def get_mcp_resource_tools(
 
 def _uri_allowed(uri: str, allowed_uris: list[str] | None) -> bool:
     """Return True if *uri* is unrestricted, listed, or matches a listed template."""
-    if allowed_uris is None:
+    if not allowed_uris:
         return True
     if uri in allowed_uris:
         return True
@@ -107,41 +221,22 @@ def _raise_or_format_http(exc: HTTPException) -> str:
     return f"MCP resource request failed ({exc.status_code}): {exc.detail}"
 
 
+def _format_generic_failure(exc: BaseException) -> str:
+    """Return a stable tool error; do not forward raw exception text to the model."""
+    if isinstance(exc, TimeoutError):
+        return "MCP resource request failed: timed out"
+    logger.exception("MCP resource request failed")
+    return "MCP resource request failed"
+
+
 def _dump(payload: dict[str, Any]) -> str:
     return json.dumps(payload, ensure_ascii=False)
-
-
-def _omit_blobs(payload: dict[str, Any]) -> dict[str, Any]:
-    """Drop MCP ``blob`` bytes so they never enter the model context.
-
-    Future: attach as ``content_blocks`` when the current model can ingest the
-    MIME type; otherwise write to thread files and let the model ``read_file``.
-    """
-    contents = payload.get("contents")
-    if not isinstance(contents, list):
-        return payload
-    out_contents: list[Any] = []
-    changed = False
-    for item in contents:
-        if not isinstance(item, dict) or "blob" not in item:
-            out_contents.append(item)
-            continue
-        changed = True
-        stub = {k: v for k, v in item.items() if k != "blob"}
-        if "text" not in stub:
-            stub["text"] = BLOB_OMITTED
-        out_contents.append(stub)
-    if not changed:
-        return payload
-    out = dict(payload)
-    out["contents"] = out_contents
-    return out
 
 
 def _filter_resources(
     payload: dict[str, Any], allowed_uris: list[str] | None
 ) -> dict[str, Any]:
-    if allowed_uris is None:
+    if not allowed_uris:
         return payload
     out = dict(payload)
     out["resources"] = [
@@ -156,7 +251,7 @@ def _filter_resources(
 def _filter_templates(
     payload: dict[str, Any], allowed_uris: list[str] | None
 ) -> dict[str, Any]:
-    if allowed_uris is None:
+    if not allowed_uris:
         return payload
     key = (
         "resourceTemplates" if "resourceTemplates" in payload else "resource_templates"
@@ -182,17 +277,19 @@ def build_mcp_resource_tools(
     allowed_servers: list[str],
     allowed_uris: list[str] | None = None,
 ) -> list[Any]:
-    """Return list/templates/read tools, or ``[]`` when nothing is allowed.
+    """Return list/templates/read tools, or ``[]`` when no servers are available.
 
     Args:
         allowed_servers: MCP ``mcp.json`` keys this agent may call.
-        allowed_uris: ``None`` = all URIs; ``[]`` = no tools; otherwise allowlist
-            of concrete URIs and ``uriTemplate`` strings.
+        allowed_uris: ``None`` = all URIs; non-empty list = allowlist.
+            Production callers normalize ``[]`` to ``None`` (falsy = unrestricted,
+            matching ``mcps:`` and ``tools:`` behavior).
     """
     servers = tuple(s for s in allowed_servers if s)
-    if not servers or allowed_uris == []:
+    if not servers:
         return []
 
+    max_chars = _get_max_chars()
     server_list = ", ".join(servers)
 
     class _ListInput(BaseModel):
@@ -211,6 +308,14 @@ def build_mcp_resource_tools(
         uri: str = PydanticField(
             description="Resource URI from resources/list or a template"
         )
+        offset: int = PydanticField(
+            default=DEFAULT_READ_OFFSET,
+            description="Line offset (0-indexed). Use for pagination of large resources.",
+        )
+        limit: int = PydanticField(
+            default=DEFAULT_READ_LIMIT,
+            description="Max lines to return. Default 100. Pass a higher value for large resources.",
+        )
 
     async def _list(mcp_name: str, cursor: str | None = None) -> str:
         if mcp_name not in servers:
@@ -225,7 +330,7 @@ def build_mcp_resource_tools(
         except HTTPException as exc:
             return _raise_or_format_http(exc)
         except Exception as exc:
-            return f"MCP resource request failed: {exc}"
+            return _format_generic_failure(exc)
         return _dump(_filter_resources(payload, allowed_uris))
 
     async def _templates(mcp_name: str, cursor: str | None = None) -> str:
@@ -241,10 +346,15 @@ def build_mcp_resource_tools(
         except HTTPException as exc:
             return _raise_or_format_http(exc)
         except Exception as exc:
-            return f"MCP resource request failed: {exc}"
+            return _format_generic_failure(exc)
         return _dump(_filter_templates(payload, allowed_uris))
 
-    async def _read(mcp_name: str, uri: str) -> str:
+    async def _read(
+        mcp_name: str,
+        uri: str,
+        offset: int = DEFAULT_READ_OFFSET,
+        limit: int = DEFAULT_READ_LIMIT,
+    ) -> str:
         if mcp_name not in servers:
             return _reject_server(mcp_name, servers)
         if not _uri_allowed(uri, allowed_uris):
@@ -257,8 +367,11 @@ def build_mcp_resource_tools(
         except HTTPException as exc:
             return _raise_or_format_http(exc)
         except Exception as exc:
-            return f"MCP resource request failed: {exc}"
-        return _dump(_omit_blobs(payload))
+            return _format_generic_failure(exc)
+        text = _extract_text(payload)
+        return _paginate_text(
+            text, uri, offset=offset, limit=limit, max_chars=max_chars
+        )
 
     list_desc = (
         "List MCP resources (resources/list). Returns catalog metadata for concrete "
@@ -274,6 +387,8 @@ def build_mcp_resource_tools(
     )
     read_desc = (
         "Read an MCP resource (resources/read) by URI. Use after listing. "
+        "By default reads up to 100 lines starting from the beginning. "
+        "Use offset/limit to page through large resources. "
         "Binary blob contents are omitted. "
         f"mcp_name must be one of: {server_list}."
     )

--- a/deep_agent/aegra/mcp_resource_tools.py
+++ b/deep_agent/aegra/mcp_resource_tools.py
@@ -397,21 +397,18 @@ def build_mcp_resource_tools(
         StructuredTool(
             name=LIST_TOOL,
             description=list_desc,
-            func=lambda **_: "",
             coroutine=_list,
             args_schema=_ListInput,
         ),
         StructuredTool(
             name=TEMPLATES_TOOL,
             description=templates_desc,
-            func=lambda **_: "",
             coroutine=_templates,
             args_schema=_ListInput,
         ),
         StructuredTool(
             name=READ_TOOL,
             description=read_desc,
-            func=lambda **_: "",
             coroutine=_read,
             args_schema=_ReadInput,
         ),

--- a/deep_agent/aegra/mcp_resource_tools.py
+++ b/deep_agent/aegra/mcp_resource_tools.py
@@ -1,0 +1,270 @@
+"""Host-side LangChain tools that call MCP ``resources/*`` (not server tools).
+
+The model cannot speak JSON-RPC. These tools are the host adapter: they open the
+same request-scoped MCP session as the Apps HTTP proxy, then return the payload
+unchanged. No catalog cache — safe for multi-pod.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from fastapi import HTTPException
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel
+from pydantic import Field as PydanticField
+
+from deep_agent.aegra.mcp import (
+    _current_access_token,
+    _current_user_id,
+    _filter_by_names,
+    _get_server_configs,
+)
+from deep_agent.aegra.mcp_auth import NeedsAuthorization
+from deep_agent.aegra.mcp_host import (
+    list_resource_templates,
+    list_resources,
+    read_resource,
+)
+
+LIST_TOOL = "mcp_list_resources"
+TEMPLATES_TOOL = "mcp_list_resource_templates"
+READ_TOOL = "mcp_read_resource"
+
+
+def get_mcp_resource_tools(
+    *,
+    server_names: list[str] | None = None,
+    allowed_uris: list[str] | None = None,
+) -> list[Any]:
+    """Return host resource tools scoped like ``get_mcp_tools``.
+
+    Filters enabled MCP servers (and optional ``mcps:`` names) with the same
+    helpers as tool discovery. Does **not** connect or call ``resources/list``
+    — the three tools talk to the server at turn time.
+    """
+    servers = _get_server_configs()
+    enabled = {
+        k: v
+        for k, v in servers.items()
+        if isinstance(v, dict) and v.get("enabled", False)
+    }
+    enabled = _filter_by_names(enabled, server_names)
+    return build_mcp_resource_tools(
+        allowed_servers=list(enabled.keys()),
+        allowed_uris=allowed_uris,
+    )
+
+
+def _uri_allowed(uri: str, allowed_uris: list[str] | None) -> bool:
+    """Return True if *uri* is unrestricted, listed, or matches a listed template."""
+    if allowed_uris is None:
+        return True
+    if uri in allowed_uris:
+        return True
+    return any(
+        "{" in pattern and _template_matches(pattern, uri) for pattern in allowed_uris
+    )
+
+
+def _template_matches(pattern: str, uri: str) -> bool:
+    """Match RFC-6570-style ``{param}`` as a single URI path segment."""
+    parts = re.split(r"(\{[^}]+\})", pattern)
+    regex = (
+        "^"
+        + "".join(
+            r"[^/]+" if p.startswith("{") and p.endswith("}") else re.escape(p)
+            for p in parts
+        )
+        + "$"
+    )
+    return re.match(regex, uri) is not None
+
+
+def _auth_context() -> tuple[str, str | None]:
+    return _current_user_id.get() or "", _current_access_token.get()
+
+
+def _is_authorization_required(exc: HTTPException) -> bool:
+    detail = exc.detail
+    return (
+        exc.status_code == 401
+        and isinstance(detail, dict)
+        and detail.get("error") == "authorization_required"
+        and isinstance(detail.get("mcp_name"), str)
+        and isinstance(detail.get("connect_url"), str)
+    )
+
+
+def _raise_or_format_http(exc: HTTPException) -> str:
+    if _is_authorization_required(exc):
+        detail = exc.detail
+        raise NeedsAuthorization(detail["mcp_name"], detail["connect_url"]) from None
+    return f"MCP resource request failed ({exc.status_code}): {exc.detail}"
+
+
+def _dump(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _filter_resources(
+    payload: dict[str, Any], allowed_uris: list[str] | None
+) -> dict[str, Any]:
+    if allowed_uris is None:
+        return payload
+    out = dict(payload)
+    out["resources"] = [
+        item
+        for item in (payload.get("resources") or [])
+        if isinstance(item, dict)
+        and _uri_allowed(str(item.get("uri") or ""), allowed_uris)
+    ]
+    return out
+
+
+def _filter_templates(
+    payload: dict[str, Any], allowed_uris: list[str] | None
+) -> dict[str, Any]:
+    if allowed_uris is None:
+        return payload
+    key = (
+        "resourceTemplates" if "resourceTemplates" in payload else "resource_templates"
+    )
+    out = dict(payload)
+    out[key] = [
+        item
+        for item in (payload.get(key) or [])
+        if isinstance(item, dict)
+        and str(item.get("uriTemplate") or item.get("uri_template") or "")
+        in allowed_uris
+    ]
+    return out
+
+
+def _reject_server(mcp_name: str, allowed_servers: tuple[str, ...]) -> str:
+    allowed = ", ".join(allowed_servers) if allowed_servers else "(none)"
+    return f"Unknown or disallowed MCP server {mcp_name!r}. Allowed: {allowed}"
+
+
+def build_mcp_resource_tools(
+    *,
+    allowed_servers: list[str],
+    allowed_uris: list[str] | None = None,
+) -> list[Any]:
+    """Return list/templates/read tools, or ``[]`` when nothing is allowed.
+
+    Args:
+        allowed_servers: MCP ``mcp.json`` keys this agent may call.
+        allowed_uris: ``None`` = all URIs; ``[]`` = no tools; otherwise allowlist
+            of concrete URIs and ``uriTemplate`` strings.
+    """
+    servers = tuple(s for s in allowed_servers if s)
+    if not servers or allowed_uris == []:
+        return []
+
+    server_list = ", ".join(servers)
+
+    class _ListInput(BaseModel):
+        mcp_name: str = PydanticField(
+            description=f"MCP server name. Allowed: {server_list}"
+        )
+        cursor: str | None = PydanticField(
+            default=None,
+            description="Pagination cursor from a previous list call",
+        )
+
+    class _ReadInput(BaseModel):
+        mcp_name: str = PydanticField(
+            description=f"MCP server name. Allowed: {server_list}"
+        )
+        uri: str = PydanticField(
+            description="Resource URI from resources/list or a template"
+        )
+
+    async def _list(mcp_name: str, cursor: str | None = None) -> str:
+        if mcp_name not in servers:
+            return _reject_server(mcp_name, servers)
+        user_id, sso = _auth_context()
+        try:
+            payload = await list_resources(
+                mcp_name, cursor=cursor, user_id=user_id, sso_token=sso
+            )
+        except NeedsAuthorization:
+            raise
+        except HTTPException as exc:
+            return _raise_or_format_http(exc)
+        except Exception as exc:
+            return f"MCP resource request failed: {exc}"
+        return _dump(_filter_resources(payload, allowed_uris))
+
+    async def _templates(mcp_name: str, cursor: str | None = None) -> str:
+        if mcp_name not in servers:
+            return _reject_server(mcp_name, servers)
+        user_id, sso = _auth_context()
+        try:
+            payload = await list_resource_templates(
+                mcp_name, cursor=cursor, user_id=user_id, sso_token=sso
+            )
+        except NeedsAuthorization:
+            raise
+        except HTTPException as exc:
+            return _raise_or_format_http(exc)
+        except Exception as exc:
+            return f"MCP resource request failed: {exc}"
+        return _dump(_filter_templates(payload, allowed_uris))
+
+    async def _read(mcp_name: str, uri: str) -> str:
+        if mcp_name not in servers:
+            return _reject_server(mcp_name, servers)
+        if not _uri_allowed(uri, allowed_uris):
+            return f"Resource URI not allowed: {uri}"
+        user_id, sso = _auth_context()
+        try:
+            payload = await read_resource(mcp_name, uri, user_id=user_id, sso_token=sso)
+        except NeedsAuthorization:
+            raise
+        except HTTPException as exc:
+            return _raise_or_format_http(exc)
+        except Exception as exc:
+            return f"MCP resource request failed: {exc}"
+        return _dump(payload)
+
+    list_desc = (
+        "List MCP resources (resources/list). Returns catalog metadata, not file "
+        "contents. If the list is empty, call mcp_list_resource_templates. "
+        f"mcp_name must be one of: {server_list}."
+    )
+    templates_desc = (
+        "List MCP resource templates (resources/templates/list) for parameterized "
+        f"URIs. mcp_name must be one of: {server_list}."
+    )
+    read_desc = (
+        "Read an MCP resource (resources/read) by URI. Use after listing. "
+        f"mcp_name must be one of: {server_list}."
+    )
+
+    return [
+        StructuredTool(
+            name=LIST_TOOL,
+            description=list_desc,
+            func=lambda **_: "",
+            coroutine=_list,
+            args_schema=_ListInput,
+        ),
+        StructuredTool(
+            name=TEMPLATES_TOOL,
+            description=templates_desc,
+            func=lambda **_: "",
+            coroutine=_templates,
+            args_schema=_ListInput,
+        ),
+        StructuredTool(
+            name=READ_TOOL,
+            description=read_desc,
+            func=lambda **_: "",
+            coroutine=_read,
+            args_schema=_ReadInput,
+        ),
+    ]

--- a/deep_agent/aegra/mcp_resource_tools.py
+++ b/deep_agent/aegra/mcp_resource_tools.py
@@ -1,8 +1,9 @@
 """Host-side LangChain tools that call MCP ``resources/*`` (not server tools).
 
 The model cannot speak JSON-RPC. These tools are the host adapter: they open the
-same request-scoped MCP session as the Apps HTTP proxy, then return the payload
-unchanged. No catalog cache — safe for multi-pod.
+same request-scoped MCP session as the Apps HTTP proxy. List/templates return
+the catalog JSON unchanged. Read returns text contents and replaces binary
+blobs with a short omitted notice. No catalog cache — safe for multi-pod.
 """
 
 from __future__ import annotations
@@ -32,6 +33,7 @@ from deep_agent.aegra.mcp_host import (
 LIST_TOOL = "mcp_list_resources"
 TEMPLATES_TOOL = "mcp_list_resource_templates"
 READ_TOOL = "mcp_read_resource"
+BLOB_OMITTED = "Resource in blob format, omitted"
 
 
 def get_mcp_resource_tools(
@@ -107,6 +109,33 @@ def _raise_or_format_http(exc: HTTPException) -> str:
 
 def _dump(payload: dict[str, Any]) -> str:
     return json.dumps(payload, ensure_ascii=False)
+
+
+def _omit_blobs(payload: dict[str, Any]) -> dict[str, Any]:
+    """Drop MCP ``blob`` bytes so they never enter the model context.
+
+    Future: attach as ``content_blocks`` when the current model can ingest the
+    MIME type; otherwise write to thread files and let the model ``read_file``.
+    """
+    contents = payload.get("contents")
+    if not isinstance(contents, list):
+        return payload
+    out_contents: list[Any] = []
+    changed = False
+    for item in contents:
+        if not isinstance(item, dict) or "blob" not in item:
+            out_contents.append(item)
+            continue
+        changed = True
+        stub = {k: v for k, v in item.items() if k != "blob"}
+        if "text" not in stub:
+            stub["text"] = BLOB_OMITTED
+        out_contents.append(stub)
+    if not changed:
+        return payload
+    out = dict(payload)
+    out["contents"] = out_contents
+    return out
 
 
 def _filter_resources(
@@ -229,19 +258,23 @@ def build_mcp_resource_tools(
             return _raise_or_format_http(exc)
         except Exception as exc:
             return f"MCP resource request failed: {exc}"
-        return _dump(payload)
+        return _dump(_omit_blobs(payload))
 
     list_desc = (
-        "List MCP resources (resources/list). Returns catalog metadata, not file "
-        "contents. If the list is empty, call mcp_list_resource_templates. "
+        "List MCP resources (resources/list). Returns catalog metadata for concrete "
+        "URIs, not file contents. Also call mcp_list_resource_templates when listing "
+        "what resources are available. "
         f"mcp_name must be one of: {server_list}."
     )
     templates_desc = (
-        "List MCP resource templates (resources/templates/list) for parameterized "
-        f"URIs. mcp_name must be one of: {server_list}."
+        "List MCP resource templates (resources/templates/list). These are URI "
+        "patterns with {param} placeholders, not readable files. Fill a pattern "
+        "then call mcp_read_resource. "
+        f"mcp_name must be one of: {server_list}."
     )
     read_desc = (
         "Read an MCP resource (resources/read) by URI. Use after listing. "
+        "Binary blob contents are omitted. "
         f"mcp_name must be one of: {server_list}."
     )
 

--- a/deep_agent/src/agent/config/loader.py
+++ b/deep_agent/src/agent/config/loader.py
@@ -318,19 +318,23 @@ class AgentConfig:
         return self._base_dir
 
     @staticmethod
-    def _validate_mcps_field(mcps: Any, agent_name: str) -> None:
-        """Validate the ``mcps`` frontmatter field is a list of strings.
+    def _validate_string_list_field(value: Any, agent_name: str, *, field: str) -> None:
+        """Validate a frontmatter field is a list of strings.
+
+        Missing keys are not passed here — omit means “no restriction”
+        for ``resources`` (allow all) and “unset” for ``mcps``.
 
         Args:
-            mcps: The raw value from frontmatter.
+            value: Raw frontmatter value.
             agent_name: Agent name for error messages.
+            field: Frontmatter key (``mcps`` or ``resources``).
 
         Raises:
-            AppException: If ``mcps`` is not a list of strings.
+            AppException: If *value* is not a list of strings.
         """
-        if not isinstance(mcps, list) or not all(isinstance(s, str) for s in mcps):
+        if not isinstance(value, list) or not all(isinstance(s, str) for s in value):
             raise AppException(
-                f"Agent '{agent_name}': 'mcps' must be a list of strings",
+                f"Agent '{agent_name}': '{field}' must be a list of strings",
                 ErrorCodes.CONFIGURATION_VALIDATION_ERROR,
             )
 
@@ -349,9 +353,14 @@ class AgentConfig:
             if "body" in config:
                 config["body"] = inject_runtime_values(config["body"])
 
+            agent_name = config.get("name", "orchestrator")
             if "mcps" in config:
-                self._validate_mcps_field(
-                    config["mcps"], config.get("name", "orchestrator")
+                self._validate_string_list_field(
+                    config["mcps"], agent_name, field="mcps"
+                )
+            if "resources" in config:
+                self._validate_string_list_field(
+                    config["resources"], agent_name, field="resources"
                 )
 
             # Resolve skill names to paths eagerly
@@ -457,7 +466,11 @@ class AgentConfig:
                 name = config.get("name", agent_file.stem)
 
                 if "mcps" in config:
-                    self._validate_mcps_field(config["mcps"], name)
+                    self._validate_string_list_field(config["mcps"], name, field="mcps")
+                if "resources" in config:
+                    self._validate_string_list_field(
+                        config["resources"], name, field="resources"
+                    )
 
                 # Resolve skill names to paths eagerly
                 skill_names = config.get("skills", [])

--- a/deep_agent/src/infrastructure/subagents.py
+++ b/deep_agent/src/infrastructure/subagents.py
@@ -375,6 +375,24 @@ def _build_single_subagent(
     return _build_default_subagent(name, agent_cfg, tools)
 
 
+def _append_mcp_resource_tools(
+    resolved_tools: list[Any], agent_cfg: dict[str, Any]
+) -> list[Any]:
+    """Append host resource tools using this subagent's mcps/resources allowlists."""
+    from deep_agent.aegra.mcp_resource_tools import get_mcp_resource_tools
+    from deep_agent.aegra.mcp_tool_auth import wrap_mcp_tools_for_auth
+
+    extra = wrap_mcp_tools_for_auth(
+        get_mcp_resource_tools(
+            server_names=agent_cfg.get("mcps") or None,
+            allowed_uris=(agent_cfg["resources"] if "resources" in agent_cfg else None),
+        )
+    )
+    if not extra:
+        return resolved_tools
+    return [*resolved_tools, *extra]
+
+
 def _build_default_subagent(
     name: str,
     agent_cfg: dict[str, Any],
@@ -409,6 +427,8 @@ def _build_default_subagent(
         resolved_tools = list(tools)
     else:
         resolved_tools = []
+
+    resolved_tools = _append_mcp_resource_tools(resolved_tools, agent_cfg)
 
     skill_paths: list[str] = agent_cfg.get("skill_paths", [])
 
@@ -486,6 +506,7 @@ def _build_compiled_subagent(
         resolved_tools = list(tools)
     else:
         resolved_tools = []
+    resolved_tools = _append_mcp_resource_tools(resolved_tools, agent_cfg)
     skill_paths: list[str] = agent_cfg.get("skill_paths", [])
 
     # Build fallback middleware if spec has fallback configured

--- a/deep_agent/src/infrastructure/subagents.py
+++ b/deep_agent/src/infrastructure/subagents.py
@@ -154,6 +154,11 @@ def _inherit_from_orchestrator(
             )
             agent_cfg["mcps"] = list(parent_mcps)
 
+    if "resources" not in agent_cfg:
+        parent_resources = orchestrator_cfg.get("resources")
+        if parent_resources is not None:
+            agent_cfg["resources"] = list(parent_resources)
+
 
 def _normalize_model_to_dict(
     raw_model: Any,
@@ -385,7 +390,7 @@ def _append_mcp_resource_tools(
     extra = wrap_mcp_tools_for_auth(
         get_mcp_resource_tools(
             server_names=agent_cfg.get("mcps") or None,
-            allowed_uris=(agent_cfg["resources"] if "resources" in agent_cfg else None),
+            allowed_uris=agent_cfg.get("resources") or None,
         )
     )
     if not extra:

--- a/tests/unit/aegra/test_graph.py
+++ b/tests/unit/aegra/test_graph.py
@@ -747,19 +747,19 @@ class TestGraphCacheHit:
 
     @pytest.mark.asyncio
     async def test_resources_empty_list_allows_all(self):
-        from deep_agent.aegra.mcp_resource_tools import LIST_TOOL
-
         mock_config = self._mock_orch_config(resources=[])
         mock_config.get_mcp_servers.return_value = {
             "template-mcp-server": {"enabled": True},
         }
 
-        _result, _compiled, mock_create, mock_mw, _subs = await self._build_agent(
-            mock_config
-        )
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.build_mcp_resource_tools",
+            return_value=[],
+        ) as mock_build:
+            await self._build_agent(mock_config)
 
-        names = [t.name for t in mock_create.call_args.kwargs["tools"]]
-        assert LIST_TOOL in names
+        mock_build.assert_called_once()
+        assert mock_build.call_args.kwargs["allowed_uris"] is None
 
     @pytest.mark.asyncio
     async def test_resource_tools_honor_declared_mcps(self):

--- a/tests/unit/aegra/test_graph.py
+++ b/tests/unit/aegra/test_graph.py
@@ -503,6 +503,27 @@ class TestGraphHelpers:
         fp2 = _graph_fingerprint("model", "prompt", ["b", "a"])
         assert fp1 == fp2
 
+    def test_graph_fingerprint_includes_mcps_and_resources(self):
+        from deep_agent.aegra.graph import _graph_fingerprint
+
+        base = dict(model_name="model", system_prompt="prompt", tool_names=["t"])
+        fp_none = _graph_fingerprint(**base)
+        fp_empty = _graph_fingerprint(**base, mcp_names=[], resource_uris=[])
+        fp_mcps = _graph_fingerprint(**base, mcp_names=["keep-me"])
+        fp_resources = _graph_fingerprint(**base, resource_uris=["template://about"])
+        fp_resources_order = _graph_fingerprint(
+            **base, resource_uris=["template://echo/{text}", "template://about"]
+        )
+        fp_resources_order_rev = _graph_fingerprint(
+            **base, resource_uris=["template://about", "template://echo/{text}"]
+        )
+
+        assert fp_none == fp_empty
+        assert fp_mcps != fp_none
+        assert fp_resources != fp_none
+        assert fp_resources != fp_mcps
+        assert fp_resources_order == fp_resources_order_rev
+
     def test_invalidate_graph_cache_clears_caches(self):
         import time
 
@@ -725,7 +746,7 @@ class TestGraphCacheHit:
         assert mock_subs.call_args.kwargs["tools"] == []
 
     @pytest.mark.asyncio
-    async def test_omits_resource_tools_when_resources_empty_list(self):
+    async def test_resources_empty_list_allows_all(self):
         from deep_agent.aegra.mcp_resource_tools import LIST_TOOL
 
         mock_config = self._mock_orch_config(resources=[])
@@ -738,9 +759,7 @@ class TestGraphCacheHit:
         )
 
         names = [t.name for t in mock_create.call_args.kwargs["tools"]]
-        assert LIST_TOOL not in names
-        mw_names = mock_mw.call_args.kwargs["mcp_tool_names"]
-        assert LIST_TOOL not in mw_names
+        assert LIST_TOOL in names
 
     @pytest.mark.asyncio
     async def test_resource_tools_honor_declared_mcps(self):
@@ -759,6 +778,27 @@ class TestGraphCacheHit:
         mock_build.assert_called_once()
         assert mock_build.call_args.kwargs["allowed_servers"] == ["keep-me"]
         assert mock_build.call_args.kwargs["allowed_uris"] is None
+
+    @pytest.mark.asyncio
+    async def test_resource_tools_honor_declared_resources(self):
+        mock_config = self._mock_orch_config(
+            resources=["template://about", "template://echo/{text}"]
+        )
+        mock_config.get_mcp_servers.return_value = {
+            "template-mcp-server": {"enabled": True},
+        }
+
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.build_mcp_resource_tools",
+            return_value=[],
+        ) as mock_build:
+            await self._build_agent(mock_config)
+
+        mock_build.assert_called_once()
+        assert mock_build.call_args.kwargs["allowed_uris"] == [
+            "template://about",
+            "template://echo/{text}",
+        ]
 
 
 class TestGuardianActivationGate:

--- a/tests/unit/aegra/test_graph.py
+++ b/tests/unit/aegra/test_graph.py
@@ -32,11 +32,16 @@ class TestAgentFactory:
     def _no_guardian_wrapping(self):
         mock_settings = MagicMock()
         mock_settings.GUARDIAN_API_BASE = ""
+        mock_settings.LIFECYCLE_PERSISTENCE_ENABLED = False
         mock_settings.MEMORY_ENABLED = False
         mock_settings.PYTHON_LOG_LEVEL = "WARNING"
         with (
             patch("deep_agent.src.settings.settings", mock_settings),
             patch("deep_agent.src.pii.get_scrubber", return_value=None),
+            patch(
+                "deep_agent.aegra.mcp_resource_tools._get_server_configs",
+                return_value={},
+            ),
         ):
             yield
 
@@ -606,6 +611,155 @@ class TestGraphCacheHit:
         assert result is mock_cached_graph
         mock_create.assert_not_called()
 
+    def _mock_orch_config(self, **orch_overrides):
+        mock_config = MagicMock()
+        orch = {
+            "name": "orchestrator",
+            "model": "gemini-2.5-flash",
+            "body": "test prompt",
+            "skill_paths": [],
+            "tools": [],
+        }
+        orch.update(orch_overrides)
+        mock_config.get_orchestrator_config.return_value = orch
+        mock_config.resolve_tools.return_value = []
+        mock_config.resolve_agent_middleware.return_value = MagicMock(
+            skills_enabled=True
+        )
+        return mock_config
+
+    async def _build_agent(self, mock_config):
+        mock_compiled = MagicMock()
+        mock_runtime = MagicMock()
+        mock_runtime.user = None
+        mock_create = MagicMock(return_value=mock_compiled)
+        mock_mw = MagicMock(return_value=[])
+        mock_subs = MagicMock(return_value=None)
+        mcp_servers = mock_config.get_mcp_servers.return_value
+        if not isinstance(mcp_servers, dict):
+            mcp_servers = {}
+        _reset_graph_state()
+        with (
+            patch("deep_agent.src.agent.config.agent_config", mock_config),
+            patch(
+                "deep_agent.aegra.mcp_resource_tools._get_server_configs",
+                return_value=mcp_servers,
+            ),
+            patch(
+                "deep_agent.src.infrastructure.providers.register_profiles_from_config",
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.src.agent.config.model.parse_model_config",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.src.cache.model_cache.get_or_create_model_from_spec",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.aegra.mcp.get_mcp_tools",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.load_subagents",
+                mock_subs,
+            ),
+            patch(
+                "deep_agent.src.infrastructure.backend.get_configured_backend",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.async_tasks.build_async_middleware",
+                return_value=None,
+            ),
+            patch(
+                "deep_agent.src.infrastructure.middleware.build_middleware_list",
+                mock_mw,
+            ),
+            patch(
+                "deep_agent.src.infrastructure.middleware.resolve_memory_param",
+                return_value=None,
+            ),
+            patch("deep_agent.aegra.graph._ensure_startup", new_callable=AsyncMock),
+            patch("deepagents.create_deep_agent", mock_create),
+            patch(
+                "deep_agent.src.settings.settings.LIFECYCLE_PERSISTENCE_ENABLED",
+                False,
+            ),
+        ):
+            from deep_agent.aegra.graph import agent
+
+            result = await agent(mock_runtime)
+        return result, mock_compiled, mock_create, mock_mw, mock_subs
+
+    @pytest.mark.asyncio
+    async def test_attaches_resource_tools_when_mcp_enabled(self):
+        from deep_agent.aegra.mcp_resource_tools import (
+            LIST_TOOL,
+            READ_TOOL,
+            TEMPLATES_TOOL,
+        )
+
+        mock_config = self._mock_orch_config()
+        mock_config.get_mcp_servers.return_value = {
+            "template-mcp-server": {"enabled": True},
+            "template-mcp-server-dcr": {"enabled": False},
+        }
+
+        (
+            result,
+            mock_compiled,
+            mock_create,
+            mock_mw,
+            mock_subs,
+        ) = await self._build_agent(mock_config)
+
+        assert result is mock_compiled
+        names = [t.name for t in mock_create.call_args.kwargs["tools"]]
+        assert names == [LIST_TOOL, TEMPLATES_TOOL, READ_TOOL]
+        mw_names = mock_mw.call_args.kwargs["mcp_tool_names"]
+        assert {LIST_TOOL, TEMPLATES_TOOL, READ_TOOL} <= set(mw_names)
+        mock_subs.assert_called_once()
+        assert mock_subs.call_args.kwargs["tools"] == []
+
+    @pytest.mark.asyncio
+    async def test_omits_resource_tools_when_resources_empty_list(self):
+        from deep_agent.aegra.mcp_resource_tools import LIST_TOOL
+
+        mock_config = self._mock_orch_config(resources=[])
+        mock_config.get_mcp_servers.return_value = {
+            "template-mcp-server": {"enabled": True},
+        }
+
+        _result, _compiled, mock_create, mock_mw, _subs = await self._build_agent(
+            mock_config
+        )
+
+        names = [t.name for t in mock_create.call_args.kwargs["tools"]]
+        assert LIST_TOOL not in names
+        mw_names = mock_mw.call_args.kwargs["mcp_tool_names"]
+        assert LIST_TOOL not in mw_names
+
+    @pytest.mark.asyncio
+    async def test_resource_tools_honor_declared_mcps(self):
+        mock_config = self._mock_orch_config(mcps=["keep-me"])
+        mock_config.get_mcp_servers.return_value = {
+            "keep-me": {"enabled": True},
+            "other": {"enabled": True},
+        }
+
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.build_mcp_resource_tools",
+            return_value=[],
+        ) as mock_build:
+            await self._build_agent(mock_config)
+
+        mock_build.assert_called_once()
+        assert mock_build.call_args.kwargs["allowed_servers"] == ["keep-me"]
+        assert mock_build.call_args.kwargs["allowed_uris"] is None
+
 
 class TestGuardianActivationGate:
     """Guardian wrapping requires BOTH guardrail config.enabled AND GUARDIAN_API_BASE."""
@@ -648,6 +802,10 @@ class TestGuardianActivationGate:
                 "deep_agent.aegra.mcp.get_mcp_tools",
                 new_callable=AsyncMock,
                 return_value=[],
+            ),
+            patch(
+                "deep_agent.aegra.mcp_resource_tools._get_server_configs",
+                return_value={},
             ),
             patch(
                 "deep_agent.src.infrastructure.subagents.load_subagents",

--- a/tests/unit/aegra/test_mcp_resource_tools.py
+++ b/tests/unit/aegra/test_mcp_resource_tools.py
@@ -11,7 +11,6 @@ from fastapi import HTTPException
 from deep_agent.aegra.mcp import _current_access_token, _current_user_id
 from deep_agent.aegra.mcp_auth import NeedsAuthorization
 from deep_agent.aegra.mcp_resource_tools import (
-    BLOB_OMITTED,
     LIST_TOOL,
     READ_TOOL,
     TEMPLATES_TOOL,
@@ -97,12 +96,12 @@ class TestGetMcpResourceTools:
 
 
 class TestBuildMcpResourceTools:
-    def test_empty_uri_allowlist_returns_no_tools(self):
+    def test_empty_uri_allowlist_still_builds_tools(self):
         tools = build_mcp_resource_tools(
             allowed_servers=["template-mcp-server"],
             allowed_uris=[],
         )
-        assert tools == []
+        assert len(tools) == 3
 
     def test_no_servers_returns_no_tools(self):
         tools = build_mcp_resource_tools(allowed_servers=[], allowed_uris=None)
@@ -207,6 +206,30 @@ class TestListResourcesTool:
             result = await _tool(tools, LIST_TOOL).ainvoke({"mcp_name": "s"})
         assert result.startswith("MCP resource request failed (404)")
 
+    @pytest.mark.asyncio
+    async def test_timeout_is_stable_string(self, auth_ctx):
+        tools = build_mcp_resource_tools(allowed_servers=["s"], allowed_uris=None)
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.list_resources",
+            new_callable=AsyncMock,
+            side_effect=TimeoutError,
+        ):
+            result = await _tool(tools, LIST_TOOL).ainvoke({"mcp_name": "s"})
+        assert result == "MCP resource request failed: timed out"
+
+    @pytest.mark.asyncio
+    async def test_generic_error_does_not_leak_exception_text(self, auth_ctx):
+        tools = build_mcp_resource_tools(allowed_servers=["s"], allowed_uris=None)
+        leak = "http://internal:443 tlsv1 alert"
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.list_resources",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError(leak),
+        ):
+            result = await _tool(tools, LIST_TOOL).ainvoke({"mcp_name": "s"})
+        assert result == "MCP resource request failed"
+        assert leak not in result
+
 
 class TestListTemplatesTool:
     @pytest.mark.asyncio
@@ -233,7 +256,7 @@ class TestListTemplatesTool:
 
 class TestReadResourceTool:
     @pytest.mark.asyncio
-    async def test_keeps_text_and_stubs_blob(self, auth_ctx):
+    async def test_returns_text_and_stubs_blob(self, auth_ctx):
         tools = build_mcp_resource_tools(allowed_servers=["s"], allowed_uris=None)
         blob = "cG5nLWJ5dGVz"
         payload = {
@@ -253,33 +276,34 @@ class TestReadResourceTool:
         mock_read.assert_awaited_once_with(
             "s", "template://logo", user_id="user-1", sso_token="sso-token"
         )
-        parsed = json.loads(result)
-        assert parsed["contents"][0]["text"] == "hello"
-        logo = parsed["contents"][1]
-        assert "blob" not in logo
-        assert logo["text"] == BLOB_OMITTED
+        assert "hello" in result
         assert blob not in result
+        assert "Binary content omitted" in result
+        assert "image/png" in result
 
     @pytest.mark.asyncio
-    async def test_text_only_is_unchanged(self, auth_ctx):
+    async def test_text_only_returns_plain_text(self, auth_ctx):
         tools = build_mcp_resource_tools(allowed_servers=["s"], allowed_uris=None)
-        payload = {
-            "contents": [
-                {"uri": "template://about", "mimeType": "text/plain", "text": "hello"}
-            ]
-        }
         with patch(
             "deep_agent.aegra.mcp_resource_tools.read_resource",
             new_callable=AsyncMock,
-            return_value=payload,
+            return_value={
+                "contents": [
+                    {
+                        "uri": "template://about",
+                        "mimeType": "text/plain",
+                        "text": "hello",
+                    }
+                ]
+            },
         ):
             result = await _tool(tools, READ_TOOL).ainvoke(
                 {"mcp_name": "s", "uri": "template://about"}
             )
-        assert json.loads(result) == payload
+        assert result == "hello"
 
     @pytest.mark.asyncio
-    async def test_keeps_text_when_same_item_has_blob(self, auth_ctx):
+    async def test_extracts_text_ignores_blob_on_same_item(self, auth_ctx):
         tools = build_mcp_resource_tools(allowed_servers=["s"], allowed_uris=None)
         with patch(
             "deep_agent.aegra.mcp_resource_tools.read_resource",
@@ -298,9 +322,8 @@ class TestReadResourceTool:
             result = await _tool(tools, READ_TOOL).ainvoke(
                 {"mcp_name": "s", "uri": "template://both"}
             )
-        item = json.loads(result)["contents"][0]
-        assert item["text"] == "caption"
-        assert "blob" not in item
+        assert "caption" in result
+        assert "eA==" not in result
 
     @pytest.mark.asyncio
     async def test_rejects_uri_not_on_allowlist(self, auth_ctx):
@@ -333,7 +356,7 @@ class TestReadResourceTool:
                 {"mcp_name": "s", "uri": "template://echo/hi"}
             )
         mock_read.assert_awaited_once()
-        assert json.loads(result)["contents"][0]["text"] == "hi"
+        assert "hi" in result
 
     @pytest.mark.asyncio
     async def test_template_does_not_match_extra_path_segment(self, auth_ctx):
@@ -350,3 +373,229 @@ class TestReadResourceTool:
             )
         mock_read.assert_not_awaited()
         assert "not allowed" in result
+
+    @pytest.mark.asyncio
+    async def test_default_limit_paginates(self, auth_ctx):
+        tools = build_mcp_resource_tools(allowed_servers=["s"], allowed_uris=None)
+        body = "\n".join(f"line-{i}" for i in range(150))
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.read_resource",
+            new_callable=AsyncMock,
+            return_value={"contents": [{"text": body}]},
+        ):
+            result = await _tool(tools, READ_TOOL).ainvoke(
+                {"mcp_name": "s", "uri": "template://big"}
+            )
+        assert "line-0" in result
+        assert "line-99" in result
+        assert "line-100" not in result
+        assert "offset=100" in result
+
+    @pytest.mark.asyncio
+    async def test_offset_and_limit(self, auth_ctx):
+        tools = build_mcp_resource_tools(allowed_servers=["s"], allowed_uris=None)
+        body = "\n".join(f"line-{i}" for i in range(200))
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.read_resource",
+            new_callable=AsyncMock,
+            return_value={"contents": [{"text": body}]},
+        ):
+            result = await _tool(tools, READ_TOOL).ainvoke(
+                {"mcp_name": "s", "uri": "template://big", "offset": 100, "limit": 50}
+            )
+        assert "line-100" in result
+        assert "line-149" in result
+        assert "line-150" not in result
+        assert "offset=150" in result
+
+    @pytest.mark.asyncio
+    async def test_short_body_no_truncation(self, auth_ctx):
+        tools = build_mcp_resource_tools(allowed_servers=["s"], allowed_uris=None)
+        body = "\n".join(f"line-{i}" for i in range(10))
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.read_resource",
+            new_callable=AsyncMock,
+            return_value={"contents": [{"text": body}]},
+        ):
+            result = await _tool(tools, READ_TOOL).ainvoke(
+                {"mcp_name": "s", "uri": "template://small"}
+            )
+        assert "line-0" in result
+        assert "line-9" in result
+        assert "truncated" not in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_huge_line_is_split_and_pageable(self, auth_ctx):
+        tools = build_mcp_resource_tools(allowed_servers=["s"], allowed_uris=None)
+        huge = "x" * 500_000
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.read_resource",
+            new_callable=AsyncMock,
+            return_value={"contents": [{"text": huge}]},
+        ):
+            r1 = await _tool(tools, READ_TOOL).ainvoke(
+                {"mcp_name": "s", "uri": "template://huge"}
+            )
+        assert len(r1) < 500_000
+        assert "offset=1" in r1
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.read_resource",
+            new_callable=AsyncMock,
+            return_value={"contents": [{"text": huge}]},
+        ):
+            r2 = await _tool(tools, READ_TOOL).ainvoke(
+                {"mcp_name": "s", "uri": "template://huge", "offset": 1}
+            )
+        assert "x" in r2
+        assert "truncated" not in r2.lower()
+
+    @pytest.mark.asyncio
+    async def test_char_cap_cuts_at_line_boundary(self, auth_ctx):
+        tools = build_mcp_resource_tools(allowed_servers=["s"], allowed_uris=None)
+        short = [f"short-{i}" for i in range(50)]
+        long = [f"long-{i}-" + "x" * 10000 for i in range(50)]
+        body = "\n".join(short + long)
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.read_resource",
+            new_callable=AsyncMock,
+            return_value={"contents": [{"text": body}]},
+        ):
+            result = await _tool(tools, READ_TOOL).ainvoke(
+                {"mcp_name": "s", "uri": "template://mixed"}
+            )
+        content_before_notice = result.split("\n\n[Output truncated")[0]
+        assert content_before_notice.endswith("\n")
+        assert "offset=" in result
+        offset_val = int(result.split("offset=")[1].split(" ")[0].rstrip(","))
+        assert offset_val < 100
+        assert "short-0" in result
+        assert f"short-{offset_val}" not in content_before_notice
+
+    @pytest.mark.asyncio
+    async def test_negative_limit_clamped_to_1(self, auth_ctx):
+        tools = build_mcp_resource_tools(allowed_servers=["s"], allowed_uris=None)
+        body = "\n".join(f"line-{i}" for i in range(10))
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.read_resource",
+            new_callable=AsyncMock,
+            return_value={"contents": [{"text": body}]},
+        ):
+            result = await _tool(tools, READ_TOOL).ainvoke(
+                {"mcp_name": "s", "uri": "template://x", "limit": -1}
+            )
+        assert "line-0" in result
+        assert "offset=-1" not in result
+
+    @pytest.mark.asyncio
+    async def test_zero_limit_clamped_to_1(self, auth_ctx):
+        tools = build_mcp_resource_tools(allowed_servers=["s"], allowed_uris=None)
+        body = "\n".join(f"line-{i}" for i in range(10))
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.read_resource",
+            new_callable=AsyncMock,
+            return_value={"contents": [{"text": body}]},
+        ):
+            result = await _tool(tools, READ_TOOL).ainvoke(
+                {"mcp_name": "s", "uri": "template://x", "limit": 0}
+            )
+        assert "line-0" in result
+        assert "limit=0" not in result
+
+    @pytest.mark.asyncio
+    async def test_offset_past_end_returns_notice(self, auth_ctx):
+        tools = build_mcp_resource_tools(allowed_servers=["s"], allowed_uris=None)
+        body = "\n".join(f"line-{i}" for i in range(10))
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.read_resource",
+            new_callable=AsyncMock,
+            return_value={"contents": [{"text": body}]},
+        ):
+            result = await _tool(tools, READ_TOOL).ainvoke(
+                {"mcp_name": "s", "uri": "template://x", "offset": 999}
+            )
+        assert "No content at offset=999" in result
+        assert "10 lines" in result
+
+    @pytest.mark.asyncio
+    async def test_blank_line_then_long_line_paginates(self, auth_ctx):
+        tools = build_mcp_resource_tools(allowed_servers=["s"], allowed_uris=None)
+        body = "\n" + "x" * 500_000
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.read_resource",
+            new_callable=AsyncMock,
+            return_value={"contents": [{"text": body}]},
+        ):
+            result = await _tool(tools, READ_TOOL).ainvoke(
+                {"mcp_name": "s", "uri": "template://blank-start"}
+            )
+        assert "offset=" in result
+        assert "size limits" not in result
+
+
+class TestPaginateTextDirect:
+    """Direct _paginate_text tests with controlled max_chars."""
+
+    def test_small_budget_truncates_and_paginates(self):
+        from deep_agent.aegra.mcp_resource_tools import _paginate_text
+
+        text = "\n".join(f"line-{i}: content" for i in range(10))
+        result = _paginate_text(text, "u", offset=0, limit=10, max_chars=50)
+        assert "line-0" in result
+        assert "offset=" in result
+        lines_before_notice = result.split("\n\n[")[0].count("\n")
+        assert lines_before_notice < 10
+
+    def test_budget_fits_all_no_truncation(self):
+        from deep_agent.aegra.mcp_resource_tools import _paginate_text
+
+        text = "short\ntext\n"
+        result = _paginate_text(text, "u", offset=0, limit=10, max_chars=1000)
+        assert result == "short\ntext\n"
+        assert "truncated" not in result.lower()
+
+    def test_line_boundary_respected(self):
+        from deep_agent.aegra.mcp_resource_tools import _paginate_text
+
+        text = "a" * 30 + "\n" + "b" * 30 + "\n"
+        result = _paginate_text(text, "u", offset=0, limit=10, max_chars=40)
+        content = result.split("\n\n[")[0]
+        assert content.endswith("\n")
+        assert "b" not in content
+
+    def test_long_line_split_at_small_budget(self):
+        from deep_agent.aegra.mcp_resource_tools import _paginate_text
+
+        text = "x" * 200
+        result = _paginate_text(text, "u", offset=0, limit=1, max_chars=50)
+        assert "offset=1" in result
+        assert len(result.split("\n\n[")[0]) <= 50
+
+
+class TestEvictionSkipList:
+    def test_adds_read_tool_to_skip_list(self):
+        from deepagents.middleware import filesystem as _fs
+
+        from deep_agent.aegra.graph import _exclude_resource_read_from_eviction
+
+        original = _fs.TOOLS_EXCLUDED_FROM_EVICTION
+        try:
+            _fs.TOOLS_EXCLUDED_FROM_EVICTION = ("ls", "read_file")
+            _exclude_resource_read_from_eviction()
+            assert READ_TOOL in _fs.TOOLS_EXCLUDED_FROM_EVICTION
+        finally:
+            _fs.TOOLS_EXCLUDED_FROM_EVICTION = original
+
+    def test_idempotent(self):
+        from deepagents.middleware import filesystem as _fs
+
+        from deep_agent.aegra.graph import _exclude_resource_read_from_eviction
+
+        original = _fs.TOOLS_EXCLUDED_FROM_EVICTION
+        try:
+            _fs.TOOLS_EXCLUDED_FROM_EVICTION = ("ls", "read_file")
+            _exclude_resource_read_from_eviction()
+            _exclude_resource_read_from_eviction()
+            count = _fs.TOOLS_EXCLUDED_FROM_EVICTION.count(READ_TOOL)
+            assert count == 1
+        finally:
+            _fs.TOOLS_EXCLUDED_FROM_EVICTION = original

--- a/tests/unit/aegra/test_mcp_resource_tools.py
+++ b/tests/unit/aegra/test_mcp_resource_tools.py
@@ -1,0 +1,305 @@
+"""Unit tests for host MCP resource tools (resources/list, templates, read)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from deep_agent.aegra.mcp import _current_access_token, _current_user_id
+from deep_agent.aegra.mcp_auth import NeedsAuthorization
+from deep_agent.aegra.mcp_resource_tools import (
+    LIST_TOOL,
+    READ_TOOL,
+    TEMPLATES_TOOL,
+    build_mcp_resource_tools,
+)
+
+
+def _tool(tools, name):
+    return next(t for t in tools if t.name == name)
+
+
+@pytest.fixture
+def auth_ctx():
+    uid = _current_user_id.set("user-1")
+    tok = _current_access_token.set("sso-token")
+    try:
+        yield
+    finally:
+        _current_user_id.reset(uid)
+        _current_access_token.reset(tok)
+
+
+class TestGetMcpResourceTools:
+    def test_all_enabled_when_server_names_omitted(self):
+        with (
+            patch(
+                "deep_agent.aegra.mcp_resource_tools._get_server_configs",
+                return_value={
+                    "a": {"enabled": True},
+                    "b": {"enabled": False},
+                    "c": {"enabled": True},
+                },
+            ),
+            patch(
+                "deep_agent.aegra.mcp_resource_tools.build_mcp_resource_tools",
+                return_value=[],
+            ) as mock_build,
+        ):
+            from deep_agent.aegra.mcp_resource_tools import get_mcp_resource_tools
+
+            get_mcp_resource_tools(server_names=None)
+        mock_build.assert_called_once_with(
+            allowed_servers=["a", "c"], allowed_uris=None
+        )
+
+    def test_intersects_declared_mcps_with_enabled(self):
+        with (
+            patch(
+                "deep_agent.aegra.mcp_resource_tools._get_server_configs",
+                return_value={
+                    "a": {"enabled": True},
+                    "b": {"enabled": False},
+                    "c": {"enabled": True},
+                },
+            ),
+            patch(
+                "deep_agent.aegra.mcp_resource_tools.build_mcp_resource_tools",
+                return_value=[],
+            ) as mock_build,
+        ):
+            from deep_agent.aegra.mcp_resource_tools import get_mcp_resource_tools
+
+            get_mcp_resource_tools(server_names=["b", "c", "missing"])
+        mock_build.assert_called_once_with(allowed_servers=["c"], allowed_uris=None)
+
+    def test_forwards_allowed_uris(self):
+        with (
+            patch(
+                "deep_agent.aegra.mcp_resource_tools._get_server_configs",
+                return_value={"a": {"enabled": True}},
+            ),
+            patch(
+                "deep_agent.aegra.mcp_resource_tools.build_mcp_resource_tools",
+                return_value=[],
+            ) as mock_build,
+        ):
+            from deep_agent.aegra.mcp_resource_tools import get_mcp_resource_tools
+
+            get_mcp_resource_tools(server_names=None, allowed_uris=["template://about"])
+        mock_build.assert_called_once_with(
+            allowed_servers=["a"], allowed_uris=["template://about"]
+        )
+
+
+class TestBuildMcpResourceTools:
+    def test_empty_uri_allowlist_returns_no_tools(self):
+        tools = build_mcp_resource_tools(
+            allowed_servers=["template-mcp-server"],
+            allowed_uris=[],
+        )
+        assert tools == []
+
+    def test_no_servers_returns_no_tools(self):
+        tools = build_mcp_resource_tools(allowed_servers=[], allowed_uris=None)
+        assert tools == []
+
+    def test_unrestricted_returns_three_tools(self):
+        tools = build_mcp_resource_tools(
+            allowed_servers=["template-mcp-server"],
+            allowed_uris=None,
+        )
+        assert [t.name for t in tools] == [LIST_TOOL, TEMPLATES_TOOL, READ_TOOL]
+
+
+class TestListResourcesTool:
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_server(self, auth_ctx):
+        tools = build_mcp_resource_tools(
+            allowed_servers=["template-mcp-server"],
+            allowed_uris=None,
+        )
+        result = await _tool(tools, LIST_TOOL).ainvoke({"mcp_name": "other"})
+        assert "disallowed" in result
+        assert "template-mcp-server" in result
+
+    @pytest.mark.asyncio
+    async def test_passes_cursor_and_auth(self, auth_ctx):
+        tools = build_mcp_resource_tools(
+            allowed_servers=["template-mcp-server"],
+            allowed_uris=None,
+        )
+        payload = {
+            "resources": [{"uri": "template://about", "name": "about"}],
+            "nextCursor": "page-2",
+        }
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.list_resources",
+            new_callable=AsyncMock,
+            return_value=payload,
+        ) as mock_list:
+            result = await _tool(tools, LIST_TOOL).ainvoke(
+                {"mcp_name": "template-mcp-server", "cursor": "abc"}
+            )
+        mock_list.assert_awaited_once_with(
+            "template-mcp-server",
+            cursor="abc",
+            user_id="user-1",
+            sso_token="sso-token",
+        )
+        parsed = json.loads(result)
+        assert parsed["resources"][0]["uri"] == "template://about"
+        assert parsed["nextCursor"] == "page-2"
+
+    @pytest.mark.asyncio
+    async def test_filters_list_by_allowlist(self, auth_ctx):
+        tools = build_mcp_resource_tools(
+            allowed_servers=["s"],
+            allowed_uris=["template://about"],
+        )
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.list_resources",
+            new_callable=AsyncMock,
+            return_value={
+                "resources": [
+                    {"uri": "template://about", "name": "about"},
+                    {"uri": "template://secret", "name": "secret"},
+                ]
+            },
+        ):
+            result = await _tool(tools, LIST_TOOL).ainvoke({"mcp_name": "s"})
+        uris = [r["uri"] for r in json.loads(result)["resources"]]
+        assert uris == ["template://about"]
+
+    @pytest.mark.asyncio
+    async def test_authorization_required_raises(self, auth_ctx):
+        tools = build_mcp_resource_tools(allowed_servers=["s"], allowed_uris=None)
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.list_resources",
+            new_callable=AsyncMock,
+            side_effect=HTTPException(
+                status_code=401,
+                detail={
+                    "error": "authorization_required",
+                    "mcp_name": "s",
+                    "connect_url": "/mcp/s/connect",
+                },
+            ),
+        ):
+            with pytest.raises(NeedsAuthorization) as exc:
+                await _tool(tools, LIST_TOOL).ainvoke({"mcp_name": "s"})
+        assert exc.value.mcp_name == "s"
+        assert exc.value.connect_url == "/mcp/s/connect"
+
+    @pytest.mark.asyncio
+    async def test_other_http_errors_are_strings(self, auth_ctx):
+        tools = build_mcp_resource_tools(allowed_servers=["s"], allowed_uris=None)
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.list_resources",
+            new_callable=AsyncMock,
+            side_effect=HTTPException(status_code=404, detail="Unknown or disabled"),
+        ):
+            result = await _tool(tools, LIST_TOOL).ainvoke({"mcp_name": "s"})
+        assert result.startswith("MCP resource request failed (404)")
+
+
+class TestListTemplatesTool:
+    @pytest.mark.asyncio
+    async def test_filters_templates_by_exact_uri_template(self, auth_ctx):
+        tools = build_mcp_resource_tools(
+            allowed_servers=["s"],
+            allowed_uris=["template://echo/{text}"],
+        )
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.list_resource_templates",
+            new_callable=AsyncMock,
+            return_value={
+                "resourceTemplates": [
+                    {"uriTemplate": "template://echo/{text}", "name": "echo"},
+                    {"uriTemplate": "template://other/{id}", "name": "other"},
+                ]
+            },
+        ):
+            result = await _tool(tools, TEMPLATES_TOOL).ainvoke({"mcp_name": "s"})
+        templates = json.loads(result)["resourceTemplates"]
+        assert len(templates) == 1
+        assert templates[0]["uriTemplate"] == "template://echo/{text}"
+
+
+class TestReadResourceTool:
+    @pytest.mark.asyncio
+    async def test_returns_full_text_and_blob(self, auth_ctx):
+        tools = build_mcp_resource_tools(allowed_servers=["s"], allowed_uris=None)
+        blob = "a" * 20_000
+        payload = {
+            "contents": [
+                {"uri": "template://about", "mimeType": "text/plain", "text": "hello"},
+                {"uri": "template://logo", "mimeType": "image/png", "blob": blob},
+            ]
+        }
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.read_resource",
+            new_callable=AsyncMock,
+            return_value=payload,
+        ) as mock_read:
+            result = await _tool(tools, READ_TOOL).ainvoke(
+                {"mcp_name": "s", "uri": "template://logo"}
+            )
+        mock_read.assert_awaited_once_with(
+            "s", "template://logo", user_id="user-1", sso_token="sso-token"
+        )
+        parsed = json.loads(result)
+        assert parsed["contents"][0]["text"] == "hello"
+        assert parsed["contents"][1]["blob"] == blob
+
+    @pytest.mark.asyncio
+    async def test_rejects_uri_not_on_allowlist(self, auth_ctx):
+        tools = build_mcp_resource_tools(
+            allowed_servers=["s"],
+            allowed_uris=["template://about"],
+        )
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.read_resource",
+            new_callable=AsyncMock,
+        ) as mock_read:
+            result = await _tool(tools, READ_TOOL).ainvoke(
+                {"mcp_name": "s", "uri": "template://secret"}
+            )
+        mock_read.assert_not_awaited()
+        assert "not allowed" in result
+
+    @pytest.mark.asyncio
+    async def test_allows_uri_matching_listed_template(self, auth_ctx):
+        tools = build_mcp_resource_tools(
+            allowed_servers=["s"],
+            allowed_uris=["template://echo/{text}"],
+        )
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.read_resource",
+            new_callable=AsyncMock,
+            return_value={"contents": [{"uri": "template://echo/hi", "text": "hi"}]},
+        ) as mock_read:
+            result = await _tool(tools, READ_TOOL).ainvoke(
+                {"mcp_name": "s", "uri": "template://echo/hi"}
+            )
+        mock_read.assert_awaited_once()
+        assert json.loads(result)["contents"][0]["text"] == "hi"
+
+    @pytest.mark.asyncio
+    async def test_template_does_not_match_extra_path_segment(self, auth_ctx):
+        tools = build_mcp_resource_tools(
+            allowed_servers=["s"],
+            allowed_uris=["template://echo/{text}"],
+        )
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.read_resource",
+            new_callable=AsyncMock,
+        ) as mock_read:
+            result = await _tool(tools, READ_TOOL).ainvoke(
+                {"mcp_name": "s", "uri": "template://echo/a/b"}
+            )
+        mock_read.assert_not_awaited()
+        assert "not allowed" in result

--- a/tests/unit/aegra/test_mcp_resource_tools.py
+++ b/tests/unit/aegra/test_mcp_resource_tools.py
@@ -114,6 +114,9 @@ class TestBuildMcpResourceTools:
         )
         assert [t.name for t in tools] == [LIST_TOOL, TEMPLATES_TOOL, READ_TOOL]
         assert "omitted" in _tool(tools, READ_TOOL).description
+        for t in tools:
+            assert t.func is None
+            assert t.coroutine is not None
 
 
 class TestListResourcesTool:
@@ -468,8 +471,10 @@ class TestReadResourceTool:
         assert "offset=" in result
         offset_val = int(result.split("offset=")[1].split(" ")[0].rstrip(","))
         assert offset_val < 100
-        assert "short-0" in result
-        assert f"short-{offset_val}" not in content_before_notice
+        assert offset_val >= 50
+        assert "short-0" in content_before_notice
+        assert "short-49" in content_before_notice
+        assert f"long-{offset_val - 50}-" not in content_before_notice
 
     @pytest.mark.asyncio
     async def test_negative_limit_clamped_to_1(self, auth_ctx):

--- a/tests/unit/aegra/test_mcp_resource_tools.py
+++ b/tests/unit/aegra/test_mcp_resource_tools.py
@@ -11,6 +11,7 @@ from fastapi import HTTPException
 from deep_agent.aegra.mcp import _current_access_token, _current_user_id
 from deep_agent.aegra.mcp_auth import NeedsAuthorization
 from deep_agent.aegra.mcp_resource_tools import (
+    BLOB_OMITTED,
     LIST_TOOL,
     READ_TOOL,
     TEMPLATES_TOOL,
@@ -113,6 +114,7 @@ class TestBuildMcpResourceTools:
             allowed_uris=None,
         )
         assert [t.name for t in tools] == [LIST_TOOL, TEMPLATES_TOOL, READ_TOOL]
+        assert "omitted" in _tool(tools, READ_TOOL).description
 
 
 class TestListResourcesTool:
@@ -231,9 +233,9 @@ class TestListTemplatesTool:
 
 class TestReadResourceTool:
     @pytest.mark.asyncio
-    async def test_returns_full_text_and_blob(self, auth_ctx):
+    async def test_keeps_text_and_stubs_blob(self, auth_ctx):
         tools = build_mcp_resource_tools(allowed_servers=["s"], allowed_uris=None)
-        blob = "a" * 20_000
+        blob = "cG5nLWJ5dGVz"
         payload = {
             "contents": [
                 {"uri": "template://about", "mimeType": "text/plain", "text": "hello"},
@@ -253,7 +255,52 @@ class TestReadResourceTool:
         )
         parsed = json.loads(result)
         assert parsed["contents"][0]["text"] == "hello"
-        assert parsed["contents"][1]["blob"] == blob
+        logo = parsed["contents"][1]
+        assert "blob" not in logo
+        assert logo["text"] == BLOB_OMITTED
+        assert blob not in result
+
+    @pytest.mark.asyncio
+    async def test_text_only_is_unchanged(self, auth_ctx):
+        tools = build_mcp_resource_tools(allowed_servers=["s"], allowed_uris=None)
+        payload = {
+            "contents": [
+                {"uri": "template://about", "mimeType": "text/plain", "text": "hello"}
+            ]
+        }
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.read_resource",
+            new_callable=AsyncMock,
+            return_value=payload,
+        ):
+            result = await _tool(tools, READ_TOOL).ainvoke(
+                {"mcp_name": "s", "uri": "template://about"}
+            )
+        assert json.loads(result) == payload
+
+    @pytest.mark.asyncio
+    async def test_keeps_text_when_same_item_has_blob(self, auth_ctx):
+        tools = build_mcp_resource_tools(allowed_servers=["s"], allowed_uris=None)
+        with patch(
+            "deep_agent.aegra.mcp_resource_tools.read_resource",
+            new_callable=AsyncMock,
+            return_value={
+                "contents": [
+                    {
+                        "uri": "template://both",
+                        "mimeType": "text/plain",
+                        "text": "caption",
+                        "blob": "eA==",
+                    }
+                ]
+            },
+        ):
+            result = await _tool(tools, READ_TOOL).ainvoke(
+                {"mcp_name": "s", "uri": "template://both"}
+            )
+        item = json.loads(result)["contents"][0]
+        assert item["text"] == "caption"
+        assert "blob" not in item
 
     @pytest.mark.asyncio
     async def test_rejects_uri_not_on_allowlist(self, auth_ctx):

--- a/tests/unit/agent/config/test_config.py
+++ b/tests/unit/agent/config/test_config.py
@@ -226,7 +226,7 @@ Orchestrator.
         assert orch["resources"] == ["template://about", "template://echo/{text}"]
 
     def test_orchestrator_empty_resources_list(self, tmp_path):
-        """Explicit empty list is valid (allow none), distinct from omit."""
+        """Loader preserves empty list; wiring normalizes to unrestricted (same as omit)."""
         config_dir = tmp_path / "agent_config"
         config_dir.mkdir()
         (config_dir / "skills").mkdir()

--- a/tests/unit/agent/config/test_config.py
+++ b/tests/unit/agent/config/test_config.py
@@ -182,6 +182,143 @@ Bad agent.
         assert "must be a list of strings" in caplog.text
 
 
+class TestResourcesValidation:
+    """Test optional resources URI allowlist frontmatter."""
+
+    def setup_method(self):
+        AgentConfig._instance = None
+
+    def test_orchestrator_omits_resources_key(self, tmp_path):
+        """Missing resources means allow-all later — do not default to []."""
+        config_dir = tmp_path / "agent_config"
+        config_dir.mkdir()
+        (config_dir / "skills").mkdir()
+
+        (config_dir / "PROMPT.md").write_text("""---
+name: orch
+model: gemini-2.5-flash
+---
+Orchestrator.
+""")
+
+        cfg = AgentConfig(config_dir)
+        orch = cfg.get_orchestrator_config()
+        assert "resources" not in orch
+
+    def test_orchestrator_valid_resources(self, tmp_path):
+        """Valid resources list of URI strings loads without error."""
+        config_dir = tmp_path / "agent_config"
+        config_dir.mkdir()
+        (config_dir / "skills").mkdir()
+
+        (config_dir / "PROMPT.md").write_text("""---
+name: orch
+model: gemini-2.5-flash
+resources:
+  - template://about
+  - template://echo/{text}
+---
+Orchestrator.
+""")
+
+        cfg = AgentConfig(config_dir)
+        orch = cfg.get_orchestrator_config()
+        assert orch["resources"] == ["template://about", "template://echo/{text}"]
+
+    def test_orchestrator_empty_resources_list(self, tmp_path):
+        """Explicit empty list is valid (allow none), distinct from omit."""
+        config_dir = tmp_path / "agent_config"
+        config_dir.mkdir()
+        (config_dir / "skills").mkdir()
+
+        (config_dir / "PROMPT.md").write_text("""---
+name: orch
+model: gemini-2.5-flash
+resources: []
+---
+Orchestrator.
+""")
+
+        cfg = AgentConfig(config_dir)
+        orch = cfg.get_orchestrator_config()
+        assert orch["resources"] == []
+
+    def test_orchestrator_invalid_resources_raises(self, tmp_path):
+        """Non-list resources raises AppException."""
+        config_dir = tmp_path / "agent_config"
+        config_dir.mkdir()
+        (config_dir / "skills").mkdir()
+
+        (config_dir / "PROMPT.md").write_text("""---
+name: orch
+model: gemini-2.5-flash
+resources: "not-a-list"
+---
+Orchestrator.
+""")
+
+        with pytest.raises(AppException, match="must be a list of strings"):
+            cfg = AgentConfig(config_dir)
+            cfg.get_orchestrator_config()
+
+    def test_subagent_valid_resources(self, tmp_path):
+        """Subagent resources list of strings is kept on the config."""
+        config_dir = tmp_path / "agent_config"
+        config_dir.mkdir()
+        (config_dir / "skills").mkdir()
+
+        (config_dir / "PROMPT.md").write_text("""---
+name: orch
+model: gemini-2.5-flash
+---
+Orchestrator.
+""")
+
+        sub_dir = config_dir / "subagents"
+        sub_dir.mkdir()
+        (sub_dir / "analyst.md").write_text("""---
+name: analyst
+model: gemini-2.5-flash
+resources:
+  - template://about
+---
+Analyst.
+""")
+
+        cfg = AgentConfig(config_dir)
+        subs = cfg.get_all_subagent_configs()
+        assert subs["analyst"]["resources"] == ["template://about"]
+
+    def test_subagent_invalid_resources_is_skipped(self, tmp_path, caplog):
+        """Subagent with non-string resources entries is skipped and logged."""
+        config_dir = tmp_path / "agent_config"
+        config_dir.mkdir()
+        (config_dir / "skills").mkdir()
+
+        (config_dir / "PROMPT.md").write_text("""---
+name: orch
+model: gemini-2.5-flash
+---
+Orchestrator.
+""")
+
+        sub_dir = config_dir / "subagents"
+        sub_dir.mkdir()
+        (sub_dir / "bad.md").write_text("""---
+name: bad-agent
+model: gemini-2.5-flash
+resources:
+  - 123
+---
+Bad agent.
+""")
+
+        cfg = AgentConfig(config_dir)
+        subs = cfg.get_all_subagent_configs()
+        assert "bad-agent" not in subs
+        assert "must be a list of strings" in caplog.text
+
+
 class TestLoadGuardrailsConfig:
     """Tests for _load_guardrails_config taking agent_yaml_guardrail dict."""
 

--- a/tests/unit/infrastructure/test_subagents.py
+++ b/tests/unit/infrastructure/test_subagents.py
@@ -1357,9 +1357,7 @@ class TestMcpResourceToolsOnSubagents:
             server_names=["keep-me"], allowed_uris=["template://about"]
         )
 
-    def test_default_omits_resource_tools_when_resources_empty(
-        self, _no_mcp_resource_tools
-    ):
+    def test_default_resources_empty_allows_all(self, _no_mcp_resource_tools):
         mock_tool = MagicMock()
         mock_settings = MagicMock()
         mock_settings.GUARDIAN_API_BASE = ""
@@ -1408,7 +1406,56 @@ class TestMcpResourceToolsOnSubagents:
 
         assert mock_sa.call_args.kwargs["tools"] == [mock_tool]
         _no_mcp_resource_tools.assert_called_once_with(
-            server_names=None, allowed_uris=[]
+            server_names=None, allowed_uris=None
+        )
+
+    def test_default_inherits_orchestrator_resources(self, _no_mcp_resource_tools):
+        mock_settings = MagicMock()
+        mock_settings.GUARDIAN_API_BASE = ""
+
+        with (
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_all_subagent_configs",
+                return_value={
+                    "analyst": {
+                        "name": "analyst",
+                        "model": "gemini-2.5-flash",
+                        "description": "Analyst",
+                        "body": "Prompt",
+                        "tools": ["calculate_bmi"],
+                    }
+                },
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_orchestrator_config",
+                return_value={"resources": ["template://about"]},
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.resolve_tools",
+                return_value=[MagicMock()],
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.get_or_create_model_from_spec",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.SubAgent",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.build_audit_middleware",
+                return_value=None,
+            ),
+            patch("deep_agent.src.settings.settings", mock_settings),
+            patch(
+                "deep_agent.src.infrastructure.subagents.build_opa_middleware",
+                return_value=None,
+            ),
+        ):
+            load_subagents(tools=[])
+
+        _no_mcp_resource_tools.assert_called_once_with(
+            server_names=None, allowed_uris=["template://about"]
         )
 
     def test_compiled_explicit_tools_still_gets_resource_tools(

--- a/tests/unit/infrastructure/test_subagents.py
+++ b/tests/unit/infrastructure/test_subagents.py
@@ -9,6 +9,16 @@ from deep_agent.src.exceptions import SubAgentError
 from deep_agent.src.infrastructure.subagents import VALID_AGENT_TYPES, load_subagents
 
 
+@pytest.fixture(autouse=True)
+def _no_mcp_resource_tools():
+    """Keep existing tool-list assertions hermetic; override in resource tests."""
+    with patch(
+        "deep_agent.aegra.mcp_resource_tools.get_mcp_resource_tools",
+        return_value=[],
+    ) as mock:
+        yield mock
+
+
 class TestLoadSubagents:
     """Tests for load_subagents function."""
 
@@ -1235,3 +1245,252 @@ class TestGuardianActivationGate:
 
         mock_wrap.assert_not_called()
         mock_safety_cls.assert_not_called()
+
+
+class TestMcpResourceToolsOnSubagents:
+    """Resource tools are appended per subagent, even with an explicit tools: list."""
+
+    def test_default_explicit_tools_still_gets_resource_tools(
+        self, _no_mcp_resource_tools
+    ):
+        resource_tool = MagicMock()
+        resource_tool.name = "mcp_list_resources"
+        _no_mcp_resource_tools.return_value = [resource_tool]
+        mock_tool = MagicMock()
+        mock_settings = MagicMock()
+        mock_settings.GUARDIAN_API_BASE = ""
+
+        with (
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_all_subagent_configs",
+                return_value={
+                    "analyst": {
+                        "name": "analyst",
+                        "model": "gemini-2.5-flash",
+                        "description": "Analyst",
+                        "body": "Prompt",
+                        "tools": ["calculate_bmi"],
+                    }
+                },
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_orchestrator_config",
+                return_value={},
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.resolve_tools",
+                return_value=[mock_tool],
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.get_or_create_model_from_spec",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.SubAgent",
+                return_value=MagicMock(),
+            ) as mock_sa,
+            patch(
+                "deep_agent.src.infrastructure.subagents.build_audit_middleware",
+                return_value=None,
+            ),
+            patch("deep_agent.src.settings.settings", mock_settings),
+            patch(
+                "deep_agent.src.infrastructure.subagents.build_opa_middleware",
+                return_value=None,
+            ),
+        ):
+            load_subagents(tools=[mock_tool])
+
+        assert mock_sa.call_args.kwargs["tools"] == [mock_tool, resource_tool]
+        _no_mcp_resource_tools.assert_called_once_with(
+            server_names=None, allowed_uris=None
+        )
+
+    def test_default_passes_agent_mcps_and_resources(self, _no_mcp_resource_tools):
+        mock_settings = MagicMock()
+        mock_settings.GUARDIAN_API_BASE = ""
+
+        with (
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_all_subagent_configs",
+                return_value={
+                    "analyst": {
+                        "name": "analyst",
+                        "model": "gemini-2.5-flash",
+                        "description": "Analyst",
+                        "body": "Prompt",
+                        "tools": ["calculate_bmi"],
+                        "mcps": ["keep-me"],
+                        "resources": ["template://about"],
+                    }
+                },
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_orchestrator_config",
+                return_value={},
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.resolve_tools",
+                return_value=[MagicMock()],
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.get_or_create_model_from_spec",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.SubAgent",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.build_audit_middleware",
+                return_value=None,
+            ),
+            patch("deep_agent.src.settings.settings", mock_settings),
+            patch(
+                "deep_agent.src.infrastructure.subagents.build_opa_middleware",
+                return_value=None,
+            ),
+        ):
+            load_subagents(tools=[])
+
+        _no_mcp_resource_tools.assert_called_once_with(
+            server_names=["keep-me"], allowed_uris=["template://about"]
+        )
+
+    def test_default_omits_resource_tools_when_resources_empty(
+        self, _no_mcp_resource_tools
+    ):
+        mock_tool = MagicMock()
+        mock_settings = MagicMock()
+        mock_settings.GUARDIAN_API_BASE = ""
+
+        with (
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_all_subagent_configs",
+                return_value={
+                    "analyst": {
+                        "name": "analyst",
+                        "model": "gemini-2.5-flash",
+                        "description": "Analyst",
+                        "body": "Prompt",
+                        "tools": ["calculate_bmi"],
+                        "resources": [],
+                    }
+                },
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_orchestrator_config",
+                return_value={},
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.resolve_tools",
+                return_value=[mock_tool],
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.get_or_create_model_from_spec",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.SubAgent",
+                return_value=MagicMock(),
+            ) as mock_sa,
+            patch(
+                "deep_agent.src.infrastructure.subagents.build_audit_middleware",
+                return_value=None,
+            ),
+            patch("deep_agent.src.settings.settings", mock_settings),
+            patch(
+                "deep_agent.src.infrastructure.subagents.build_opa_middleware",
+                return_value=None,
+            ),
+        ):
+            load_subagents(tools=[mock_tool])
+
+        assert mock_sa.call_args.kwargs["tools"] == [mock_tool]
+        _no_mcp_resource_tools.assert_called_once_with(
+            server_names=None, allowed_uris=[]
+        )
+
+    def test_compiled_explicit_tools_still_gets_resource_tools(
+        self, _no_mcp_resource_tools
+    ):
+        resource_tool = MagicMock()
+        resource_tool.name = "mcp_list_resources"
+        _no_mcp_resource_tools.return_value = [resource_tool]
+        mock_tool = MagicMock()
+        mock_settings = MagicMock()
+        mock_settings.GUARDIAN_API_BASE = ""
+
+        with (
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_all_subagent_configs",
+                return_value={
+                    "analyst": {
+                        "name": "analyst",
+                        "type": "compiled",
+                        "model": "gemini-2.5-pro",
+                        "description": "Fast analyst",
+                        "body": "Prompt",
+                        "tools": ["calculate_bmi"],
+                    }
+                },
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_orchestrator_config",
+                return_value={},
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.resolve_tools",
+                return_value=[mock_tool],
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.get_or_create_model_from_spec",
+                return_value=MagicMock(),
+            ),
+            patch("deepagents.create_deep_agent") as mock_create_agent,
+            patch(
+                "deep_agent.src.infrastructure.backend.get_configured_backend",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.CompiledSubAgent",
+                return_value=MagicMock(),
+            ),
+            patch("deep_agent.src.settings.settings", mock_settings),
+            patch("deep_agent.src.pii.get_scrubber", return_value=None),
+        ):
+            load_subagents(tools=[mock_tool])
+
+        assert mock_create_agent.call_args.kwargs["tools"] == [
+            mock_tool,
+            resource_tool,
+        ]
+        _no_mcp_resource_tools.assert_called_once_with(
+            server_names=None, allowed_uris=None
+        )
+
+    def test_async_subagent_does_not_attach_resource_tools(
+        self, _no_mcp_resource_tools
+    ):
+        with (
+            patch(
+                "deep_agent.src.infrastructure.subagents.agent_config.get_all_subagent_configs",
+                return_value={
+                    "researcher": {
+                        "name": "researcher",
+                        "type": "async",
+                        "description": "Remote researcher",
+                        "body": "",
+                        "graph_id": "researcher-graph",
+                        "url": "http://research-agent:8000",
+                    }
+                },
+            ),
+            patch(
+                "deep_agent.src.infrastructure.subagents.AsyncSubAgent",
+                return_value=MagicMock(),
+            ),
+        ):
+            load_subagents(tools=[])
+
+        _no_mcp_resource_tools.assert_not_called()


### PR DESCRIPTION
## What

Add spec-compliant MCP resource tools (`mcp_list_resources`, `mcp_list_resource_templates`, `mcp_read_resource`) so agents can read resources from any enabled MCP server, with `read_file`-style pagination and context-safe defaults.

Fixes #316

## How

**Three new LangChain tools** in `mcp_resource_tools.py` that proxy MCP `resources/list`, `resources/templates/list`, and `resources/read` at turn time. No catalog cache — stateless and multi-pod safe.

**Pagination** on `mcp_read_resource`: `offset`/`limit` (defaults 0/100), 400k char budget (sized for full GUIDANCE.md), line-boundary truncation, long-line pre-splitting. Blobs replaced with `[Binary content omitted (mime)]` stubs.

**Eviction skip list**: `mcp_read_resource` added to `TOOLS_EXCLUDED_FROM_EVICTION` so FilesystemMiddleware does not offload results to `/large_tool_results/`.

**Scoping**: `resources:` frontmatter allowlist (URI / `uriTemplate` strings). Omit or `[]` = all URIs. Subagents without `resources:` inherit the orchestrator's list.

**Graph cache**: fingerprint now includes `resource_uris` and `mcp_server_names` so allowlist changes bust the cache.

**Config validation**: `loader.py` validates `resources:` as a list of strings at load time.

## Testing

- [x] Unit tests added/updated (35 resource tool tests, 5 graph tests, 6 subagent tests, config validation tests)
- [x] Ran locally (`uv run pytest tests/unit -x`)
- [x] Manual verification against mock MCP server: pagination (short/long/wide/huge-line), blob handling, template URI matching, server/URI allowlist rejection, edge cases (negative limit, offset past end, blank-line + long-line), resource inheritance (orchestrator restricts → subagent inherits → subagent overrides)

## Rollback

Revert the three commits. Resource tools are additive — removing them leaves agents with only MCP server tools, which is the pre-existing behavior.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `ci:`, etc.)
- [x] No secrets, credentials, or PII in the diff
- [x] No breaking changes (or documented above with a migration path)
- [x] Pre-commit hooks pass (`uv run pre-commit run --all-files`)