### PR TITLE
fix: add distributed lock and proactive refresh for SSO token renewal

### DIFF
--- a/deep_agent/aegra/auth.py
+++ b/deep_agent/aegra/auth.py
@@ -245,7 +245,9 @@ async def authenticate(headers: dict) -> dict:
         raise PermissionError("Missing or invalid Authorization header")
 
     access_token = auth_header[7:]
-    refresh_token = headers.get("x-refresh-token", "")
+    refresh_token = headers.get("x-user-refresh-token", "") or headers.get(
+        "x-refresh-token", ""
+    )
 
     try:
         payload = _decode_token(access_token)

--- a/deep_agent/aegra/graph.py
+++ b/deep_agent/aegra/graph.py
@@ -272,6 +272,11 @@ async def agent(runtime: ServerRuntime) -> Any:
         sso_token = await refresh_access_token(
             sso_token, refresh_token, user_id=user_identity
         )
+        from deep_agent.aegra.mcp import _user_token_cache
+
+        cached = _user_token_cache.get(user_identity) if user_identity else None
+        if cached:
+            refresh_token = cached[1]
 
     set_mcp_auth_context(sso_token, refresh_token, user_identity)
     orchestrator_cfg = agent_config.get_orchestrator_config()

--- a/deep_agent/aegra/graph.py
+++ b/deep_agent/aegra/graph.py
@@ -266,11 +266,12 @@ async def agent(runtime: ServerRuntime) -> Any:
     user = getattr(runtime, "user", None)
     sso_token = getattr(user, "access_token", None) if user else None
     refresh_token = getattr(user, "refresh_token", None) if user else None
+    user_identity = getattr(user, "identity", None) if user else None
 
     if sso_token:
-        sso_token = await refresh_access_token(sso_token, refresh_token)
-
-    user_identity = getattr(user, "identity", None) if user else None
+        sso_token = await refresh_access_token(
+            sso_token, refresh_token, user_id=user_identity
+        )
 
     set_mcp_auth_context(sso_token, refresh_token, user_identity)
     orchestrator_cfg = agent_config.get_orchestrator_config()

--- a/deep_agent/aegra/mcp.py
+++ b/deep_agent/aegra/mcp.py
@@ -190,16 +190,24 @@ def _jwt_exp(token: str) -> float:
         return 0.0
 
 
+_SSO_REFRESH_BUFFER_SECS: float = 60.0
+
+_sso_refresh_lock: asyncio.Lock = asyncio.Lock()
+
+
 async def refresh_access_token(
     access_token: str,
     refresh_token: str | None,
 ) -> str:
     """Return a fresh access token, using the refresh_token grant if needed.
 
-    If the current ``access_token`` has more than 30 seconds of remaining
-    lifetime it is returned as-is.  Otherwise, if a ``refresh_token`` and
-    the OIDC token endpoint are available, the token is refreshed via the
-    standard ``refresh_token`` grant.
+    Proactively refreshes when fewer than 60 seconds remain (up from 30)
+    so long-running tool chains are less likely to hit expiry mid-call.
+
+    Uses a distributed Redis lock (falling back to an in-process asyncio
+    lock) to prevent concurrent refresh calls from racing — important when
+    Keycloak refresh-token rotation is enabled, as the old refresh token is
+    invalidated on first use.
 
     Args:
         access_token: Current JWT access token (may be expired).
@@ -210,7 +218,7 @@ async def refresh_access_token(
         is unavailable or fails).
     """
     remaining: float = _jwt_exp(access_token) - time.time()
-    if remaining > 30:
+    if remaining > _SSO_REFRESH_BUFFER_SECS:
         logger.debug("Access token still valid (%.0fs remaining)", remaining)
         return access_token
 
@@ -227,6 +235,52 @@ async def refresh_access_token(
         logger.warning("Cannot refresh token — SSO_ISSUER_URL or SSO_CLIENT_ID not set")
         return access_token
 
+    return await _locked_sso_refresh(access_token, refresh_token, remaining)
+
+
+async def _locked_sso_refresh(
+    access_token: str,
+    refresh_token: str,
+    remaining: float,
+) -> str:
+    """Perform the actual SSO refresh under a lock to prevent concurrent races."""
+    from deep_agent.aegra.redis import distributed_lock
+
+    user_id = _current_user_id.get() or "unknown"
+    lock_name = f"sso:refresh:{user_id}"
+
+    async with distributed_lock(lock_name, ttl_seconds=15, wait_seconds=10) as state:
+        if state == "no_redis":
+            async with _sso_refresh_lock:
+                return await _do_sso_refresh(access_token, refresh_token, remaining)
+        elif state == "timeout":
+            current = _current_access_token.get()
+            if current and current != access_token:
+                check_remaining = _jwt_exp(current) - time.time()
+                if check_remaining > 10:
+                    logger.info(
+                        "SSO refresh lock timeout — another thread refreshed (%.0fs left)",
+                        check_remaining,
+                    )
+                    return current
+            logger.warning("SSO refresh lock timeout — using current token")
+            return access_token
+        else:
+            current = _current_access_token.get()
+            if current and current != access_token:
+                check_remaining = _jwt_exp(current) - time.time()
+                if check_remaining > _SSO_REFRESH_BUFFER_SECS:
+                    logger.debug("SSO token already refreshed by another call")
+                    return current
+            return await _do_sso_refresh(access_token, refresh_token, remaining)
+
+
+async def _do_sso_refresh(
+    access_token: str,
+    refresh_token: str,
+    remaining: float,
+) -> str:
+    """Execute the OIDC refresh grant and update context vars."""
     logger.info("Refreshing SSO access token (%.0fs remaining)", remaining)
     try:
         from deep_agent.aegra.auth import EVAL_TOKEN_REFRESH_ENABLED, _oidc_refresh

--- a/deep_agent/aegra/mcp.py
+++ b/deep_agent/aegra/mcp.py
@@ -57,6 +57,12 @@ _current_refresh_token: contextvars.ContextVar[str | None] = contextvars.Context
 _current_user_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "_current_user_id", default=None
 )
+
+# Cross-task shared token cache keyed by user_id.
+# ContextVars are task-local in asyncio, so a refresh completed in one task
+# is invisible to a concurrent task for the same user.  This dict lets the
+# distributed-lock peer-check work across tasks.
+_user_token_cache: dict[str, tuple[str, str]] = {}
 _mcp_tool_discovery: contextvars.ContextVar[bool] = contextvars.ContextVar(
     "_mcp_tool_discovery", default=False
 )
@@ -256,40 +262,44 @@ async def _locked_sso_refresh(
     lock_name = f"sso:refresh:{user_id}"
 
     async with distributed_lock(lock_name, ttl_seconds=15, wait_seconds=10) as state:
+        cached = _user_token_cache.get(user_id)
         if state == "no_redis":
             async with _sso_refresh_lock:
-                current = _current_access_token.get()
-                if current and current != access_token:
-                    check_remaining = _jwt_exp(current) - time.time()
-                    if check_remaining > _SSO_REFRESH_BUFFER_SECS:
-                        logger.debug(
-                            "SSO token already refreshed by peer (no-redis path)"
-                        )
-                        return current
-                latest_rt = _current_refresh_token.get() or refresh_token
+                cached = _user_token_cache.get(user_id)
+                if cached:
+                    cached_at, cached_rt = cached
+                    if cached_at != access_token:
+                        check_remaining = _jwt_exp(cached_at) - time.time()
+                        if check_remaining > _SSO_REFRESH_BUFFER_SECS:
+                            logger.debug(
+                                "SSO token already refreshed by peer (no-redis path)"
+                            )
+                            return cached_at
+                latest_rt = (cached[1] if cached else None) or refresh_token
                 return await _do_sso_refresh(access_token, latest_rt, remaining)
         elif state == "timeout":
-            current = _current_access_token.get()
-            if current and current != access_token:
-                check_remaining = _jwt_exp(current) - time.time()
-                if check_remaining > 10:
-                    logger.info(
-                        "SSO refresh lock timeout — another thread refreshed (%.0fs left)",
-                        check_remaining,
-                    )
-                    return current
+            if cached:
+                cached_at, _ = cached
+                if cached_at != access_token:
+                    check_remaining = _jwt_exp(cached_at) - time.time()
+                    if check_remaining > 10:
+                        logger.info(
+                            "SSO refresh lock timeout — another task refreshed (%.0fs left)",
+                            check_remaining,
+                        )
+                        return cached_at
             logger.warning("SSO refresh lock timeout — using current token")
             return access_token
         else:
-            current = _current_access_token.get()
-            if current and current != access_token:
-                check_remaining = _jwt_exp(current) - time.time()
-                if check_remaining > _SSO_REFRESH_BUFFER_SECS:
-                    logger.debug("SSO token already refreshed by another call")
-                    return current
-                latest_rt = _current_refresh_token.get() or refresh_token
-                return await _do_sso_refresh(access_token, latest_rt, remaining)
-            latest_rt = _current_refresh_token.get() or refresh_token
+            cached = _user_token_cache.get(user_id)
+            if cached:
+                cached_at, cached_rt = cached
+                if cached_at != access_token:
+                    check_remaining = _jwt_exp(cached_at) - time.time()
+                    if check_remaining > _SSO_REFRESH_BUFFER_SECS:
+                        logger.debug("SSO token already refreshed by another task")
+                        return cached_at
+            latest_rt = (cached[1] if cached else None) or refresh_token
             return await _do_sso_refresh(access_token, latest_rt, remaining)
 
 
@@ -310,18 +320,19 @@ async def _do_sso_refresh(
         _current_access_token.set(new_token)
         if new_rt != refresh_token:
             _current_refresh_token.set(new_rt)
+        sub = _current_user_id.get()
+        if sub:
+            _user_token_cache[sub] = (new_token, new_rt)
             if EVAL_TOKEN_REFRESH_ENABLED:
-                sub = _current_user_id.get()
-                if sub:
-                    from deep_agent.aegra.mcp_crypto import encrypt_secret
-                    from deep_agent.aegra.redis import cache_get, cache_set
+                from deep_agent.aegra.mcp_crypto import encrypt_secret
+                from deep_agent.aegra.redis import cache_get, cache_set
 
-                    if await asyncio.to_thread(cache_get, f"eval:active:{sub}"):
-                        encrypted_rt = encrypt_secret(new_rt)
-                        if encrypted_rt:
-                            await asyncio.to_thread(
-                                cache_set, f"eval:refresh:{sub}", encrypted_rt, 3600
-                            )
+                if await asyncio.to_thread(cache_get, f"eval:active:{sub}"):
+                    encrypted_rt = encrypt_secret(new_rt)
+                    if encrypted_rt:
+                        await asyncio.to_thread(
+                            cache_set, f"eval:refresh:{sub}", encrypted_rt, 3600
+                        )
 
         return new_token
     except Exception:

--- a/deep_agent/aegra/mcp.py
+++ b/deep_agent/aegra/mcp.py
@@ -198,6 +198,7 @@ _sso_refresh_lock: asyncio.Lock = asyncio.Lock()
 async def refresh_access_token(
     access_token: str,
     refresh_token: str | None,
+    user_id: str | None = None,
 ) -> str:
     """Return a fresh access token, using the refresh_token grant if needed.
 
@@ -212,6 +213,8 @@ async def refresh_access_token(
     Args:
         access_token: Current JWT access token (may be expired).
         refresh_token: OIDC refresh token (may be ``None`` or ``""``).
+        user_id: Explicit user identity for the lock key. Falls back to
+            ``_current_user_id`` context var if not provided.
 
     Returns:
         A valid access token (refreshed if necessary, original if refresh
@@ -235,24 +238,36 @@ async def refresh_access_token(
         logger.warning("Cannot refresh token — SSO_ISSUER_URL or SSO_CLIENT_ID not set")
         return access_token
 
-    return await _locked_sso_refresh(access_token, refresh_token, remaining)
+    resolved_user_id = user_id or _current_user_id.get() or "unknown"
+    return await _locked_sso_refresh(
+        access_token, refresh_token, remaining, resolved_user_id
+    )
 
 
 async def _locked_sso_refresh(
     access_token: str,
     refresh_token: str,
     remaining: float,
+    user_id: str = "unknown",
 ) -> str:
     """Perform the actual SSO refresh under a lock to prevent concurrent races."""
     from deep_agent.aegra.redis import distributed_lock
 
-    user_id = _current_user_id.get() or "unknown"
     lock_name = f"sso:refresh:{user_id}"
 
     async with distributed_lock(lock_name, ttl_seconds=15, wait_seconds=10) as state:
         if state == "no_redis":
             async with _sso_refresh_lock:
-                return await _do_sso_refresh(access_token, refresh_token, remaining)
+                current = _current_access_token.get()
+                if current and current != access_token:
+                    check_remaining = _jwt_exp(current) - time.time()
+                    if check_remaining > _SSO_REFRESH_BUFFER_SECS:
+                        logger.debug(
+                            "SSO token already refreshed by peer (no-redis path)"
+                        )
+                        return current
+                latest_rt = _current_refresh_token.get() or refresh_token
+                return await _do_sso_refresh(access_token, latest_rt, remaining)
         elif state == "timeout":
             current = _current_access_token.get()
             if current and current != access_token:
@@ -272,7 +287,10 @@ async def _locked_sso_refresh(
                 if check_remaining > _SSO_REFRESH_BUFFER_SECS:
                     logger.debug("SSO token already refreshed by another call")
                     return current
-            return await _do_sso_refresh(access_token, refresh_token, remaining)
+                latest_rt = _current_refresh_token.get() or refresh_token
+                return await _do_sso_refresh(access_token, latest_rt, remaining)
+            latest_rt = _current_refresh_token.get() or refresh_token
+            return await _do_sso_refresh(access_token, latest_rt, remaining)
 
 
 async def _do_sso_refresh(

--- a/deep_agent/aegra/mcp.py
+++ b/deep_agent/aegra/mcp.py
@@ -282,7 +282,7 @@ async def _locked_sso_refresh(
                 cached_at, _ = cached
                 if cached_at != access_token:
                     check_remaining = _jwt_exp(cached_at) - time.time()
-                    if check_remaining > 10:
+                    if check_remaining > _SSO_REFRESH_BUFFER_SECS:
                         logger.info(
                             "SSO refresh lock timeout — another task refreshed (%.0fs left)",
                             check_remaining,

--- a/tests/unit/aegra/test_graph.py
+++ b/tests/unit/aegra/test_graph.py
@@ -205,7 +205,7 @@ class TestAgentFactory:
             result = await agent(mock_runtime)
             assert result is mock_compiled
             mock_refresh.assert_awaited_once_with(
-                "test_access_token", "test_refresh_token"
+                "test_access_token", "test_refresh_token", user_id=None
             )
 
     @pytest.mark.asyncio

--- a/tests/unit/aegra/test_sso_refresh_lock.py
+++ b/tests/unit/aegra/test_sso_refresh_lock.py
@@ -176,18 +176,14 @@ class TestLockedSsoRefresh:
 
         token = _current_user_id.set("cache-user")
         try:
-            with patch(
-                "deep_agent.aegra.mcp._oidc_refresh",
-                new=AsyncMock(return_value=("new-at", "new-rt")),
-            ):
-                with patch("deep_agent.aegra.auth.EVAL_TOKEN_REFRESH_ENABLED", False):
-                    with patch(
-                        "deep_agent.aegra.auth._oidc_refresh",
-                        new=AsyncMock(return_value=("new-at", "new-rt")),
-                    ):
-                        from deep_agent.aegra.mcp import _do_sso_refresh
+            with patch("deep_agent.aegra.auth.EVAL_TOKEN_REFRESH_ENABLED", False):
+                with patch(
+                    "deep_agent.aegra.auth._oidc_refresh",
+                    new=AsyncMock(return_value=("new-at", "new-rt")),
+                ):
+                    from deep_agent.aegra.mcp import _do_sso_refresh
 
-                        result = await _do_sso_refresh("old-at", "old-rt", 10.0)
+                    result = await _do_sso_refresh("old-at", "old-rt", 10.0)
 
             assert result == "new-at"
             assert _user_token_cache.get("cache-user") == ("new-at", "new-rt")

--- a/tests/unit/aegra/test_sso_refresh_lock.py
+++ b/tests/unit/aegra/test_sso_refresh_lock.py
@@ -36,15 +36,9 @@ class TestLockedSsoRefresh:
     async def test_timeout_peer_already_refreshed(self):
         with (
             patch("deep_agent.aegra.redis.distributed_lock", _timeout_lock),
-            patch(
-                "deep_agent.aegra.mcp._current_access_token"
-            ) as mock_cv,
-            patch(
-                "deep_agent.aegra.mcp._current_user_id"
-            ) as mock_uid,
-            patch(
-                "deep_agent.aegra.mcp._jwt_exp", side_effect=_fake_jwt_exp_future
-            ),
+            patch("deep_agent.aegra.mcp._current_access_token") as mock_cv,
+            patch("deep_agent.aegra.mcp._current_user_id") as mock_uid,
+            patch("deep_agent.aegra.mcp._jwt_exp", side_effect=_fake_jwt_exp_future),
         ):
             mock_uid.get.return_value = "user-1"
             mock_cv.get.return_value = "fresh-token"
@@ -56,12 +50,8 @@ class TestLockedSsoRefresh:
     async def test_timeout_no_peer_refresh(self):
         with (
             patch("deep_agent.aegra.redis.distributed_lock", _timeout_lock),
-            patch(
-                "deep_agent.aegra.mcp._current_access_token"
-            ) as mock_cv,
-            patch(
-                "deep_agent.aegra.mcp._current_user_id"
-            ) as mock_uid,
+            patch("deep_agent.aegra.mcp._current_access_token") as mock_cv,
+            patch("deep_agent.aegra.mcp._current_user_id") as mock_uid,
         ):
             mock_uid.get.return_value = "user-1"
             mock_cv.get.return_value = None
@@ -73,15 +63,9 @@ class TestLockedSsoRefresh:
     async def test_timeout_peer_token_expiring_soon(self):
         with (
             patch("deep_agent.aegra.redis.distributed_lock", _timeout_lock),
-            patch(
-                "deep_agent.aegra.mcp._current_access_token"
-            ) as mock_cv,
-            patch(
-                "deep_agent.aegra.mcp._current_user_id"
-            ) as mock_uid,
-            patch(
-                "deep_agent.aegra.mcp._jwt_exp", side_effect=_fake_jwt_exp_soon
-            ),
+            patch("deep_agent.aegra.mcp._current_access_token") as mock_cv,
+            patch("deep_agent.aegra.mcp._current_user_id") as mock_uid,
+            patch("deep_agent.aegra.mcp._jwt_exp", side_effect=_fake_jwt_exp_soon),
         ):
             mock_uid.get.return_value = "user-1"
             mock_cv.get.return_value = "almost-expired"
@@ -95,18 +79,10 @@ class TestLockedSsoRefresh:
 
         with (
             patch("deep_agent.aegra.redis.distributed_lock", _held_lock),
-            patch(
-                "deep_agent.aegra.mcp._current_access_token"
-            ) as mock_cv,
-            patch(
-                "deep_agent.aegra.mcp._current_user_id"
-            ) as mock_uid,
-            patch(
-                "deep_agent.aegra.mcp._jwt_exp", side_effect=_fake_jwt_exp_future
-            ),
-            patch(
-                "deep_agent.aegra.mcp._do_sso_refresh", mock_do_refresh
-            ),
+            patch("deep_agent.aegra.mcp._current_access_token") as mock_cv,
+            patch("deep_agent.aegra.mcp._current_user_id") as mock_uid,
+            patch("deep_agent.aegra.mcp._jwt_exp", side_effect=_fake_jwt_exp_future),
+            patch("deep_agent.aegra.mcp._do_sso_refresh", mock_do_refresh),
         ):
             mock_uid.get.return_value = "user-1"
             mock_cv.get.return_value = "fresh-token"
@@ -121,15 +97,9 @@ class TestLockedSsoRefresh:
 
         with (
             patch("deep_agent.aegra.redis.distributed_lock", _held_lock),
-            patch(
-                "deep_agent.aegra.mcp._current_access_token"
-            ) as mock_cv,
-            patch(
-                "deep_agent.aegra.mcp._current_user_id"
-            ) as mock_uid,
-            patch(
-                "deep_agent.aegra.mcp._do_sso_refresh", mock_do_refresh
-            ),
+            patch("deep_agent.aegra.mcp._current_access_token") as mock_cv,
+            patch("deep_agent.aegra.mcp._current_user_id") as mock_uid,
+            patch("deep_agent.aegra.mcp._do_sso_refresh", mock_do_refresh),
         ):
             mock_uid.get.return_value = "user-1"
             mock_cv.get.return_value = None

--- a/tests/unit/aegra/test_sso_refresh_lock.py
+++ b/tests/unit/aegra/test_sso_refresh_lock.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from deep_agent.aegra.mcp import _locked_sso_refresh
+from deep_agent.aegra.mcp import _locked_sso_refresh, _user_token_cache
 
 
 @asynccontextmanager
@@ -34,16 +34,22 @@ def _fake_jwt_exp_soon(token: str) -> float:
     return time.time() + 5
 
 
+@pytest.fixture(autouse=True)
+def _clear_token_cache():
+    _user_token_cache.clear()
+    yield
+    _user_token_cache.clear()
+
+
 @pytest.mark.asyncio
 class TestLockedSsoRefresh:
     async def test_timeout_peer_already_refreshed(self):
+        _user_token_cache["user-1"] = ("fresh-token", "new-refresh")
+
         with (
             patch("deep_agent.aegra.redis.distributed_lock", _timeout_lock),
-            patch("deep_agent.aegra.mcp._current_access_token") as mock_cv,
             patch("deep_agent.aegra.mcp._jwt_exp", side_effect=_fake_jwt_exp_future),
         ):
-            mock_cv.get.return_value = "fresh-token"
-
             result = await _locked_sso_refresh(
                 "old-token", "refresh-tok", 10.0, user_id="user-1"
             )
@@ -51,12 +57,7 @@ class TestLockedSsoRefresh:
         assert result == "fresh-token"
 
     async def test_timeout_no_peer_refresh(self):
-        with (
-            patch("deep_agent.aegra.redis.distributed_lock", _timeout_lock),
-            patch("deep_agent.aegra.mcp._current_access_token") as mock_cv,
-        ):
-            mock_cv.get.return_value = None
-
+        with patch("deep_agent.aegra.redis.distributed_lock", _timeout_lock):
             result = await _locked_sso_refresh(
                 "old-token", "refresh-tok", 10.0, user_id="user-1"
             )
@@ -64,13 +65,12 @@ class TestLockedSsoRefresh:
         assert result == "old-token"
 
     async def test_timeout_peer_token_expiring_soon(self):
+        _user_token_cache["user-1"] = ("almost-expired", "refresh")
+
         with (
             patch("deep_agent.aegra.redis.distributed_lock", _timeout_lock),
-            patch("deep_agent.aegra.mcp._current_access_token") as mock_cv,
             patch("deep_agent.aegra.mcp._jwt_exp", side_effect=_fake_jwt_exp_soon),
         ):
-            mock_cv.get.return_value = "almost-expired"
-
             result = await _locked_sso_refresh(
                 "old-token", "refresh-tok", 10.0, user_id="user-1"
             )
@@ -78,16 +78,14 @@ class TestLockedSsoRefresh:
         assert result == "old-token"
 
     async def test_held_peer_already_refreshed(self):
+        _user_token_cache["user-1"] = ("fresh-token", "new-refresh")
         mock_do_refresh = AsyncMock(return_value="should-not-be-called")
 
         with (
             patch("deep_agent.aegra.redis.distributed_lock", _held_lock),
-            patch("deep_agent.aegra.mcp._current_access_token") as mock_cv,
             patch("deep_agent.aegra.mcp._jwt_exp", side_effect=_fake_jwt_exp_future),
             patch("deep_agent.aegra.mcp._do_sso_refresh", mock_do_refresh),
         ):
-            mock_cv.get.return_value = "fresh-token"
-
             result = await _locked_sso_refresh(
                 "old-token", "refresh-tok", 10.0, user_id="user-1"
             )
@@ -100,50 +98,39 @@ class TestLockedSsoRefresh:
 
         with (
             patch("deep_agent.aegra.redis.distributed_lock", _held_lock),
-            patch("deep_agent.aegra.mcp._current_access_token") as mock_cv,
-            patch("deep_agent.aegra.mcp._current_refresh_token") as mock_rt,
             patch("deep_agent.aegra.mcp._do_sso_refresh", mock_do_refresh),
         ):
-            mock_cv.get.return_value = None
-            mock_rt.get.return_value = "rotated-refresh"
-
             result = await _locked_sso_refresh(
                 "old-token", "refresh-tok", 10.0, user_id="user-1"
             )
 
         assert result == "new-token"
-        mock_do_refresh.assert_awaited_once_with("old-token", "rotated-refresh", 10.0)
+        mock_do_refresh.assert_awaited_once_with("old-token", "refresh-tok", 10.0)
 
-    async def test_held_uses_latest_refresh_token(self):
+    async def test_held_uses_cached_refresh_token(self):
+        _user_token_cache["user-1"] = ("old-token", "rotated-refresh")
         mock_do_refresh = AsyncMock(return_value="new-token")
 
         with (
             patch("deep_agent.aegra.redis.distributed_lock", _held_lock),
-            patch("deep_agent.aegra.mcp._current_access_token") as mock_cv,
-            patch("deep_agent.aegra.mcp._current_refresh_token") as mock_rt,
             patch("deep_agent.aegra.mcp._do_sso_refresh", mock_do_refresh),
         ):
-            mock_cv.get.return_value = None
-            mock_rt.get.return_value = None
-
             result = await _locked_sso_refresh(
                 "old-token", "original-refresh", 10.0, user_id="user-1"
             )
 
         assert result == "new-token"
-        mock_do_refresh.assert_awaited_once_with("old-token", "original-refresh", 10.0)
+        mock_do_refresh.assert_awaited_once_with("old-token", "rotated-refresh", 10.0)
 
     async def test_no_redis_peer_already_refreshed(self):
+        _user_token_cache["user-1"] = ("fresh-token", "new-refresh")
         mock_do_refresh = AsyncMock(return_value="should-not-be-called")
 
         with (
             patch("deep_agent.aegra.redis.distributed_lock", _no_redis_lock),
-            patch("deep_agent.aegra.mcp._current_access_token") as mock_cv,
             patch("deep_agent.aegra.mcp._jwt_exp", side_effect=_fake_jwt_exp_future),
             patch("deep_agent.aegra.mcp._do_sso_refresh", mock_do_refresh),
         ):
-            mock_cv.get.return_value = "fresh-token"
-
             result = await _locked_sso_refresh(
                 "old-token", "refresh-tok", 10.0, user_id="user-1"
             )
@@ -151,18 +138,14 @@ class TestLockedSsoRefresh:
         assert result == "fresh-token"
         mock_do_refresh.assert_not_called()
 
-    async def test_no_redis_uses_latest_refresh_token(self):
+    async def test_no_redis_uses_cached_refresh_token(self):
+        _user_token_cache["user-1"] = ("old-token", "rotated-refresh")
         mock_do_refresh = AsyncMock(return_value="new-token")
 
         with (
             patch("deep_agent.aegra.redis.distributed_lock", _no_redis_lock),
-            patch("deep_agent.aegra.mcp._current_access_token") as mock_cv,
-            patch("deep_agent.aegra.mcp._current_refresh_token") as mock_rt,
             patch("deep_agent.aegra.mcp._do_sso_refresh", mock_do_refresh),
         ):
-            mock_cv.get.return_value = None
-            mock_rt.get.return_value = "rotated-refresh"
-
             result = await _locked_sso_refresh(
                 "old-token", "original-refresh", 10.0, user_id="user-1"
             )
@@ -182,13 +165,31 @@ class TestLockedSsoRefresh:
 
         with (
             patch("deep_agent.aegra.redis.distributed_lock", _capture_lock),
-            patch("deep_agent.aegra.mcp._current_access_token") as mock_cv,
-            patch("deep_agent.aegra.mcp._current_refresh_token") as mock_rt,
             patch("deep_agent.aegra.mcp._do_sso_refresh", mock_do_refresh),
         ):
-            mock_cv.get.return_value = None
-            mock_rt.get.return_value = None
-
             await _locked_sso_refresh("old-token", "refresh-tok", 10.0, user_id="alice")
 
         assert lock_names == ["sso:refresh:alice"]
+
+    async def test_do_sso_refresh_updates_shared_cache(self):
+        from deep_agent.aegra.mcp import _current_user_id
+
+        token = _current_user_id.set("cache-user")
+        try:
+            with patch(
+                "deep_agent.aegra.mcp._oidc_refresh",
+                new=AsyncMock(return_value=("new-at", "new-rt")),
+            ):
+                with patch("deep_agent.aegra.auth.EVAL_TOKEN_REFRESH_ENABLED", False):
+                    with patch(
+                        "deep_agent.aegra.auth._oidc_refresh",
+                        new=AsyncMock(return_value=("new-at", "new-rt")),
+                    ):
+                        from deep_agent.aegra.mcp import _do_sso_refresh
+
+                        result = await _do_sso_refresh("old-at", "old-rt", 10.0)
+
+            assert result == "new-at"
+            assert _user_token_cache.get("cache-user") == ("new-at", "new-rt")
+        finally:
+            _current_user_id.reset(token)

--- a/tests/unit/aegra/test_sso_refresh_lock.py
+++ b/tests/unit/aegra/test_sso_refresh_lock.py
@@ -1,0 +1,140 @@
+"""Unit tests for SSO token refresh locking in mcp.py."""
+
+from __future__ import annotations
+
+import time
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from deep_agent.aegra.mcp import _locked_sso_refresh
+
+
+@asynccontextmanager
+async def _timeout_lock(*_args, **_kwargs):
+    yield "timeout"
+
+
+@asynccontextmanager
+async def _held_lock(*_args, **_kwargs):
+    yield "held"
+
+
+def _fake_jwt_exp_future(token: str) -> float:
+    """Return an exp far in the future."""
+    return time.time() + 3600
+
+
+def _fake_jwt_exp_soon(token: str) -> float:
+    """Return an exp just a few seconds away."""
+    return time.time() + 5
+
+
+@pytest.mark.asyncio
+class TestLockedSsoRefresh:
+    async def test_timeout_peer_already_refreshed(self):
+        with (
+            patch("deep_agent.aegra.redis.distributed_lock", _timeout_lock),
+            patch(
+                "deep_agent.aegra.mcp._current_access_token"
+            ) as mock_cv,
+            patch(
+                "deep_agent.aegra.mcp._current_user_id"
+            ) as mock_uid,
+            patch(
+                "deep_agent.aegra.mcp._jwt_exp", side_effect=_fake_jwt_exp_future
+            ),
+        ):
+            mock_uid.get.return_value = "user-1"
+            mock_cv.get.return_value = "fresh-token"
+
+            result = await _locked_sso_refresh("old-token", "refresh-tok", 10.0)
+
+        assert result == "fresh-token"
+
+    async def test_timeout_no_peer_refresh(self):
+        with (
+            patch("deep_agent.aegra.redis.distributed_lock", _timeout_lock),
+            patch(
+                "deep_agent.aegra.mcp._current_access_token"
+            ) as mock_cv,
+            patch(
+                "deep_agent.aegra.mcp._current_user_id"
+            ) as mock_uid,
+        ):
+            mock_uid.get.return_value = "user-1"
+            mock_cv.get.return_value = None
+
+            result = await _locked_sso_refresh("old-token", "refresh-tok", 10.0)
+
+        assert result == "old-token"
+
+    async def test_timeout_peer_token_expiring_soon(self):
+        with (
+            patch("deep_agent.aegra.redis.distributed_lock", _timeout_lock),
+            patch(
+                "deep_agent.aegra.mcp._current_access_token"
+            ) as mock_cv,
+            patch(
+                "deep_agent.aegra.mcp._current_user_id"
+            ) as mock_uid,
+            patch(
+                "deep_agent.aegra.mcp._jwt_exp", side_effect=_fake_jwt_exp_soon
+            ),
+        ):
+            mock_uid.get.return_value = "user-1"
+            mock_cv.get.return_value = "almost-expired"
+
+            result = await _locked_sso_refresh("old-token", "refresh-tok", 10.0)
+
+        assert result == "old-token"
+
+    async def test_held_peer_already_refreshed(self):
+        mock_do_refresh = AsyncMock(return_value="should-not-be-called")
+
+        with (
+            patch("deep_agent.aegra.redis.distributed_lock", _held_lock),
+            patch(
+                "deep_agent.aegra.mcp._current_access_token"
+            ) as mock_cv,
+            patch(
+                "deep_agent.aegra.mcp._current_user_id"
+            ) as mock_uid,
+            patch(
+                "deep_agent.aegra.mcp._jwt_exp", side_effect=_fake_jwt_exp_future
+            ),
+            patch(
+                "deep_agent.aegra.mcp._do_sso_refresh", mock_do_refresh
+            ),
+        ):
+            mock_uid.get.return_value = "user-1"
+            mock_cv.get.return_value = "fresh-token"
+
+            result = await _locked_sso_refresh("old-token", "refresh-tok", 10.0)
+
+        assert result == "fresh-token"
+        mock_do_refresh.assert_not_called()
+
+    async def test_held_no_peer_refresh_calls_do_sso_refresh(self):
+        mock_do_refresh = AsyncMock(return_value="new-token")
+
+        with (
+            patch("deep_agent.aegra.redis.distributed_lock", _held_lock),
+            patch(
+                "deep_agent.aegra.mcp._current_access_token"
+            ) as mock_cv,
+            patch(
+                "deep_agent.aegra.mcp._current_user_id"
+            ) as mock_uid,
+            patch(
+                "deep_agent.aegra.mcp._do_sso_refresh", mock_do_refresh
+            ),
+        ):
+            mock_uid.get.return_value = "user-1"
+            mock_cv.get.return_value = None
+
+            result = await _locked_sso_refresh("old-token", "refresh-tok", 10.0)
+
+        assert result == "new-token"
+        mock_do_refresh.assert_awaited_once_with("old-token", "refresh-tok", 10.0)

--- a/tests/unit/aegra/test_sso_refresh_lock.py
+++ b/tests/unit/aegra/test_sso_refresh_lock.py
@@ -21,13 +21,16 @@ async def _held_lock(*_args, **_kwargs):
     yield "held"
 
 
+@asynccontextmanager
+async def _no_redis_lock(*_args, **_kwargs):
+    yield "no_redis"
+
+
 def _fake_jwt_exp_future(token: str) -> float:
-    """Return an exp far in the future."""
     return time.time() + 3600
 
 
 def _fake_jwt_exp_soon(token: str) -> float:
-    """Return an exp just a few seconds away."""
     return time.time() + 5
 
 
@@ -37,13 +40,13 @@ class TestLockedSsoRefresh:
         with (
             patch("deep_agent.aegra.redis.distributed_lock", _timeout_lock),
             patch("deep_agent.aegra.mcp._current_access_token") as mock_cv,
-            patch("deep_agent.aegra.mcp._current_user_id") as mock_uid,
             patch("deep_agent.aegra.mcp._jwt_exp", side_effect=_fake_jwt_exp_future),
         ):
-            mock_uid.get.return_value = "user-1"
             mock_cv.get.return_value = "fresh-token"
 
-            result = await _locked_sso_refresh("old-token", "refresh-tok", 10.0)
+            result = await _locked_sso_refresh(
+                "old-token", "refresh-tok", 10.0, user_id="user-1"
+            )
 
         assert result == "fresh-token"
 
@@ -51,12 +54,12 @@ class TestLockedSsoRefresh:
         with (
             patch("deep_agent.aegra.redis.distributed_lock", _timeout_lock),
             patch("deep_agent.aegra.mcp._current_access_token") as mock_cv,
-            patch("deep_agent.aegra.mcp._current_user_id") as mock_uid,
         ):
-            mock_uid.get.return_value = "user-1"
             mock_cv.get.return_value = None
 
-            result = await _locked_sso_refresh("old-token", "refresh-tok", 10.0)
+            result = await _locked_sso_refresh(
+                "old-token", "refresh-tok", 10.0, user_id="user-1"
+            )
 
         assert result == "old-token"
 
@@ -64,13 +67,13 @@ class TestLockedSsoRefresh:
         with (
             patch("deep_agent.aegra.redis.distributed_lock", _timeout_lock),
             patch("deep_agent.aegra.mcp._current_access_token") as mock_cv,
-            patch("deep_agent.aegra.mcp._current_user_id") as mock_uid,
             patch("deep_agent.aegra.mcp._jwt_exp", side_effect=_fake_jwt_exp_soon),
         ):
-            mock_uid.get.return_value = "user-1"
             mock_cv.get.return_value = "almost-expired"
 
-            result = await _locked_sso_refresh("old-token", "refresh-tok", 10.0)
+            result = await _locked_sso_refresh(
+                "old-token", "refresh-tok", 10.0, user_id="user-1"
+            )
 
         assert result == "old-token"
 
@@ -80,14 +83,14 @@ class TestLockedSsoRefresh:
         with (
             patch("deep_agent.aegra.redis.distributed_lock", _held_lock),
             patch("deep_agent.aegra.mcp._current_access_token") as mock_cv,
-            patch("deep_agent.aegra.mcp._current_user_id") as mock_uid,
             patch("deep_agent.aegra.mcp._jwt_exp", side_effect=_fake_jwt_exp_future),
             patch("deep_agent.aegra.mcp._do_sso_refresh", mock_do_refresh),
         ):
-            mock_uid.get.return_value = "user-1"
             mock_cv.get.return_value = "fresh-token"
 
-            result = await _locked_sso_refresh("old-token", "refresh-tok", 10.0)
+            result = await _locked_sso_refresh(
+                "old-token", "refresh-tok", 10.0, user_id="user-1"
+            )
 
         assert result == "fresh-token"
         mock_do_refresh.assert_not_called()
@@ -98,13 +101,94 @@ class TestLockedSsoRefresh:
         with (
             patch("deep_agent.aegra.redis.distributed_lock", _held_lock),
             patch("deep_agent.aegra.mcp._current_access_token") as mock_cv,
-            patch("deep_agent.aegra.mcp._current_user_id") as mock_uid,
+            patch("deep_agent.aegra.mcp._current_refresh_token") as mock_rt,
             patch("deep_agent.aegra.mcp._do_sso_refresh", mock_do_refresh),
         ):
-            mock_uid.get.return_value = "user-1"
             mock_cv.get.return_value = None
+            mock_rt.get.return_value = "rotated-refresh"
 
-            result = await _locked_sso_refresh("old-token", "refresh-tok", 10.0)
+            result = await _locked_sso_refresh(
+                "old-token", "refresh-tok", 10.0, user_id="user-1"
+            )
 
         assert result == "new-token"
-        mock_do_refresh.assert_awaited_once_with("old-token", "refresh-tok", 10.0)
+        mock_do_refresh.assert_awaited_once_with("old-token", "rotated-refresh", 10.0)
+
+    async def test_held_uses_latest_refresh_token(self):
+        mock_do_refresh = AsyncMock(return_value="new-token")
+
+        with (
+            patch("deep_agent.aegra.redis.distributed_lock", _held_lock),
+            patch("deep_agent.aegra.mcp._current_access_token") as mock_cv,
+            patch("deep_agent.aegra.mcp._current_refresh_token") as mock_rt,
+            patch("deep_agent.aegra.mcp._do_sso_refresh", mock_do_refresh),
+        ):
+            mock_cv.get.return_value = None
+            mock_rt.get.return_value = None
+
+            result = await _locked_sso_refresh(
+                "old-token", "original-refresh", 10.0, user_id="user-1"
+            )
+
+        assert result == "new-token"
+        mock_do_refresh.assert_awaited_once_with("old-token", "original-refresh", 10.0)
+
+    async def test_no_redis_peer_already_refreshed(self):
+        mock_do_refresh = AsyncMock(return_value="should-not-be-called")
+
+        with (
+            patch("deep_agent.aegra.redis.distributed_lock", _no_redis_lock),
+            patch("deep_agent.aegra.mcp._current_access_token") as mock_cv,
+            patch("deep_agent.aegra.mcp._jwt_exp", side_effect=_fake_jwt_exp_future),
+            patch("deep_agent.aegra.mcp._do_sso_refresh", mock_do_refresh),
+        ):
+            mock_cv.get.return_value = "fresh-token"
+
+            result = await _locked_sso_refresh(
+                "old-token", "refresh-tok", 10.0, user_id="user-1"
+            )
+
+        assert result == "fresh-token"
+        mock_do_refresh.assert_not_called()
+
+    async def test_no_redis_uses_latest_refresh_token(self):
+        mock_do_refresh = AsyncMock(return_value="new-token")
+
+        with (
+            patch("deep_agent.aegra.redis.distributed_lock", _no_redis_lock),
+            patch("deep_agent.aegra.mcp._current_access_token") as mock_cv,
+            patch("deep_agent.aegra.mcp._current_refresh_token") as mock_rt,
+            patch("deep_agent.aegra.mcp._do_sso_refresh", mock_do_refresh),
+        ):
+            mock_cv.get.return_value = None
+            mock_rt.get.return_value = "rotated-refresh"
+
+            result = await _locked_sso_refresh(
+                "old-token", "original-refresh", 10.0, user_id="user-1"
+            )
+
+        assert result == "new-token"
+        mock_do_refresh.assert_awaited_once_with("old-token", "rotated-refresh", 10.0)
+
+    async def test_user_id_used_in_lock_name(self):
+        lock_names = []
+
+        @asynccontextmanager
+        async def _capture_lock(name, **_kwargs):
+            lock_names.append(name)
+            yield "held"
+
+        mock_do_refresh = AsyncMock(return_value="new-token")
+
+        with (
+            patch("deep_agent.aegra.redis.distributed_lock", _capture_lock),
+            patch("deep_agent.aegra.mcp._current_access_token") as mock_cv,
+            patch("deep_agent.aegra.mcp._current_refresh_token") as mock_rt,
+            patch("deep_agent.aegra.mcp._do_sso_refresh", mock_do_refresh),
+        ):
+            mock_cv.get.return_value = None
+            mock_rt.get.return_value = None
+
+            await _locked_sso_refresh("old-token", "refresh-tok", 10.0, user_id="alice")
+
+        assert lock_names == ["sso:refresh:alice"]


### PR DESCRIPTION
## What

Fixes SSO token refresh reliability during long-running agent executions. Without this change, concurrent MCP tool calls on expired SSO tokens can race on refresh (especially with Keycloak refresh token rotation), and tokens that expire during computation gaps (no tool calls) aren't refreshed proactively.

Fixes #322

## How

- **Distributed lock for SSO refresh**: `refresh_access_token()` now acquires a Redis distributed lock (`sso:refresh:{user_id}`) before refreshing, with fallback to an in-process `asyncio.Lock` when Redis is unavailable. After acquiring the lock, it re-checks whether another caller already refreshed to avoid redundant OIDC calls. This follows the same pattern used by the OAuth/DCR token refresh path in `McpCredentialResolver`.

- **Increased refresh buffer**: `_SSO_REFRESH_BUFFER_SECS` increased from 30s to 60s, triggering refresh earlier before expiry.

- **Cross-task shared token cache**: `ContextVar` values are task-local in asyncio, so a refresh completed in one task is invisible to a concurrent task for the same user. Added a module-level `_user_token_cache` dict (keyed by `user_id`) that `_do_sso_refresh` writes to after a successful refresh, and `_locked_sso_refresh` reads from for peer-checks. This ensures the lock peer-check works across asyncio tasks, not just within the same task.

- **Rotated refresh token preserved**: After `refresh_access_token()` rotates the refresh token via Keycloak, `graph.py` now reads the rotated value from the shared cache before calling `set_mcp_auth_context()`. Previously, `set_mcp_auth_context()` was called with the stale original refresh token, overwriting the rotated one in the ContextVar.

- **Explicit `user_id` parameter**: `refresh_access_token()` accepts an explicit `user_id` kwarg so the lock key uses the actual user identity even before `set_mcp_auth_context()` runs, preventing concurrent users from sharing the `sso:refresh:unknown` lock.

- **Read refresh token from gateway header**: `auth.py` now reads `x-user-refresh-token` (matching the gateway's `x-user-*` security header convention) with fallback to `x-refresh-token` for backwards compatibility. This pairs with gateway MR !96 which injects `X-User-Refresh-Token` alongside `X-User-Access-Token`.

## Key files changed

| File | Change |
|------|--------|
| `deep_agent/aegra/mcp.py` | Distributed lock, shared cache, peer-check logic |
| `deep_agent/aegra/graph.py` | Preserve rotated refresh token for `set_mcp_auth_context` |
| `deep_agent/aegra/auth.py` | Read `x-user-refresh-token` header from gateway |
| `tests/unit/aegra/test_sso_refresh_lock.py` | 10 tests covering all lock branches |
| `tests/unit/aegra/test_graph.py` | Updated assertion for new `user_id` kwarg |

## Testing

- [x] Unit tests added/updated (10 new tests for lock branches + shared cache)
- [x] Ran locally (`uv run pytest tests/unit -x`) — all aegra tests pass
- [x] Pre-commit hooks pass (`uvx ruff format`, `uvx ruff check`)
- [ ] Manual verification: needs testing with a long-running agent (>5 min) making MCP calls to verify refresh works under load

## Rollback

Revert the commit. The SSO refresh falls back to the previous unlocked behavior if Redis is unavailable, so partial rollback is also safe.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `ci:`, etc.)
- [x] No secrets, credentials, or PII in the diff
- [x] No breaking changes (or documented above with a migration path)
- [x] Pre-commit hooks pass

---

**AI Disclosure**: Changes identified through cross-repo timeout chain analysis and written by Claude Code. Human verification: lock pattern matches existing OAuth/DCR path; all tests and pre-commit hooks pass.

**Related**: gateway MR !95 (read timeout), gateway MR !96 (refresh token injection), agent-engine MR !177 (streaming + Route annotations), template-ai-deployment MR !5 (UI/MCP timeouts).