### PR TITLE
feat: add LDAP group-based access control with eval endpoint gating

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,58 @@ ENABLE_USER_ID_ENCRYPTION=false
 # AGENT_PUBLIC_BASE_URL=http://localhost:5002
 # UI_ORIGIN=http://localhost:5173
 
+# --- LDAP Access Control ---
+# Role-based access is driven by the groups defined in PROMPT.md (config/agent/PROMPT.md) front matter.
+# The SSO user ID (preferred_username) is compared against LDAP group members to resolve the user's role.
+# The highest role in the hierarchy wins: owners > admins > builders > users.
+#
+# Behavior based on PROMPT.md configuration:
+#   - No groups in PROMPT.md      → Everyone gets chat-only access (users role).
+#                                   Eval endpoints and dataset APIs are restricted.
+#   - Groups defined              → LDAP lookup determines role. owners/admins/builders get full access.
+#                                   users role gets chat only.
+#   - accessibility: private      → Users not in any LDAP group are denied entirely (403).
+#                                   This is the default when accessibility is not specified.
+#   - accessibility: public       → Users not in any LDAP group get chat access (users role).
+#                                   Eval and dataset APIs are still restricted
+#                                   to owners, admins, and builders only.
+#
+# PROMPT.md front matter example:
+#   ---
+#   accessibility: public
+#   groups:
+#     - role: owners
+#       group: team-owners
+#     - role: admins
+#       group: team-admins
+#     - role: builders
+#       group: team-builders
+#     - role: users
+#       group: team-users
+#   ---
+#
+# LDAP_URL              - LDAP server URL. Base DN and group search base are derived from the
+#                         hostname automatically (e.g. ldap.example.com → dc=example,dc=com).
+#                         Required when PROMPT.md has groups — if missing, all users are denied (fail-closed).
+# LDAP_BASE_UID         - Service account uid used to bind to LDAP (e.g. svcacct).
+#                         If the value contains a comma it is used as-is as the full bind DN,
+#                         otherwise it is expanded to uid=<value>,ou=users,<derived base DN>.
+# LDAP_PASSWORD          - Password for the LDAP service account. Sourced from a k8s secret in production.
+# LDAP_GROUP_SEARCH_BASE - (Optional) Override the LDAP subtree searched for groups.
+#                         Default: ou=adhoc,ou=managedGroups,<derived base DN from LDAP_URL>.
+# LDAP_TLS_VERIFY        - (Optional) Validate LDAP server TLS certificate. Default: true.
+#                         Set to false ONLY for dev/test with self-signed certs.
+# LDAP_CACHE_TTL_SECONDS - (Optional) How long LDAP membership results are cached in Redis (seconds).
+#                         Default: 300 (5 minutes). First request queries LDAP; subsequent requests
+#                         within the TTL are served from cache.
+#
+# LDAP_URL=ldaps://ldap.example.com
+# LDAP_BASE_UID=svcacct
+# LDAP_PASSWORD=
+# LDAP_GROUP_SEARCH_BASE=ou=adhoc,ou=managedGroups,dc=example,dc=com
+# LDAP_TLS_VERIFY=true
+# LDAP_CACHE_TTL_SECONDS=300
+
 # --- Infrastructure ---
 
 # Postgres (checkpoints, memory, feedback)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ A template for building [Deep Agents](https://github.com/langchain-ai/deepagents
 **Infrastructure:**
 - Aegra dev server with Redis-backed SSE streaming
 - PostgreSQL checkpoints, memory, and feedback storage
+- LDAP-based access control with group-to-role mappings defined in PROMPT.md
+- Eval and dataset APIs gated by LDAP role — see [`eval-runner/docs/`](./eval-runner/docs/) for eval documentation
 - Config-as-code in `config/agent/` (no Python edits for most changes)
 - Container-ready with Red Hat UBI; OpenShift and Kind deployment overlays
 
@@ -112,6 +114,12 @@ Configuration is split between **secrets/endpoints** (`.env`) and **operational 
 | `SSO_ISSUER_URL` | — | OIDC issuer (Keycloak, Okta, etc.) |
 | `SSO_CLIENT_ID` | — | OIDC client ID |
 | `SSO_CLIENT_SECRET` | — | OIDC client secret |
+| `LDAP_URL` | — | LDAP server URL (e.g. `ldaps://ldap.example.com`). Required when PROMPT.md has groups |
+| `LDAP_BASE_UID` | — | Service account uid for LDAP bind |
+| `LDAP_PASSWORD` | — | Service account password |
+| `LDAP_GROUP_SEARCH_BASE` | `ou=adhoc,ou=managedGroups,<baseDn>` | Override group search subtree |
+| `LDAP_TLS_VERIFY` | `true` | Validate LDAP server TLS certificate |
+| `LDAP_CACHE_TTL_SECONDS` | `300` | Redis cache TTL for LDAP membership lookups |
 | `LANGFUSE_PUBLIC_KEY` | — | Langfuse public key (optional) |
 | `LANGFUSE_SECRET_KEY` | — | Langfuse secret key (optional) |
 | `LANGFUSE_BASE_URL` | — | Langfuse host (optional) |
@@ -145,6 +153,85 @@ An [Open Policy Agent](https://www.openpolicyagent.org/) sidecar enforces author
 The `opa:` section in `agent.yaml` and the `OPA_*` environment variables above configure the agent-side client. Local policies live in `config/agent/compliance/policies/` and can be augmented from a remote git repository with automatic hot-reload.
 
 See **[`opa/README.md`](./opa/README.md)** for a full explanation of how the middleware, service, config, and OPA container work together.
+
+## LDAP Access Control
+
+Role-based access control driven by LDAP group membership. Group-to-role mappings are defined in [`config/agent/PROMPT.md`](./config/agent/PROMPT.md) YAML front matter — no code changes needed to add or remove groups.
+
+### Role hierarchy
+
+| Role | Priority | Chat | Eval / Dataset |
+|---|---|---|---|
+| `owners` | 4 | Yes | Yes |
+| `admins` | 3 | Yes | Yes |
+| `builders` | 2 | Yes | Yes |
+| `users` | 1 | Yes | No (403) |
+| `denied` | — | No (403) | No (403) |
+
+When a user belongs to multiple groups, the highest-priority role wins.
+
+### PROMPT.md configuration
+
+Groups and accessibility are set in the YAML front matter of `config/agent/PROMPT.md`:
+
+```yaml
+---
+accessibility: public
+groups:
+  - role: owners
+    group: aifactory-template-owner
+  - role: admins
+    group: team-admins
+  - role: builders
+    group: team-builders
+  - role: users
+    group: team-users
+---
+```
+
+### Behavior matrix
+
+| Scenario | Chat (`/threads/*`, `/runs/*`) | Eval (`/evals/*`, `/v1/eval/*`) |
+|---|---|---|
+| `ENABLE_AUTH=false` | Full access | Full access |
+| No groups in PROMPT.md | Allowed | 403 (everyone is `users`) |
+| Groups + role `owners`/`admins`/`builders` | Allowed | Allowed |
+| Groups + role `users` | Allowed | 403 |
+| Groups + no match + `accessibility: private` | 403 (denied) | 403 (denied) |
+| Groups + no match + `accessibility: public` | Allowed (as `users`) | 403 |
+| Groups defined + `LDAP_URL` missing | Depends on accessibility | 403 |
+
+### How it works
+
+1. User authenticates via SSO/OIDC — the JWT `preferred_username` claim identifies the user.
+2. The agent reads group-to-role mappings from PROMPT.md front matter (cached with mtime-based invalidation).
+3. For each configured group, the agent queries LDAP to check if the user is a member (`member`, `uniqueMember`, or `memberUid` attributes).
+4. The highest-priority matching role is assigned. If no groups match, the role is `denied` (private) or `users` (public).
+5. LDAP results are cached in Redis (with in-memory fallback) for `LDAP_CACHE_TTL_SECONDS` (default: 300s).
+
+### Two enforcement layers
+
+- **LangGraph auth** (`deep_agent/aegra/auth.py`): gates chat endpoints (`/threads/*`, `/runs/*`). Raises `PermissionError` for `denied` role — blocks the conversation entirely.
+- **FastAPI dependencies** (`deep_agent/aegra/eval_routes.py`): gates eval and dataset endpoints. Requires `owners`, `admins`, or `builders` role — returns HTTP 403 for `users` or `denied`.
+
+### Setup
+
+1. Define groups in `config/agent/PROMPT.md` front matter (see example above).
+2. Set LDAP environment variables in `.env`:
+
+```bash
+LDAP_URL=ldaps://ldap.example.com
+LDAP_BASE_UID=svcacct
+LDAP_PASSWORD=your-password
+# Optional:
+# LDAP_GROUP_SEARCH_BASE=ou=adhoc,ou=managedGroups,dc=example,dc=com
+# LDAP_TLS_VERIFY=true
+# LDAP_CACHE_TTL_SECONDS=300
+```
+
+3. Set `ENABLE_AUTH=true` and configure SSO variables.
+
+When `ENABLE_AUTH=false` (dev mode), LDAP is skipped entirely and all endpoints are accessible.
 
 ## MCP Server Configuration
 

--- a/config/agent/PROMPT.md
+++ b/config/agent/PROMPT.md
@@ -4,6 +4,16 @@ description: >
   Main coordinator for Red Hat fitness assistant. Handles client intake,
   routes to analyst and publisher subagents, manages TODO lists and
   delegates health metric analysis.
+# accessibility: private
+# groups:
+#   - role: owners
+#     group: template-owners
+#   - role: admins
+#     group: template-admins
+#   - role: builders
+#     group: template-builders
+#   - role: users
+#     group: template-owner
 model: gemini-2.5-pro
 # MaaS (Models as a Service) lets you serve open-source models via a managed
 # API without owning the infrastructure — see:

--- a/deep_agent/aegra/auth.py
+++ b/deep_agent/aegra/auth.py
@@ -193,7 +193,32 @@ def _build_dev_user() -> dict[str, Any]:
         "is_authenticated": True,
         "email": "dev@localhost",
         "encrypted_id": encrypt_user_id(DEV_USER_ID),
+        "ldap_role": None,
     }
+
+
+async def _resolve_ldap_role(payload: dict[str, Any]) -> str | None:
+    """Resolve the user's LDAP role from PROMPT.md groups."""
+    from deep_agent.src.ldap.service import resolve_user_role
+
+    user_id = str(payload.get("preferred_username") or payload.get("sub") or "").strip()
+    if not user_id:
+        return "denied"
+    return await resolve_user_role(user_id)
+
+
+def _check_ldap_access(role: str | None) -> None:
+    """Enforce LDAP role at the LangGraph auth layer (gates chat access).
+
+    Raises PermissionError for 'denied' role — blocks chat and everything.
+    All other roles pass through; eval gating happens at the route level.
+    """
+    if role is None:
+        return
+    if role == "denied":
+        raise PermissionError(
+            "Access denied: user is not a member of any configured LDAP group"
+        )
 
 
 @auth.authenticate
@@ -256,7 +281,10 @@ async def authenticate(headers: dict) -> dict:
                 p = _decode_token(cached)
                 enc_rt = await asyncio.to_thread(cache_get, f"eval:refresh:{sub}") or ""
                 stored_rt = decrypt_secret(enc_rt) or "" if enc_rt else ""
-                return _make_user(p, cached, stored_rt)
+                user = _make_user(p, cached, stored_rt)
+                user["ldap_role"] = await _resolve_ldap_role(p)
+                _check_ldap_access(user["ldap_role"])
+                return user
             except Exception:
                 pass  # cached token also expired — fall through to lock path
 
@@ -296,7 +324,11 @@ async def authenticate(headers: dict) -> dict:
                     _EVAL_REFRESH_TTL,
                 )
                 logger.info("eval_token_refreshed")
-                return _make_user(_decode_token(new_access), new_access, new_rt)
+                refreshed_payload = _decode_token(new_access)
+                user = _make_user(refreshed_payload, new_access, new_rt)
+                user["ldap_role"] = await _resolve_ldap_role(refreshed_payload)
+                _check_ldap_access(user["ldap_role"])
+                return user
             else:
                 # Lock loser: poll until winner writes the cache
                 for _ in range(6):
@@ -312,7 +344,10 @@ async def authenticate(headers: dict) -> dict:
                                 lambda: cache_get(f"eval:refresh:{sub}") or ""
                             )
                             stored_rt = decrypt_secret(enc_rt) or "" if enc_rt else ""
-                            return _make_user(p, polled, stored_rt)
+                            user = _make_user(p, polled, stored_rt)
+                            user["ldap_role"] = await _resolve_ldap_role(p)
+                            _check_ldap_access(user["ldap_role"])
+                            return user
                         except Exception:
                             break
                 raise PermissionError(
@@ -336,7 +371,11 @@ async def authenticate(headers: dict) -> dict:
                     _EVAL_REFRESH_TTL,
                 )
 
-    return _make_user(payload, access_token, refresh_token)
+    user = _make_user(payload, access_token, refresh_token)
+    ldap_role = await _resolve_ldap_role(payload)
+    user["ldap_role"] = ldap_role
+    _check_ldap_access(ldap_role)
+    return user
 
 
 def _make_user(

--- a/deep_agent/aegra/auth.py
+++ b/deep_agent/aegra/auth.py
@@ -285,6 +285,8 @@ async def authenticate(headers: dict) -> dict:
                 user["ldap_role"] = await _resolve_ldap_role(p)
                 _check_ldap_access(user["ldap_role"])
                 return user
+            except PermissionError:
+                raise
             except Exception:
                 pass  # cached token also expired — fall through to lock path
 
@@ -348,6 +350,8 @@ async def authenticate(headers: dict) -> dict:
                             user["ldap_role"] = await _resolve_ldap_role(p)
                             _check_ldap_access(user["ldap_role"])
                             return user
+                        except PermissionError:
+                            raise
                         except Exception:
                             break
                 raise PermissionError(

--- a/deep_agent/aegra/auth_helpers.py
+++ b/deep_agent/aegra/auth_helpers.py
@@ -37,7 +37,14 @@ async def check_ldap_role(request: Request, *, developer_only: bool = False) -> 
             status_code=401, detail="Missing or invalid Authorization header"
         )
 
-    payload = await asyncio.to_thread(_decode_token, auth_header[7:])
+    import jwt
+
+    try:
+        payload = await asyncio.to_thread(_decode_token, auth_header[7:])
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Token expired") from None
+    except jwt.PyJWTError as exc:
+        raise HTTPException(status_code=401, detail=f"Invalid token: {exc}") from None
     user_id = str(payload.get("preferred_username") or payload.get("sub") or "").strip()
     if not user_id:
         raise HTTPException(status_code=401, detail="Token missing user identity")

--- a/deep_agent/aegra/auth_helpers.py
+++ b/deep_agent/aegra/auth_helpers.py
@@ -11,8 +11,58 @@ from deep_agent.utils.pylogger import get_python_logger
 logger = get_python_logger()
 
 
+async def check_ldap_role(request: Request, *, developer_only: bool = False) -> str:
+    """Extract user ID from JWT and resolve LDAP role.
+
+    Args:
+        request: The incoming FastAPI request.
+        developer_only: If True, only owners/admins/builders pass.
+
+    Returns:
+        The user's preferred_username from the JWT.
+
+    Raises:
+        HTTPException(403): If the user's LDAP role doesn't have access.
+    """
+    from deep_agent.aegra.auth import ENABLE_AUTH, _decode_token
+
+    if not ENABLE_AUTH:
+        from deep_agent.aegra.auth import DEV_USER_ID
+
+        return DEV_USER_ID
+
+    auth_header = request.headers.get("authorization", "")
+    if not auth_header.startswith("Bearer "):
+        raise HTTPException(
+            status_code=401, detail="Missing or invalid Authorization header"
+        )
+
+    payload = await asyncio.to_thread(_decode_token, auth_header[7:])
+    user_id = str(payload.get("preferred_username") or payload.get("sub") or "").strip()
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Token missing user identity")
+
+    from deep_agent.src.ldap import PRIVILEGED_ROLES, resolve_user_role
+
+    role = await resolve_user_role(user_id)
+
+    if role == "denied":
+        raise HTTPException(
+            status_code=403,
+            detail="Access denied: not a member of any configured LDAP group",
+        )
+
+    if developer_only and role is not None and role not in PRIVILEGED_ROLES:
+        raise HTTPException(status_code=403, detail="Developer access required")
+
+    return user_id
+
+
 async def authenticated_user_id(
-    request: Request, *, reject_anonymous: bool = False
+    request: Request,
+    *,
+    reject_anonymous: bool = False,
+    developer_only: bool = False,
 ) -> str:
     """Extract and return the authenticated user's identity from the JWT.
 
@@ -20,6 +70,7 @@ async def authenticated_user_id(
         request: The incoming FastAPI request.
         reject_anonymous: If True, raise 401 when credentials are missing
             instead of returning ``"anonymous"``.
+        developer_only: If True, only LDAP privileged roles pass (403 otherwise).
 
     Returns:
         The ``sub`` claim from the JWT, ``DEV_USER_ID`` when auth is
@@ -40,6 +91,17 @@ async def authenticated_user_id(
         return "anonymous"
 
     payload = await asyncio.to_thread(_decode_token, auth_header[7:])
+
+    if developer_only:
+        user_id = str(
+            payload.get("preferred_username") or payload.get("sub") or ""
+        ).strip()
+        from deep_agent.src.ldap import PRIVILEGED_ROLES, resolve_user_role
+
+        role = await resolve_user_role(user_id)
+        if role is not None and role not in PRIVILEGED_ROLES:
+            raise HTTPException(status_code=403, detail="Developer access required")
+
     return str(payload["sub"])
 
 

--- a/deep_agent/aegra/eval_routes.py
+++ b/deep_agent/aegra/eval_routes.py
@@ -31,18 +31,49 @@ from pydantic import BaseModel
 _bearer = HTTPBearer(auto_error=False)
 
 
-def _require_bearer(
+async def _require_developer(
     creds: HTTPAuthorizationCredentials | None = Depends(_bearer),
 ) -> str:
-    """Reject requests that carry no Bearer token.
+    """Validate JWT and enforce privileged LDAP role for eval endpoints.
 
-    Both /v1/eval/run and /v1/eval/thread-tool-calls/{thread_id} invoke the
-    production agent or read checkpoint blobs that may contain user PII.
-    Callers (run_eval.py subprocess) always forward the session token; any
-    request without one is unauthenticated and must be rejected.
+    Requires owners/admins/builders role. Users with 'users' or 'denied' role get 403.
+    When ENABLE_AUTH=false (dev mode), passes through without LDAP check.
     """
     if creds is None or not creds.credentials:
         raise HTTPException(status_code=401, detail="Bearer token required")
+
+    from deep_agent.aegra.auth import ENABLE_AUTH, _decode_token
+
+    if not ENABLE_AUTH:
+        return str(creds.credentials)
+
+    import asyncio as _asyncio
+
+    import jwt
+
+    try:
+        payload = await _asyncio.to_thread(_decode_token, creds.credentials)
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Token expired") from None
+    except jwt.PyJWTError as exc:
+        raise HTTPException(status_code=401, detail=f"Invalid token: {exc}") from None
+
+    user_id = str(payload.get("preferred_username") or payload.get("sub") or "").strip()
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Token missing user identity")
+
+    from deep_agent.src.ldap import PRIVILEGED_ROLES, resolve_user_role
+
+    role = await resolve_user_role(user_id)
+
+    if role == "denied":
+        raise HTTPException(
+            status_code=403,
+            detail="Access denied: not a member of any configured LDAP group",
+        )
+    if role is not None and role not in PRIVILEGED_ROLES:
+        raise HTTPException(status_code=403, detail="Developer access required")
+
     return str(creds.credentials)
 
 
@@ -463,7 +494,7 @@ def _detect_interrupt(run_state: dict) -> bool:
 async def get_thread_tool_calls(
     thread_id: str,
     request: Request,
-    _token: str = Depends(_require_bearer),
+    _token: str = Depends(_require_developer),
 ) -> dict[str, Any]:
     """Return all subagent tool calls for a completed thread.
 
@@ -505,7 +536,7 @@ async def _verify_thread_ownership(thread_id: str, request: Request) -> None:
 @router.post("/run", response_model=EvalRunResponse)
 async def eval_run(
     body: EvalRunRequest,
-    _token: str = Depends(_require_bearer),
+    _token: str = Depends(_require_developer),
 ) -> EvalRunResponse:
     """Run one conversation turn for eval purposes.
 
@@ -920,7 +951,9 @@ async def _require_eval_files() -> None:
 
 
 @eval_mgmt_router.post("/trigger", response_model=None)
-async def trigger_eval(request: Request) -> Any:
+async def trigger_eval(
+    request: Request, _token: str = Depends(_require_developer)
+) -> Any:
     """Cache-first eval trigger. Returns cached result or sets in_progress."""
     if not _EVAL_RUNNER_URL:
         raise HTTPException(
@@ -992,7 +1025,9 @@ async def trigger_eval(request: Request) -> Any:
 
 
 @eval_mgmt_router.post("/force-trigger", response_model=None)
-async def force_trigger_eval(request: Request) -> Any:
+async def force_trigger_eval(
+    request: Request, _token: str = Depends(_require_developer)
+) -> Any:
     """Force a fresh eval run, bypassing cache."""
     if not _EVAL_RUNNER_URL:
         raise HTTPException(
@@ -1054,7 +1089,9 @@ _EVAL_STALE_TIMEOUT_MINUTES = int(os.environ.get("EVAL_STALE_TIMEOUT_MINUTES", "
 
 
 @eval_mgmt_router.get("/status")
-async def eval_status() -> dict[str, Any]:
+async def eval_status(
+    _token: str = Depends(_require_developer),
+) -> dict[str, Any]:
     """Return the latest eval record for this agent.
 
     Returns {"eval_status": "no_dataset"} immediately when no dataset is
@@ -1108,7 +1145,9 @@ async def eval_status() -> dict[str, Any]:
 
 
 @eval_mgmt_router.get("/results")
-async def eval_results(request: Request) -> dict[str, Any]:
+async def eval_results(
+    request: Request, _token: str = Depends(_require_developer)
+) -> dict[str, Any]:
     """Return a completed eval report.
 
     Optional query param ``completed_at`` fetches a specific run by its
@@ -1154,7 +1193,9 @@ async def eval_results(request: Request) -> dict[str, Any]:
 
 
 @eval_mgmt_router.get("/history")
-async def eval_history(request: Request) -> dict[str, Any]:
+async def eval_history(
+    request: Request, _token: str = Depends(_require_developer)
+) -> dict[str, Any]:
     """Return historical completed eval runs (scalars only, no results_detail)."""
     try:
         limit = min(int(request.query_params.get("limit", "20")), 100)
@@ -1205,7 +1246,9 @@ async def eval_history(request: Request) -> dict[str, Any]:
 
 
 @eval_mgmt_router.get("/trends")
-async def eval_trends(request: Request) -> dict[str, Any]:
+async def eval_trends(
+    request: Request, _token: str = Depends(_require_developer)
+) -> dict[str, Any]:
     """Return per-metric score trends across historical eval runs."""
     try:
         limit = min(int(request.query_params.get("limit", "20")), 100)
@@ -1312,7 +1355,9 @@ def _collect_agent_models() -> list[dict[str, Any]]:
 
 
 @eval_mgmt_router.get("/models")
-async def get_eval_models() -> dict[str, Any]:
+async def get_eval_models(
+    _token: str = Depends(_require_developer),
+) -> dict[str, Any]:
     """Return available LLM models for evaluation (orchestrator + subagents)."""
     return {"models": _collect_agent_models()}
 
@@ -1325,7 +1370,9 @@ class DatasetUpsertRequest(BaseModel):
 
 
 @eval_mgmt_router.post("/dataset")
-async def upsert_dataset(body: DatasetUpsertRequest) -> dict[str, Any]:
+async def upsert_dataset(
+    body: DatasetUpsertRequest, _token: str = Depends(_require_developer)
+) -> dict[str, Any]:
     """Upsert the eval dataset for this agent.
 
     Only one row is kept — DELETE + INSERT ensures the latest submission always wins.
@@ -1349,7 +1396,9 @@ async def upsert_dataset(body: DatasetUpsertRequest) -> dict[str, Any]:
 
 
 @eval_mgmt_router.get("/dataset")
-async def get_dataset() -> dict[str, Any]:
+async def get_dataset(
+    _token: str = Depends(_require_developer),
+) -> dict[str, Any]:
     """Return the stored eval dataset for this agent."""
     await _ensure_datasets_table_once()
 

--- a/deep_agent/aegra/shutdown.py
+++ b/deep_agent/aegra/shutdown.py
@@ -122,7 +122,7 @@ def run_shutdown_sync() -> None:
         ("otel", _shutdown_otel),
         ("langfuse", _shutdown_langfuse_sync),
         ("graph_cache", _clear_graph_cache),
-        ("ldap", _close_ldap),
+        ("ldap", _close_ldap_sync),
         ("redis", _close_redis),
     ]:
         try:
@@ -337,8 +337,20 @@ def _shutdown_otel() -> str:
         return f"error: {exc}"
 
 
-def _close_ldap() -> str:
+async def _close_ldap() -> str:
     """Close the LDAP connection and clear the membership cache."""
+    try:
+        from deep_agent.src.ldap.service import close_ldap
+
+        await asyncio.to_thread(close_ldap)
+        return "ok"
+    except Exception as exc:
+        logger.warning("LDAP close failed: %s", exc)
+        return f"error: {exc}"
+
+
+def _close_ldap_sync() -> str:
+    """Close the LDAP connection synchronously (atexit path)."""
     try:
         from deep_agent.src.ldap.service import close_ldap
 

--- a/deep_agent/aegra/shutdown.py
+++ b/deep_agent/aegra/shutdown.py
@@ -122,6 +122,7 @@ def run_shutdown_sync() -> None:
         ("otel", _shutdown_otel),
         ("langfuse", _shutdown_langfuse_sync),
         ("graph_cache", _clear_graph_cache),
+        ("ldap", _close_ldap),
         ("redis", _close_redis),
     ]:
         try:
@@ -205,6 +206,7 @@ async def run_shutdown() -> dict[str, str]:
         ("otel", _shutdown_otel),
         ("langfuse", _shutdown_langfuse),
         ("graph_cache", _clear_graph_cache),
+        ("ldap", _close_ldap),
         ("redis", _close_redis),
     ]:
         try:
@@ -332,6 +334,18 @@ def _shutdown_otel() -> str:
         return "ok"
     except Exception as exc:
         logger.warning("OTEL shutdown failed: %s", exc)
+        return f"error: {exc}"
+
+
+def _close_ldap() -> str:
+    """Close the LDAP connection and clear the membership cache."""
+    try:
+        from deep_agent.src.ldap.service import close_ldap
+
+        close_ldap()
+        return "ok"
+    except Exception as exc:
+        logger.warning("LDAP close failed: %s", exc)
         return f"error: {exc}"
 
 

--- a/deep_agent/aegra/startup.py
+++ b/deep_agent/aegra/startup.py
@@ -51,6 +51,7 @@ async def run_startup() -> dict[str, str]:
     results: dict[str, str] = {}
 
     results["config"] = await _validate_config()
+    results["ldap"] = _init_ldap()
     results["aegra_db"] = await _init_aegra_db()
     results["database"] = await _ensure_database()
     _check_mcp_encryption_key()
@@ -81,6 +82,41 @@ def _upgrade_signal_handlers() -> None:
         register_signal_handlers()
     except Exception:
         logger.warning("Failed to register signal handlers", exc_info=True)
+
+
+def _init_ldap() -> str:
+    """Load PROMPT.md access config and validate LDAP settings."""
+    try:
+        from deep_agent.src.ldap.config import ldap_settings
+        from deep_agent.src.ldap.prompt_config import get_prompt_access_config
+
+        config = get_prompt_access_config()
+        group_count = len(config.groups) if config.groups else 0
+
+        if group_count == 0:
+            logger.info(
+                "LDAP access control: no groups in PROMPT.md — everyone gets users role"
+            )
+            return "ok: no groups configured"
+
+        if not ldap_settings.LDAP_URL:
+            logger.warning(
+                "LDAP access control: %d group(s) defined but LDAP_URL not set — "
+                "access will be denied (fail-closed) when accessibility=private",
+                group_count,
+            )
+            return f"warning: {group_count} group(s) but no LDAP_URL"
+
+        logger.info(
+            "LDAP access control: %d group(s), accessibility=%s, url=%s",
+            group_count,
+            config.accessibility,
+            ldap_settings.LDAP_URL,
+        )
+        return f"ok: {group_count} group(s), accessibility={config.accessibility}"
+    except Exception as exc:
+        logger.warning("LDAP init failed: %s", exc)
+        return f"warning: {exc}"
 
 
 async def _init_aegra_db() -> str:

--- a/deep_agent/src/ldap/__init__.py
+++ b/deep_agent/src/ldap/__init__.py
@@ -1,0 +1,21 @@
+"""LDAP-based access control for the template agent.
+
+Reads group-to-role mappings from PROMPT.md front matter, queries LDAP
+for user membership, and resolves the highest-priority role. Results
+are cached in Redis (with in-memory fallback) for configurable TTL.
+"""
+
+from deep_agent.src.ldap.prompt_config import (
+    PRIVILEGED_ROLES,
+    ROLE_HIERARCHY,
+    get_prompt_access_config,
+)
+from deep_agent.src.ldap.service import close_ldap, resolve_user_role
+
+__all__ = [
+    "PRIVILEGED_ROLES",
+    "ROLE_HIERARCHY",
+    "close_ldap",
+    "get_prompt_access_config",
+    "resolve_user_role",
+]

--- a/deep_agent/src/ldap/config.py
+++ b/deep_agent/src/ldap/config.py
@@ -1,0 +1,64 @@
+"""LDAP connection settings loaded from environment variables.
+
+Required when PROMPT.md has groups defined:
+    LDAP_URL:               LDAP server URL (e.g. ldaps://ldap.example.com).
+                            Base DN is derived from hostname automatically.
+    LDAP_BASE_UID:          Service account uid for bind (e.g. svcacct).
+                            If it contains a comma, used as-is as bind DN.
+    LDAP_PASSWORD:          Service account password.
+
+Optional (have sensible defaults):
+    LDAP_GROUP_SEARCH_BASE: Override group search subtree.
+                            Default: ou=adhoc,ou=managedGroups,<derived base DN>.
+    LDAP_CACHE_TTL_SECONDS: Redis cache TTL for membership lookups (default: 300).
+"""
+
+from urllib.parse import urlparse
+
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class LdapSettings(BaseSettings):
+    """LDAP connection configuration loaded from environment."""
+
+    LDAP_URL: str = Field(default="")
+    LDAP_BASE_UID: str = Field(default="")
+    LDAP_PASSWORD: str = Field(default="", repr=False)
+    LDAP_GROUP_SEARCH_BASE: str = Field(default="")
+    LDAP_TLS_VERIFY: bool = Field(default=True)
+    LDAP_CACHE_TTL_SECONDS: int = Field(default=300, ge=10, le=86400)
+
+    def derive_base_dn(self) -> str:
+        """Derive LDAP base DN from the URL hostname (e.g. ldap.example.com -> dc=example,dc=com)."""
+        if not self.LDAP_URL:
+            return ""
+        try:
+            hostname = urlparse(self.LDAP_URL).hostname or ""
+            parts = hostname.split(".")
+            if len(parts) < 2:
+                return ""
+            return ",".join(f"dc={p}" for p in parts[-2:])
+        except Exception:
+            return ""
+
+    def get_bind_dn(self) -> str:
+        """Construct the bind DN from LDAP_BASE_UID."""
+        if not self.LDAP_BASE_UID:
+            return ""
+        if "," in self.LDAP_BASE_UID:
+            return self.LDAP_BASE_UID
+        base_dn = self.derive_base_dn()
+        return f"uid={self.LDAP_BASE_UID},ou=users,{base_dn}"
+
+    def get_group_search_base(self) -> str:
+        """Return the group search base, defaulting to ou=adhoc,ou=managedGroups,<baseDn>."""
+        if self.LDAP_GROUP_SEARCH_BASE:
+            return self.LDAP_GROUP_SEARCH_BASE
+        base_dn = self.derive_base_dn()
+        if not base_dn:
+            return ""
+        return f"ou=adhoc,ou=managedGroups,{base_dn}"
+
+
+ldap_settings = LdapSettings()

--- a/deep_agent/src/ldap/prompt_config.py
+++ b/deep_agent/src/ldap/prompt_config.py
@@ -1,0 +1,122 @@
+"""Parse PROMPT.md front matter for LDAP group-to-role mappings.
+
+Reads the ``groups`` and ``accessibility`` fields from the YAML front
+matter of PROMPT.md.  The result is cached in-memory and invalidated
+when the file's mtime changes.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from deep_agent.utils.pylogger import get_python_logger
+
+logger = get_python_logger()
+
+ROLE_HIERARCHY: dict[str, int] = {
+    "owners": 4,
+    "admins": 3,
+    "builders": 2,
+    "users": 1,
+}
+
+PRIVILEGED_ROLES: set[str] = {"owners", "admins", "builders"}
+
+
+@dataclass
+class GroupRoleMapping:
+    """Maps an LDAP group CN to a role name (e.g. owners, admins)."""
+
+    role: str
+    group: str
+
+
+@dataclass
+class PromptAccessConfig:
+    """Parsed PROMPT.md access control configuration."""
+
+    groups: list[GroupRoleMapping] | None = None
+    accessibility: str = "private"
+
+
+_cached_config: PromptAccessConfig | None = None
+_cached_mtime: float = 0.0
+
+
+def _prompt_md_path() -> Path:
+    """Return the path to PROMPT.md based on CONFIG_PATH env var."""
+    config_dir = os.environ.get("CONFIG_PATH", "config/agent")
+    return Path(config_dir) / "PROMPT.md"
+
+
+def _parse_groups_from_frontmatter(path: Path) -> PromptAccessConfig:
+    """Parse groups and accessibility from PROMPT.md YAML front matter."""
+    try:
+        from deep_agent.src.agent.config.parser import parse_frontmatter
+
+        fm = parse_frontmatter(path)
+    except Exception:
+        logger.debug("Could not read %s — no group restrictions", path)
+        return PromptAccessConfig()
+
+    accessibility = "public" if fm.get("accessibility") == "public" else "private"
+
+    raw_groups = fm.get("groups")
+    if not isinstance(raw_groups, list) or len(raw_groups) == 0:
+        return PromptAccessConfig(groups=None, accessibility=accessibility)
+
+    groups: list[GroupRoleMapping] = []
+    for entry in raw_groups:
+        if (
+            isinstance(entry, dict)
+            and isinstance(entry.get("role"), str)
+            and isinstance(entry.get("group"), str)
+        ):
+            groups.append(
+                GroupRoleMapping(
+                    role=entry["role"].lower(),
+                    group=entry["group"],
+                )
+            )
+
+    return PromptAccessConfig(
+        groups=groups if groups else None,
+        accessibility=accessibility,
+    )
+
+
+def get_prompt_access_config() -> PromptAccessConfig:
+    """Return the cached PROMPT.md access config, reloading when the file changes."""
+    global _cached_config, _cached_mtime
+
+    path = _prompt_md_path()
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        if _cached_config is not None:
+            return _cached_config
+        return PromptAccessConfig()
+
+    if _cached_config is not None and mtime == _cached_mtime:
+        return _cached_config
+
+    config = _parse_groups_from_frontmatter(path)
+    _cached_config = config
+    _cached_mtime = mtime
+
+    group_count = len(config.groups) if config.groups else 0
+    logger.info(
+        "PROMPT.md access config loaded: groups=%d accessibility=%s",
+        group_count,
+        config.accessibility,
+    )
+    return config
+
+
+def reset_prompt_config() -> None:
+    """Clear the cached config so the next call re-reads the file."""
+    global _cached_config, _cached_mtime
+    _cached_config = None
+    _cached_mtime = 0.0

--- a/deep_agent/src/ldap/prompt_config.py
+++ b/deep_agent/src/ldap/prompt_config.py
@@ -58,8 +58,8 @@ def _parse_groups_from_frontmatter(path: Path) -> PromptAccessConfig:
 
         fm = parse_frontmatter(path)
     except Exception:
-        logger.debug("Could not read %s — no group restrictions", path)
-        return PromptAccessConfig()
+        logger.warning("Could not read %s — failing closed (denied)", path)
+        return PromptAccessConfig(groups=[], accessibility="private")
 
     accessibility = "public" if fm.get("accessibility") == "public" else "private"
 
@@ -97,7 +97,8 @@ def get_prompt_access_config() -> PromptAccessConfig:
     except OSError:
         if _cached_config is not None:
             return _cached_config
-        return PromptAccessConfig()
+        logger.warning("PROMPT.md not found at %s — failing closed (denied)", path)
+        return PromptAccessConfig(groups=[], accessibility="private")
 
     if _cached_config is not None and mtime == _cached_mtime:
         return _cached_config

--- a/deep_agent/src/ldap/service.py
+++ b/deep_agent/src/ldap/service.py
@@ -1,0 +1,236 @@
+"""LDAP group membership queries with Redis caching.
+
+Provides the core ``resolve_user_role()`` function that ties together
+PROMPT.md group config, LDAP membership lookups, and the role hierarchy.
+All LDAP I/O is synchronous (ldap3) and wrapped in ``asyncio.to_thread``
+for use in the async auth layer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import time
+from typing import Any
+
+from deep_agent.src.ldap.config import ldap_settings
+from deep_agent.src.ldap.prompt_config import (
+    ROLE_HIERARCHY,
+    GroupRoleMapping,
+    get_prompt_access_config,
+)
+from deep_agent.utils.pylogger import get_python_logger
+
+logger = get_python_logger()
+
+_ldap_conn: Any = None
+_bind_failed: bool = False
+_memory_cache: dict[str, tuple[bool, float]] = {}
+
+_startup_warning_logged: bool = False
+
+_LDAP_FILTER_ESCAPE = re.compile(r"([\\*\(\)\x00])")
+
+
+def _escape_ldap_filter(value: str) -> str:
+    """Escape special characters for use in an LDAP search filter (RFC 4515)."""
+    return _LDAP_FILTER_ESCAPE.sub(
+        lambda m: "\\" + format(ord(m.group(1)), "02x"), value
+    )
+
+
+def _derive_base_dn() -> str:
+    """Delegate to ldap_settings for the derived base DN."""
+    return ldap_settings.derive_base_dn()
+
+
+def _ensure_bound() -> Any:
+    """Ensure an LDAP connection is bound. Returns the connection or None."""
+    global _ldap_conn, _bind_failed
+
+    if not ldap_settings.LDAP_URL:
+        return None
+
+    if _ldap_conn is not None and not _bind_failed:
+        return _ldap_conn
+
+    try:
+        import ssl
+
+        from ldap3 import Connection, Server, Tls
+
+        tls_validate = (
+            ssl.CERT_REQUIRED if ldap_settings.LDAP_TLS_VERIFY else ssl.CERT_NONE
+        )
+        tls = Tls(validate=tls_validate)
+        server = Server(
+            ldap_settings.LDAP_URL,
+            use_ssl=ldap_settings.LDAP_URL.startswith("ldaps://"),
+            tls=tls,
+            connect_timeout=10,
+        )
+        bind_dn = ldap_settings.get_bind_dn()
+        conn = Connection(
+            server,
+            user=bind_dn,
+            password=ldap_settings.LDAP_PASSWORD,
+            auto_bind=True,
+            read_only=True,
+        )
+        _ldap_conn = conn
+        _bind_failed = False
+        logger.info("LDAP bound successfully to %s", ldap_settings.LDAP_URL)
+        return conn
+    except Exception as exc:
+        logger.error("LDAP bind failed: %s", exc)
+        _bind_failed = True
+        _ldap_conn = None
+        return None
+
+
+def _cache_get(key: str) -> bool | None:
+    """Read from Redis cache, falling back to in-memory cache."""
+    from deep_agent.aegra.redis import cache_get
+
+    val = cache_get(key)
+    if val is not None:
+        return val == "1"
+
+    entry = _memory_cache.get(key)
+    if entry is not None:
+        result, ts = entry
+        if time.monotonic() - ts < ldap_settings.LDAP_CACHE_TTL_SECONDS:
+            return result
+
+    return None
+
+
+def _cache_set(key: str, value: bool) -> None:
+    """Write to Redis cache and in-memory fallback."""
+    from deep_agent.aegra.redis import cache_set
+
+    cache_set(key, "1" if value else "0", ldap_settings.LDAP_CACHE_TTL_SECONDS)
+    _memory_cache[key] = (value, time.monotonic())
+
+
+def _is_user_in_group_sync(user_id: str, group_cn: str) -> bool:
+    """Check if a user belongs to an LDAP group (synchronous)."""
+    cache_key = f"ldap:membership:{user_id}:{group_cn}"
+
+    cached = _cache_get(cache_key)
+    if cached is not None:
+        return cached
+
+    conn = _ensure_bound()
+    if conn is None:
+        return False
+
+    search_base = ldap_settings.get_group_search_base()
+    base_dn = _derive_base_dn()
+    member_attrs = ["member", "uniqueMember", "memberUid"]
+
+    try:
+        from ldap3 import SUBTREE
+
+        safe_cn = _escape_ldap_filter(group_cn)
+        conn.search(
+            search_base,
+            f"(cn={safe_cn})",
+            search_scope=SUBTREE,
+            attributes=member_attrs,
+        )
+
+        found = False
+        for entry in conn.entries:
+            for attr in member_attrs:
+                values = getattr(entry, attr, None)
+                if values is None:
+                    continue
+                raw_values = values.values if hasattr(values, "values") else values
+                if not isinstance(raw_values, (list, tuple)):
+                    raw_values = [raw_values]
+                for member_val in raw_values:
+                    member_str = str(member_val).lower()
+                    user_lower = user_id.lower()
+                    if (
+                        member_str == user_lower
+                        or member_str == f"uid={user_lower},ou=users,{base_dn}"
+                        or member_str.startswith(f"uid={user_lower},")
+                    ):
+                        found = True
+                        break
+                if found:
+                    break
+            if found:
+                break
+
+        _cache_set(cache_key, found)
+        return found
+    except Exception as exc:
+        global _bind_failed
+        logger.error("LDAP search failed for group %s: %s", group_cn, exc)
+        _bind_failed = True
+        return False
+
+
+def _resolve_user_role_sync(
+    user_id: str, group_mappings: list[GroupRoleMapping]
+) -> str:
+    """Resolve the highest-priority role from LDAP group membership (synchronous)."""
+    highest_role: str | None = None
+    highest_priority = 0
+
+    for mapping in group_mappings:
+        if _is_user_in_group_sync(user_id, mapping.group):
+            priority = ROLE_HIERARCHY.get(mapping.role, 0)
+            if priority > highest_priority:
+                highest_priority = priority
+                highest_role = mapping.role
+
+    return highest_role or "denied"
+
+
+async def resolve_user_role(user_id: str) -> str | None:
+    """Resolve a user's role from PROMPT.md groups + LDAP membership.
+
+    Returns None when ENABLE_AUTH=false (dev mode, full access).
+    Returns 'users' when no groups configured (chat only).
+    Accessibility-aware: private + no match = 'denied', public + no match = 'users'.
+    """
+    global _startup_warning_logged
+
+    config = get_prompt_access_config()
+
+    if config.groups is None:
+        return "users"
+
+    is_public = config.accessibility == "public"
+
+    if not ldap_settings.LDAP_URL:
+        if not _startup_warning_logged:
+            logger.warning(
+                "PROMPT.md has groups defined but LDAP_URL is not set — "
+                "denying all access (fail-closed)"
+            )
+            _startup_warning_logged = True
+        return "users" if is_public else "denied"
+
+    role = await asyncio.to_thread(_resolve_user_role_sync, user_id, config.groups)
+
+    if role == "denied" and is_public:
+        return "users"
+    return role
+
+
+def close_ldap() -> None:
+    """Unbind the LDAP connection and clear the in-memory cache."""
+    global _ldap_conn, _bind_failed
+    if _ldap_conn is not None:
+        try:
+            _ldap_conn.unbind()
+        except Exception:
+            pass
+        _ldap_conn = None
+    _bind_failed = False
+    _memory_cache.clear()
+    logger.info("LDAP client closed")

--- a/deep_agent/src/ldap/service.py
+++ b/deep_agent/src/ldap/service.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import re
+import threading
 import time
 from typing import Any
 
@@ -25,7 +26,9 @@ logger = get_python_logger()
 
 _ldap_conn: Any = None
 _bind_failed: bool = False
+_ldap_lock = threading.Lock()
 _memory_cache: dict[str, tuple[bool, float]] = {}
+_MEMORY_CACHE_MAX_SIZE: int = 1024
 
 _startup_warning_logged: bool = False
 
@@ -51,6 +54,13 @@ def _ensure_bound() -> Any:
     if not ldap_settings.LDAP_URL:
         return None
 
+    if not ldap_settings.LDAP_URL.startswith("ldaps://"):
+        logger.error(
+            "LDAP_URL must use ldaps:// (got %s) — refusing to send credentials in cleartext",
+            ldap_settings.LDAP_URL.split("://")[0] + "://...",
+        )
+        return None
+
     if _ldap_conn is not None and not _bind_failed:
         return _ldap_conn
 
@@ -65,7 +75,7 @@ def _ensure_bound() -> Any:
         tls = Tls(validate=tls_validate)
         server = Server(
             ldap_settings.LDAP_URL,
-            use_ssl=ldap_settings.LDAP_URL.startswith("ldaps://"),
+            use_ssl=True,
             tls=tls,
             connect_timeout=10,
         )
@@ -105,11 +115,26 @@ def _cache_get(key: str) -> bool | None:
     return None
 
 
+def _evict_expired() -> None:
+    """Remove expired entries from the in-memory cache."""
+    ttl = ldap_settings.LDAP_CACHE_TTL_SECONDS
+    now = time.monotonic()
+    expired = [k for k, (_, ts) in _memory_cache.items() if now - ts >= ttl]
+    for k in expired:
+        del _memory_cache[k]
+
+
 def _cache_set(key: str, value: bool) -> None:
     """Write to Redis cache and in-memory fallback."""
     from deep_agent.aegra.redis import cache_set
 
     cache_set(key, "1" if value else "0", ldap_settings.LDAP_CACHE_TTL_SECONDS)
+
+    if len(_memory_cache) >= _MEMORY_CACHE_MAX_SIZE:
+        _evict_expired()
+    if len(_memory_cache) >= _MEMORY_CACHE_MAX_SIZE:
+        _memory_cache.clear()
+
     _memory_cache[key] = (value, time.monotonic())
 
 
@@ -121,56 +146,58 @@ def _is_user_in_group_sync(user_id: str, group_cn: str) -> bool:
     if cached is not None:
         return cached
 
-    conn = _ensure_bound()
-    if conn is None:
-        return False
+    with _ldap_lock:
+        conn = _ensure_bound()
+        if conn is None:
+            return False
 
-    search_base = ldap_settings.get_group_search_base()
-    base_dn = _derive_base_dn()
-    member_attrs = ["member", "uniqueMember", "memberUid"]
+        search_base = ldap_settings.get_group_search_base()
+        base_dn = _derive_base_dn()
+        member_attrs = ["member", "uniqueMember", "memberUid"]
 
-    try:
-        from ldap3 import SUBTREE
+        try:
+            from ldap3 import SUBTREE
 
-        safe_cn = _escape_ldap_filter(group_cn)
-        conn.search(
-            search_base,
-            f"(cn={safe_cn})",
-            search_scope=SUBTREE,
-            attributes=member_attrs,
-        )
+            safe_cn = _escape_ldap_filter(group_cn)
+            conn.search(
+                search_base,
+                f"(cn={safe_cn})",
+                search_scope=SUBTREE,
+                attributes=member_attrs,
+            )
 
-        found = False
-        for entry in conn.entries:
-            for attr in member_attrs:
-                values = getattr(entry, attr, None)
-                if values is None:
-                    continue
-                raw_values = values.values if hasattr(values, "values") else values
-                if not isinstance(raw_values, (list, tuple)):
-                    raw_values = [raw_values]
-                for member_val in raw_values:
-                    member_str = str(member_val).lower()
-                    user_lower = user_id.lower()
-                    if (
-                        member_str == user_lower
-                        or member_str == f"uid={user_lower},ou=users,{base_dn}"
-                        or member_str.startswith(f"uid={user_lower},")
-                    ):
-                        found = True
+            found = False
+            for entry in conn.entries:
+                for attr in member_attrs:
+                    values = getattr(entry, attr, None)
+                    if values is None:
+                        continue
+                    raw_values = values.values if hasattr(values, "values") else values
+                    if not isinstance(raw_values, (list, tuple)):
+                        raw_values = [raw_values]
+                    for member_val in raw_values:
+                        member_str = str(member_val).lower()
+                        user_lower = user_id.lower()
+                        if (
+                            member_str == user_lower
+                            or member_str == f"uid={user_lower},ou=users,{base_dn}"
+                            or member_str.startswith(f"uid={user_lower},")
+                        ):
+                            found = True
+                            break
+                    if found:
                         break
                 if found:
                     break
-            if found:
-                break
 
-        _cache_set(cache_key, found)
-        return found
-    except Exception as exc:
-        global _bind_failed
-        logger.error("LDAP search failed for group %s: %s", group_cn, exc)
-        _bind_failed = True
-        return False
+        except Exception as exc:
+            global _bind_failed
+            logger.error("LDAP search failed for group %s: %s", group_cn, exc)
+            _bind_failed = True
+            return False
+
+    _cache_set(cache_key, found)
+    return found
 
 
 def _resolve_user_role_sync(
@@ -225,12 +252,13 @@ async def resolve_user_role(user_id: str) -> str | None:
 def close_ldap() -> None:
     """Unbind the LDAP connection and clear the in-memory cache."""
     global _ldap_conn, _bind_failed
-    if _ldap_conn is not None:
-        try:
-            _ldap_conn.unbind()
-        except Exception:
-            pass
-        _ldap_conn = None
-    _bind_failed = False
+    with _ldap_lock:
+        if _ldap_conn is not None:
+            try:
+                _ldap_conn.unbind()
+            except Exception:
+                pass
+            _ldap_conn = None
+        _bind_failed = False
     _memory_cache.clear()
     logger.info("LDAP client closed")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "litellm>=1.40.0",
     "aiokafka>=0.10.0",
     "msgpack==1.2.1",
-    "ldap3>=2.9",
+    "ldap3==2.9.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
     "litellm>=1.40.0",
     "aiokafka>=0.10.0",
     "msgpack==1.2.1",
+    "ldap3>=2.9",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/aegra/test_auth.py
+++ b/tests/unit/aegra/test_auth.py
@@ -64,6 +64,98 @@ class TestBuildDevUser:
             user = _build_dev_user()
             assert user["identity"] == "custom-dev"
 
+    def test_dev_user_ldap_role_is_none(self):
+        """AUTH_ENABLED=false → ldap_role=None → full access (chat=Yes, eval=Yes)."""
+        user = _build_dev_user()
+        assert user["ldap_role"] is None
+
+
+class TestCheckLdapAccess:
+    """Tests the chat-access gate from the behavior matrix.
+
+    _check_ldap_access enforces the Chat column:
+        - None → pass (AUTH_ENABLED=false, full access)
+        - 'denied' → PermissionError (private + no match → 403)
+        - 'users' → pass (chat allowed)
+        - 'owners/admins/builders' → pass (chat allowed)
+    """
+
+    def test_none_passes(self):
+        from deep_agent.aegra.auth import _check_ldap_access
+
+        _check_ldap_access(None)
+
+    def test_denied_raises(self):
+        from deep_agent.aegra.auth import _check_ldap_access
+
+        with pytest.raises(PermissionError, match="not a member"):
+            _check_ldap_access("denied")
+
+    def test_users_passes(self):
+        from deep_agent.aegra.auth import _check_ldap_access
+
+        _check_ldap_access("users")
+
+    def test_owners_passes(self):
+        from deep_agent.aegra.auth import _check_ldap_access
+
+        _check_ldap_access("owners")
+
+    def test_admins_passes(self):
+        from deep_agent.aegra.auth import _check_ldap_access
+
+        _check_ldap_access("admins")
+
+    def test_builders_passes(self):
+        from deep_agent.aegra.auth import _check_ldap_access
+
+        _check_ldap_access("builders")
+
+
+class TestResolveLdapRole:
+    @pytest.mark.asyncio
+    async def test_extracts_preferred_username(self):
+        from deep_agent.aegra.auth import _resolve_ldap_role
+
+        payload = {"preferred_username": "alice", "sub": "uuid-1"}
+        with patch(
+            "deep_agent.src.ldap.service.resolve_user_role",
+            new_callable=AsyncMock,
+            return_value="owners",
+        ) as mock_resolve:
+            result = await _resolve_ldap_role(payload)
+        assert result == "owners"
+        mock_resolve.assert_called_once_with("alice")
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_sub(self):
+        from deep_agent.aegra.auth import _resolve_ldap_role
+
+        payload = {"sub": "bob"}
+        with patch(
+            "deep_agent.src.ldap.service.resolve_user_role",
+            new_callable=AsyncMock,
+            return_value="users",
+        ) as mock_resolve:
+            result = await _resolve_ldap_role(payload)
+        assert result == "users"
+        mock_resolve.assert_called_once_with("bob")
+
+    @pytest.mark.asyncio
+    async def test_empty_user_id_returns_denied(self):
+        from deep_agent.aegra.auth import _resolve_ldap_role
+
+        payload = {"sub": ""}
+        result = await _resolve_ldap_role(payload)
+        assert result == "denied"
+
+    @pytest.mark.asyncio
+    async def test_missing_claims_returns_denied(self):
+        from deep_agent.aegra.auth import _resolve_ldap_role
+
+        result = await _resolve_ldap_role({})
+        assert result == "denied"
+
 
 class TestResolveJwksUri:
     def test_explicit_jwks_uri(self):
@@ -345,6 +437,11 @@ class TestAuthenticate:
             patch("deep_agent.aegra.auth.ENABLE_AUTH", True),
             patch("deep_agent.aegra.auth.EVAL_TOKEN_REFRESH_ENABLED", False),
             patch("deep_agent.aegra.auth._decode_token", return_value=payload),
+            patch(
+                "deep_agent.aegra.auth._resolve_ldap_role",
+                new_callable=AsyncMock,
+                return_value="users",
+            ),
         ):
             result = await authenticate(
                 {"authorization": "Bearer valid-token", "x-refresh-token": ""}
@@ -352,6 +449,7 @@ class TestAuthenticate:
 
         assert result["identity"] == "user-99"
         assert result["access_token"] == "valid-token"
+        assert result["ldap_role"] == "users"
 
     async def test_expired_token_raises_when_refresh_disabled(self):
         from deep_agent.aegra.auth import authenticate
@@ -382,6 +480,11 @@ class TestAuthenticate:
             patch("deep_agent.aegra.redis.cache_get", return_value="1") as mock_get,
             patch("deep_agent.aegra.redis.cache_set") as mock_set,
             patch("deep_agent.aegra.mcp_crypto.encrypt_secret", return_value="enc-rt"),
+            patch(
+                "deep_agent.aegra.auth._resolve_ldap_role",
+                new_callable=AsyncMock,
+                return_value="owners",
+            ),
         ):
             result = await authenticate(
                 {"authorization": "Bearer valid-tok", "x-refresh-token": "my-rt"}
@@ -402,6 +505,11 @@ class TestAuthenticate:
             patch("deep_agent.aegra.auth.EVAL_TOKEN_REFRESH_ENABLED", True),
             patch("deep_agent.aegra.auth._decode_token", return_value=payload),
             patch("deep_agent.aegra.redis.cache_set") as mock_set,
+            patch(
+                "deep_agent.aegra.auth._resolve_ldap_role",
+                new_callable=AsyncMock,
+                return_value="users",
+            ),
         ):
             result = await authenticate(
                 {"authorization": "Bearer tok", "x-refresh-token": ""}
@@ -498,6 +606,11 @@ class TestAuthenticate:
                 "deep_agent.aegra.mcp_crypto.decrypt_secret",
                 side_effect=lambda v: f"dec-{v}",
             ),
+            patch(
+                "deep_agent.aegra.auth._resolve_ldap_role",
+                new_callable=AsyncMock,
+                return_value="owners",
+            ),
         ):
             result = await authenticate(
                 {"authorization": "Bearer expired", "x-refresh-token": "rt"}
@@ -547,6 +660,11 @@ class TestAuthenticate:
             patch(
                 "deep_agent.aegra.auth._oidc_refresh",
                 return_value=("new-access", "new-rt"),
+            ),
+            patch(
+                "deep_agent.aegra.auth._resolve_ldap_role",
+                new_callable=AsyncMock,
+                return_value="owners",
             ),
         ):
             result = await authenticate(
@@ -601,6 +719,11 @@ class TestAuthenticate:
                 side_effect=lambda v: f"dec-{v}",
             ),
             patch("asyncio.sleep", new_callable=AsyncMock),
+            patch(
+                "deep_agent.aegra.auth._resolve_ldap_role",
+                new_callable=AsyncMock,
+                return_value="owners",
+            ),
         ):
             result = await authenticate(
                 {"authorization": "Bearer expired", "x-refresh-token": "rt"}

--- a/tests/unit/aegra/test_auth_helpers.py
+++ b/tests/unit/aegra/test_auth_helpers.py
@@ -7,6 +7,7 @@ from fastapi import HTTPException
 
 from deep_agent.aegra.auth_helpers import (
     authenticated_user_id,
+    check_ldap_role,
     memory_user_id,
     rule_user_ids,
 )
@@ -143,6 +144,232 @@ class TestMemoryUserId:
         ):
             await memory_user_id(request)
         assert exc_info.value.status_code == 403
+
+
+class TestCheckLdapRole:
+    """Tests the Developer/Eval column from the behavior matrix."""
+
+    @pytest.mark.asyncio
+    async def test_auth_disabled_returns_dev_user(self):
+        """AUTH_ENABLED=false → full access (eval=Yes)."""
+        request = MagicMock()
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", False),
+            patch("deep_agent.aegra.auth.DEV_USER_ID", "dev-user"),
+        ):
+            result = await check_ldap_role(request, developer_only=True)
+        assert result == "dev-user"
+
+    @pytest.mark.asyncio
+    async def test_no_bearer_raises_401(self):
+        request = MagicMock()
+        request.headers = {"authorization": ""}
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", True),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await check_ldap_role(request)
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_denied_role_raises_403(self):
+        """Groups defined, private, no match → 'denied' → 403."""
+        request = MagicMock()
+        request.headers = {"authorization": "Bearer valid-token"}
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", True),
+            patch(
+                "deep_agent.aegra.auth._decode_token",
+                return_value={"preferred_username": "outsider", "sub": "uuid-1"},
+            ),
+            patch(
+                "deep_agent.src.ldap.resolve_user_role",
+                new_callable=AsyncMock,
+                return_value="denied",
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await check_ldap_role(request)
+        assert exc_info.value.status_code == 403
+        assert "not a member" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_users_role_passes_when_not_developer_only(self):
+        """Users role → check_ldap_role without developer_only=True passes."""
+        request = MagicMock()
+        request.headers = {"authorization": "Bearer valid-token"}
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", True),
+            patch(
+                "deep_agent.aegra.auth._decode_token",
+                return_value={"preferred_username": "alice", "sub": "uuid-1"},
+            ),
+            patch(
+                "deep_agent.src.ldap.resolve_user_role",
+                new_callable=AsyncMock,
+                return_value="users",
+            ),
+        ):
+            result = await check_ldap_role(request)
+        assert result == "alice"
+
+    @pytest.mark.asyncio
+    async def test_users_role_rejected_when_developer_only(self):
+        """Users role + developer_only=True → 403 (eval=No)."""
+        request = MagicMock()
+        request.headers = {"authorization": "Bearer valid-token"}
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", True),
+            patch(
+                "deep_agent.aegra.auth._decode_token",
+                return_value={"preferred_username": "alice", "sub": "uuid-1"},
+            ),
+            patch(
+                "deep_agent.src.ldap.resolve_user_role",
+                new_callable=AsyncMock,
+                return_value="users",
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await check_ldap_role(request, developer_only=True)
+        assert exc_info.value.status_code == 403
+        assert "Developer access" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_owners_pass_developer_only(self):
+        """Owners role + developer_only=True → passes (eval=Yes)."""
+        request = MagicMock()
+        request.headers = {"authorization": "Bearer valid-token"}
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", True),
+            patch(
+                "deep_agent.aegra.auth._decode_token",
+                return_value={"preferred_username": "admin-user", "sub": "uuid-1"},
+            ),
+            patch(
+                "deep_agent.src.ldap.resolve_user_role",
+                new_callable=AsyncMock,
+                return_value="owners",
+            ),
+        ):
+            result = await check_ldap_role(request, developer_only=True)
+        assert result == "admin-user"
+
+    @pytest.mark.asyncio
+    async def test_admins_pass_developer_only(self):
+        request = MagicMock()
+        request.headers = {"authorization": "Bearer valid-token"}
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", True),
+            patch(
+                "deep_agent.aegra.auth._decode_token",
+                return_value={"preferred_username": "admin-user", "sub": "uuid-1"},
+            ),
+            patch(
+                "deep_agent.src.ldap.resolve_user_role",
+                new_callable=AsyncMock,
+                return_value="admins",
+            ),
+        ):
+            result = await check_ldap_role(request, developer_only=True)
+        assert result == "admin-user"
+
+    @pytest.mark.asyncio
+    async def test_builders_pass_developer_only(self):
+        request = MagicMock()
+        request.headers = {"authorization": "Bearer valid-token"}
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", True),
+            patch(
+                "deep_agent.aegra.auth._decode_token",
+                return_value={"preferred_username": "builder-user", "sub": "uuid-1"},
+            ),
+            patch(
+                "deep_agent.src.ldap.resolve_user_role",
+                new_callable=AsyncMock,
+                return_value="builders",
+            ),
+        ):
+            result = await check_ldap_role(request, developer_only=True)
+        assert result == "builder-user"
+
+    @pytest.mark.asyncio
+    async def test_missing_user_identity_raises_401(self):
+        request = MagicMock()
+        request.headers = {"authorization": "Bearer valid-token"}
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", True),
+            patch(
+                "deep_agent.aegra.auth._decode_token",
+                return_value={"sub": ""},
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await check_ldap_role(request)
+        assert exc_info.value.status_code == 401
+
+
+class TestAuthenticatedUserIdDeveloperOnly:
+    """Tests the developer_only parameter on authenticated_user_id."""
+
+    @pytest.mark.asyncio
+    async def test_developer_only_blocks_users_role(self):
+        request = MagicMock()
+        request.headers = {"authorization": "Bearer valid-token"}
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", True),
+            patch(
+                "deep_agent.aegra.auth._decode_token",
+                return_value={"sub": "user-1", "preferred_username": "alice"},
+            ),
+            patch(
+                "deep_agent.src.ldap.resolve_user_role",
+                new_callable=AsyncMock,
+                return_value="users",
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await authenticated_user_id(request, developer_only=True)
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_developer_only_passes_owners(self):
+        request = MagicMock()
+        request.headers = {"authorization": "Bearer valid-token"}
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", True),
+            patch(
+                "deep_agent.aegra.auth._decode_token",
+                return_value={"sub": "user-1", "preferred_username": "alice"},
+            ),
+            patch(
+                "deep_agent.src.ldap.resolve_user_role",
+                new_callable=AsyncMock,
+                return_value="owners",
+            ),
+        ):
+            result = await authenticated_user_id(request, developer_only=True)
+        assert result == "user-1"
+
+    @pytest.mark.asyncio
+    async def test_developer_only_none_role_passes(self):
+        """When resolve_user_role returns None (no groups), developer_only does not block."""
+        request = MagicMock()
+        request.headers = {"authorization": "Bearer valid-token"}
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", True),
+            patch(
+                "deep_agent.aegra.auth._decode_token",
+                return_value={"sub": "user-1", "preferred_username": "alice"},
+            ),
+            patch(
+                "deep_agent.src.ldap.resolve_user_role",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            result = await authenticated_user_id(request, developer_only=True)
+        assert result == "user-1"
 
 
 class TestRuleUserIds:

--- a/tests/unit/aegra/test_eval_routes.py
+++ b/tests/unit/aegra/test_eval_routes.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 
 import deep_agent.aegra.eval_routes as er
 
@@ -1374,27 +1375,191 @@ class TestInternalCleanupEndpoint:
         assert "status" in result
 
 
-class TestRequireBearer:
-    async def test_returns_token_when_valid(self):
-        creds = MagicMock()
-        creds.credentials = "my-token"
-        result = er._require_bearer(creds)
-        assert result == "my-token"
+class TestRequireDeveloper:
+    """Tests the Developer/Dataset/Eval column from the behavior matrix.
 
-    async def test_raises_401_when_none(self):
-        from fastapi import HTTPException
+    | Scenario                                    | Eval Access |
+    |---------------------------------------------|-------------|
+    | AUTH_ENABLED=false (local dev)               | Yes         |
+    | Groups defined, user is owner/admin/builder  | Yes         |
+    | No groups in PROMPT.md (everyone=users)      | No (403)    |
+    | Groups defined, user is users role           | No (403)    |
+    | Groups defined, private, no group match      | No (403)    |
+    | Groups defined, public, no group match       | No (403)    |
+    """
 
+    @pytest.mark.asyncio
+    async def test_raises_401_when_no_creds(self):
         with pytest.raises(HTTPException) as exc:
-            er._require_bearer(None)
+            await er._require_developer(None)
         assert exc.value.status_code == 401
 
+    @pytest.mark.asyncio
     async def test_raises_401_when_empty_credentials(self):
-        from fastapi import HTTPException
-
         creds = MagicMock()
         creds.credentials = ""
         with pytest.raises(HTTPException) as exc:
-            er._require_bearer(creds)
+            await er._require_developer(creds)
+        assert exc.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_auth_disabled_passes(self):
+        """AUTH_ENABLED=false → eval=Yes (full access)."""
+        creds = MagicMock()
+        creds.credentials = "dev-token"
+        with patch("deep_agent.aegra.auth.ENABLE_AUTH", False):
+            result = await er._require_developer(creds)
+        assert result == "dev-token"
+
+    @pytest.mark.asyncio
+    async def test_owners_pass(self):
+        """Groups defined, user is owner → eval=Yes."""
+        creds = MagicMock()
+        creds.credentials = "valid-token"
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", True),
+            patch(
+                "deep_agent.aegra.auth._decode_token",
+                return_value={"sub": "u1", "preferred_username": "alice"},
+            ),
+            patch(
+                "deep_agent.src.ldap.resolve_user_role",
+                new_callable=AsyncMock,
+                return_value="owners",
+            ),
+        ):
+            result = await er._require_developer(creds)
+        assert result == "valid-token"
+
+    @pytest.mark.asyncio
+    async def test_admins_pass(self):
+        creds = MagicMock()
+        creds.credentials = "valid-token"
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", True),
+            patch(
+                "deep_agent.aegra.auth._decode_token",
+                return_value={"sub": "u1", "preferred_username": "alice"},
+            ),
+            patch(
+                "deep_agent.src.ldap.resolve_user_role",
+                new_callable=AsyncMock,
+                return_value="admins",
+            ),
+        ):
+            result = await er._require_developer(creds)
+        assert result == "valid-token"
+
+    @pytest.mark.asyncio
+    async def test_builders_pass(self):
+        creds = MagicMock()
+        creds.credentials = "valid-token"
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", True),
+            patch(
+                "deep_agent.aegra.auth._decode_token",
+                return_value={"sub": "u1", "preferred_username": "builder"},
+            ),
+            patch(
+                "deep_agent.src.ldap.resolve_user_role",
+                new_callable=AsyncMock,
+                return_value="builders",
+            ),
+        ):
+            result = await er._require_developer(creds)
+        assert result == "valid-token"
+
+    @pytest.mark.asyncio
+    async def test_users_role_rejected(self):
+        """Groups defined, user is users role → eval=No (403)."""
+        creds = MagicMock()
+        creds.credentials = "valid-token"
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", True),
+            patch(
+                "deep_agent.aegra.auth._decode_token",
+                return_value={"sub": "u1", "preferred_username": "alice"},
+            ),
+            patch(
+                "deep_agent.src.ldap.resolve_user_role",
+                new_callable=AsyncMock,
+                return_value="users",
+            ),
+            pytest.raises(HTTPException) as exc,
+        ):
+            await er._require_developer(creds)
+        assert exc.value.status_code == 403
+        assert "Developer access" in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_denied_role_rejected(self):
+        """Groups defined, private, no match → eval=403."""
+        creds = MagicMock()
+        creds.credentials = "valid-token"
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", True),
+            patch(
+                "deep_agent.aegra.auth._decode_token",
+                return_value={"sub": "u1", "preferred_username": "outsider"},
+            ),
+            patch(
+                "deep_agent.src.ldap.resolve_user_role",
+                new_callable=AsyncMock,
+                return_value="denied",
+            ),
+            pytest.raises(HTTPException) as exc,
+        ):
+            await er._require_developer(creds)
+        assert exc.value.status_code == 403
+        assert "not a member" in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_expired_token_raises_401(self):
+        import jwt as pyjwt
+
+        creds = MagicMock()
+        creds.credentials = "expired-token"
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", True),
+            patch(
+                "deep_agent.aegra.auth._decode_token",
+                side_effect=pyjwt.ExpiredSignatureError(),
+            ),
+            pytest.raises(HTTPException) as exc,
+        ):
+            await er._require_developer(creds)
+        assert exc.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_invalid_token_raises_401(self):
+        import jwt as pyjwt
+
+        creds = MagicMock()
+        creds.credentials = "bad-token"
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", True),
+            patch(
+                "deep_agent.aegra.auth._decode_token",
+                side_effect=pyjwt.PyJWTError("Invalid"),
+            ),
+            pytest.raises(HTTPException) as exc,
+        ):
+            await er._require_developer(creds)
+        assert exc.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_missing_user_identity_raises_401(self):
+        creds = MagicMock()
+        creds.credentials = "valid-token"
+        with (
+            patch("deep_agent.aegra.auth.ENABLE_AUTH", True),
+            patch(
+                "deep_agent.aegra.auth._decode_token",
+                return_value={"sub": ""},
+            ),
+            pytest.raises(HTTPException) as exc,
+        ):
+            await er._require_developer(creds)
         assert exc.value.status_code == 401
 
 

--- a/tests/unit/ldap/test_config.py
+++ b/tests/unit/ldap/test_config.py
@@ -81,7 +81,9 @@ class TestGetBindDn:
 class TestGetGroupSearchBase:
     def test_default_derivation(self):
         s = LdapSettings(LDAP_URL="ldaps://ldap.example.com")
-        assert s.get_group_search_base() == "ou=adhoc,ou=managedGroups,dc=example,dc=com"
+        assert (
+            s.get_group_search_base() == "ou=adhoc,ou=managedGroups,dc=example,dc=com"
+        )
 
     def test_explicit_override(self):
         s = LdapSettings(

--- a/tests/unit/ldap/test_config.py
+++ b/tests/unit/ldap/test_config.py
@@ -1,0 +1,109 @@
+"""Unit tests for deep_agent.src.ldap.config."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from deep_agent.src.ldap.config import LdapSettings
+
+
+class TestLdapSettings:
+    def test_defaults(self):
+        with patch.dict(os.environ, {}, clear=True):
+            s = LdapSettings()
+            assert s.LDAP_URL == ""
+            assert s.LDAP_BASE_UID == ""
+            assert s.LDAP_PASSWORD == ""
+            assert s.LDAP_GROUP_SEARCH_BASE == ""
+            assert s.LDAP_TLS_VERIFY is True
+            assert s.LDAP_CACHE_TTL_SECONDS == 300
+
+    def test_from_env(self):
+        env = {
+            "LDAP_URL": "ldaps://ldap.corp.example.com",
+            "LDAP_BASE_UID": "svcacct",
+            "LDAP_PASSWORD": "secret",
+            "LDAP_TLS_VERIFY": "false",
+            "LDAP_CACHE_TTL_SECONDS": "600",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            s = LdapSettings()
+            assert s.LDAP_URL == "ldaps://ldap.corp.example.com"
+            assert s.LDAP_BASE_UID == "svcacct"
+            assert s.LDAP_PASSWORD == "secret"
+            assert s.LDAP_TLS_VERIFY is False
+            assert s.LDAP_CACHE_TTL_SECONDS == 600
+
+    def test_password_hidden_in_repr(self):
+        s = LdapSettings(LDAP_PASSWORD="supersecret")
+        r = repr(s)
+        assert "supersecret" not in r
+
+
+class TestDeriveBaseDn:
+    def test_standard_hostname(self):
+        s = LdapSettings(LDAP_URL="ldaps://ldap.example.com")
+        assert s.derive_base_dn() == "dc=example,dc=com"
+
+    def test_deep_hostname_uses_last_two(self):
+        s = LdapSettings(LDAP_URL="ldaps://ldap.corp.example.org")
+        assert s.derive_base_dn() == "dc=example,dc=org"
+
+    def test_empty_url(self):
+        s = LdapSettings(LDAP_URL="")
+        assert s.derive_base_dn() == ""
+
+    def test_single_part_hostname(self):
+        s = LdapSettings(LDAP_URL="ldaps://localhost")
+        assert s.derive_base_dn() == ""
+
+    def test_two_part_hostname(self):
+        s = LdapSettings(LDAP_URL="ldap://example.com")
+        assert s.derive_base_dn() == "dc=example,dc=com"
+
+
+class TestGetBindDn:
+    def test_simple_uid(self):
+        s = LdapSettings(LDAP_URL="ldaps://ldap.example.com", LDAP_BASE_UID="svc")
+        assert s.get_bind_dn() == "uid=svc,ou=users,dc=example,dc=com"
+
+    def test_full_dn_passthrough(self):
+        full_dn = "cn=admin,dc=example,dc=com"
+        s = LdapSettings(LDAP_URL="ldaps://ldap.example.com", LDAP_BASE_UID=full_dn)
+        assert s.get_bind_dn() == full_dn
+
+    def test_empty_uid(self):
+        s = LdapSettings(LDAP_BASE_UID="")
+        assert s.get_bind_dn() == ""
+
+
+class TestGetGroupSearchBase:
+    def test_default_derivation(self):
+        s = LdapSettings(LDAP_URL="ldaps://ldap.example.com")
+        assert s.get_group_search_base() == "ou=adhoc,ou=managedGroups,dc=example,dc=com"
+
+    def test_explicit_override(self):
+        s = LdapSettings(
+            LDAP_URL="ldaps://ldap.example.com",
+            LDAP_GROUP_SEARCH_BASE="ou=groups,dc=custom,dc=com",
+        )
+        assert s.get_group_search_base() == "ou=groups,dc=custom,dc=com"
+
+    def test_no_url_empty_base(self):
+        s = LdapSettings(LDAP_URL="")
+        assert s.get_group_search_base() == ""
+
+
+class TestCacheTtlValidation:
+    def test_too_low_raises(self):
+        with pytest.raises(Exception):
+            LdapSettings(LDAP_CACHE_TTL_SECONDS=5)
+
+    def test_too_high_raises(self):
+        with pytest.raises(Exception):
+            LdapSettings(LDAP_CACHE_TTL_SECONDS=100000)
+
+    def test_boundary_valid(self):
+        s = LdapSettings(LDAP_CACHE_TTL_SECONDS=10)
+        assert s.LDAP_CACHE_TTL_SECONDS == 10

--- a/tests/unit/ldap/test_prompt_config.py
+++ b/tests/unit/ldap/test_prompt_config.py
@@ -1,0 +1,270 @@
+"""Unit tests for deep_agent.src.ldap.prompt_config."""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from deep_agent.src.ldap.prompt_config import (
+    PRIVILEGED_ROLES,
+    ROLE_HIERARCHY,
+    GroupRoleMapping,
+    PromptAccessConfig,
+    _parse_groups_from_frontmatter,
+    get_prompt_access_config,
+    reset_prompt_config,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    reset_prompt_config()
+    yield
+    reset_prompt_config()
+
+
+def _write_prompt_md(tmpdir: str, content: str) -> Path:
+    path = Path(tmpdir) / "PROMPT.md"
+    path.write_text(content)
+    return path
+
+
+class TestRoleHierarchy:
+    def test_hierarchy_values(self):
+        assert ROLE_HIERARCHY["owners"] == 4
+        assert ROLE_HIERARCHY["admins"] == 3
+        assert ROLE_HIERARCHY["builders"] == 2
+        assert ROLE_HIERARCHY["users"] == 1
+
+    def test_privileged_roles(self):
+        assert PRIVILEGED_ROLES == {"owners", "admins", "builders"}
+        assert "users" not in PRIVILEGED_ROLES
+
+
+class TestParseGroupsFromFrontmatter:
+    def test_full_groups(self, tmp_path):
+        content = """\
+---
+accessibility: public
+groups:
+  - role: owners
+    group: team-owners
+  - role: admins
+    group: team-admins
+  - role: builders
+    group: team-builders
+  - role: users
+    group: team-users
+---
+System prompt here.
+"""
+        path = tmp_path / "PROMPT.md"
+        path.write_text(content)
+        config = _parse_groups_from_frontmatter(path)
+
+        assert config.accessibility == "public"
+        assert config.groups is not None
+        assert len(config.groups) == 4
+        assert config.groups[0].role == "owners"
+        assert config.groups[0].group == "team-owners"
+
+    def test_private_by_default(self, tmp_path):
+        content = """\
+---
+groups:
+  - role: admins
+    group: team-admins
+---
+"""
+        path = tmp_path / "PROMPT.md"
+        path.write_text(content)
+        config = _parse_groups_from_frontmatter(path)
+
+        assert config.accessibility == "private"
+        assert config.groups is not None
+        assert len(config.groups) == 1
+
+    def test_no_frontmatter(self, tmp_path):
+        path = tmp_path / "PROMPT.md"
+        path.write_text("Just a system prompt, no YAML.")
+        config = _parse_groups_from_frontmatter(path)
+
+        assert config.groups is None
+        assert config.accessibility == "private"
+
+    def test_empty_groups_list(self, tmp_path):
+        content = """\
+---
+groups: []
+---
+"""
+        path = tmp_path / "PROMPT.md"
+        path.write_text(content)
+        config = _parse_groups_from_frontmatter(path)
+        assert config.groups is None
+
+    def test_invalid_group_entries_skipped(self, tmp_path):
+        content = """\
+---
+groups:
+  - role: owners
+    group: team-owners
+  - role: 123
+    group: invalid-role-type
+  - bad: entry
+  - role: builders
+    group: team-builders
+---
+"""
+        path = tmp_path / "PROMPT.md"
+        path.write_text(content)
+        config = _parse_groups_from_frontmatter(path)
+
+        assert config.groups is not None
+        assert len(config.groups) == 2
+        assert config.groups[0].role == "owners"
+        assert config.groups[1].role == "builders"
+
+    def test_roles_lowercased(self, tmp_path):
+        content = """\
+---
+groups:
+  - role: OWNERS
+    group: team-owners
+---
+"""
+        path = tmp_path / "PROMPT.md"
+        path.write_text(content)
+        config = _parse_groups_from_frontmatter(path)
+        assert config.groups[0].role == "owners"
+
+    def test_file_not_found(self, tmp_path):
+        config = _parse_groups_from_frontmatter(tmp_path / "missing.md")
+        assert config.groups is None
+        assert config.accessibility == "private"
+
+    def test_accessibility_non_public_defaults_private(self, tmp_path):
+        content = """\
+---
+accessibility: restricted
+groups:
+  - role: owners
+    group: team-owners
+---
+"""
+        path = tmp_path / "PROMPT.md"
+        path.write_text(content)
+        config = _parse_groups_from_frontmatter(path)
+        assert config.accessibility == "private"
+
+    def test_no_groups_key(self, tmp_path):
+        content = """\
+---
+accessibility: public
+---
+"""
+        path = tmp_path / "PROMPT.md"
+        path.write_text(content)
+        config = _parse_groups_from_frontmatter(path)
+        assert config.groups is None
+        assert config.accessibility == "public"
+
+
+class TestGetPromptAccessConfig:
+    def test_caches_by_mtime(self, tmp_path):
+        content = """\
+---
+groups:
+  - role: owners
+    group: team-owners
+---
+"""
+        prompt_path = tmp_path / "PROMPT.md"
+        prompt_path.write_text(content)
+
+        with patch(
+            "deep_agent.src.ldap.prompt_config._prompt_md_path",
+            return_value=prompt_path,
+        ):
+            c1 = get_prompt_access_config()
+            c2 = get_prompt_access_config()
+            assert c1 is c2
+
+    def test_reloads_on_mtime_change(self, tmp_path):
+        content1 = """\
+---
+groups:
+  - role: owners
+    group: team-owners
+---
+"""
+        content2 = """\
+---
+groups:
+  - role: admins
+    group: team-admins
+  - role: builders
+    group: team-builders
+---
+"""
+        prompt_path = tmp_path / "PROMPT.md"
+        prompt_path.write_text(content1)
+
+        with patch(
+            "deep_agent.src.ldap.prompt_config._prompt_md_path",
+            return_value=prompt_path,
+        ):
+            c1 = get_prompt_access_config()
+            assert len(c1.groups) == 1
+
+            import time
+            time.sleep(0.05)
+            prompt_path.write_text(content2)
+
+            c2 = get_prompt_access_config()
+            assert len(c2.groups) == 2
+
+    def test_missing_file_returns_default(self, tmp_path):
+        with patch(
+            "deep_agent.src.ldap.prompt_config._prompt_md_path",
+            return_value=tmp_path / "nonexistent.md",
+        ):
+            config = get_prompt_access_config()
+            assert config.groups is None
+            assert config.accessibility == "private"
+
+
+class TestResetPromptConfig:
+    def test_clears_cache(self, tmp_path):
+        content = """\
+---
+groups:
+  - role: owners
+    group: team-owners
+---
+"""
+        prompt_path = tmp_path / "PROMPT.md"
+        prompt_path.write_text(content)
+
+        with patch(
+            "deep_agent.src.ldap.prompt_config._prompt_md_path",
+            return_value=prompt_path,
+        ):
+            c1 = get_prompt_access_config()
+            reset_prompt_config()
+            c2 = get_prompt_access_config()
+            assert c1 is not c2
+
+
+class TestDataclasses:
+    def test_group_role_mapping(self):
+        m = GroupRoleMapping(role="owners", group="team-owners")
+        assert m.role == "owners"
+        assert m.group == "team-owners"
+
+    def test_prompt_access_config_defaults(self):
+        c = PromptAccessConfig()
+        assert c.groups is None
+        assert c.accessibility == "private"

--- a/tests/unit/ldap/test_prompt_config.py
+++ b/tests/unit/ldap/test_prompt_config.py
@@ -142,7 +142,7 @@ groups:
 
     def test_file_not_found(self, tmp_path):
         config = _parse_groups_from_frontmatter(tmp_path / "missing.md")
-        assert config.groups is None
+        assert config.groups == []
         assert config.accessibility == "private"
 
     def test_accessibility_non_public_defaults_private(self, tmp_path):
@@ -227,13 +227,13 @@ groups:
             c2 = get_prompt_access_config()
             assert len(c2.groups) == 2
 
-    def test_missing_file_returns_default(self, tmp_path):
+    def test_missing_file_returns_denied(self, tmp_path):
         with patch(
             "deep_agent.src.ldap.prompt_config._prompt_md_path",
             return_value=tmp_path / "nonexistent.md",
         ):
             config = get_prompt_access_config()
-            assert config.groups is None
+            assert config.groups == []
             assert config.accessibility == "private"
 
 

--- a/tests/unit/ldap/test_prompt_config.py
+++ b/tests/unit/ldap/test_prompt_config.py
@@ -220,6 +220,7 @@ groups:
             assert len(c1.groups) == 1
 
             import time
+
             time.sleep(0.05)
             prompt_path.write_text(content2)
 

--- a/tests/unit/ldap/test_service.py
+++ b/tests/unit/ldap/test_service.py
@@ -1,0 +1,502 @@
+"""Unit tests for deep_agent.src.ldap.service."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import deep_agent.src.ldap.service as svc
+from deep_agent.src.ldap.prompt_config import (
+    GroupRoleMapping,
+    PromptAccessConfig,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_module():
+    """Reset module-level state between tests."""
+    svc._ldap_conn = None
+    svc._bind_failed = False
+    svc._memory_cache.clear()
+    svc._startup_warning_logged = False
+    yield
+    svc._ldap_conn = None
+    svc._bind_failed = False
+    svc._memory_cache.clear()
+    svc._startup_warning_logged = False
+
+
+def _make_entry(member=None, unique_member=None, member_uid=None):
+    """Build a mock LDAP entry with the given attribute values."""
+    entry = MagicMock()
+
+    def _attr(values):
+        if values is None:
+            return None
+        attr = MagicMock()
+        attr.values = values
+        return attr
+
+    entry.member = _attr(member)
+    entry.uniqueMember = _attr(unique_member)
+    entry.memberUid = _attr(member_uid)
+    return entry
+
+
+# ── _escape_ldap_filter ──────────────────────────────────────────────────────
+
+
+class TestEscapeLdapFilter:
+    def test_plain_string(self):
+        assert svc._escape_ldap_filter("team-owners") == "team-owners"
+
+    def test_backslash(self):
+        assert "\\5c" in svc._escape_ldap_filter("a\\b")
+
+    def test_asterisk(self):
+        assert "\\2a" in svc._escape_ldap_filter("a*b")
+
+    def test_parentheses(self):
+        result = svc._escape_ldap_filter("a(b)c")
+        assert "\\28" in result
+        assert "\\29" in result
+
+    def test_null_byte(self):
+        assert "\\00" in svc._escape_ldap_filter("a\x00b")
+
+    def test_combined(self):
+        result = svc._escape_ldap_filter("t*(e)st\\")
+        assert "(" not in result
+        assert ")" not in result
+        assert "*" not in result
+
+
+# ── _ensure_bound ────────────────────────────────────────────────────────────
+
+
+class TestEnsureBound:
+    def test_no_url_returns_none(self):
+        with patch("deep_agent.src.ldap.service.ldap_settings") as ms:
+            ms.LDAP_URL = ""
+            assert svc._ensure_bound() is None
+
+    def test_returns_existing_conn(self):
+        mock_conn = MagicMock()
+        svc._ldap_conn = mock_conn
+        svc._bind_failed = False
+        with patch("deep_agent.src.ldap.service.ldap_settings") as ms:
+            ms.LDAP_URL = "ldaps://ldap.example.com"
+            assert svc._ensure_bound() is mock_conn
+
+    def test_bind_failure_returns_none(self):
+        svc._ldap_conn = None
+        svc._bind_failed = False
+
+        ldap3_mock = MagicMock()
+        ldap3_mock.Connection.side_effect = Exception("bind error")
+
+        with patch("deep_agent.src.ldap.service.ldap_settings") as ms:
+            ms.LDAP_URL = "ldaps://ldap.example.com"
+            ms.LDAP_TLS_VERIFY = True
+            ms.LDAP_PASSWORD = "pass"
+            ms.get_bind_dn.return_value = "uid=svc,dc=example,dc=com"
+
+            with patch.dict("sys.modules", {"ldap3": ldap3_mock}):
+                result = svc._ensure_bound()
+                assert result is None
+                assert svc._bind_failed is True
+
+    def test_successful_bind(self):
+        mock_conn = MagicMock()
+        ldap3_mock = MagicMock()
+        ldap3_mock.Connection.return_value = mock_conn
+
+        svc._ldap_conn = None
+        svc._bind_failed = False
+
+        with patch("deep_agent.src.ldap.service.ldap_settings") as ms:
+            ms.LDAP_URL = "ldaps://ldap.example.com"
+            ms.LDAP_TLS_VERIFY = True
+            ms.LDAP_PASSWORD = "pass"
+            ms.get_bind_dn.return_value = "uid=svc,dc=example,dc=com"
+
+            with patch.dict("sys.modules", {"ldap3": ldap3_mock}):
+                result = svc._ensure_bound()
+                assert result is mock_conn
+                assert svc._bind_failed is False
+
+    def test_tls_verify_false(self):
+        mock_conn = MagicMock()
+        ldap3_mock = MagicMock()
+        ldap3_mock.Connection.return_value = mock_conn
+
+        svc._ldap_conn = None
+        svc._bind_failed = False
+
+        with patch("deep_agent.src.ldap.service.ldap_settings") as ms:
+            ms.LDAP_URL = "ldaps://ldap.example.com"
+            ms.LDAP_TLS_VERIFY = False
+            ms.LDAP_PASSWORD = "pass"
+            ms.get_bind_dn.return_value = "uid=svc,dc=example,dc=com"
+
+            with patch.dict("sys.modules", {"ldap3": ldap3_mock}):
+                result = svc._ensure_bound()
+                assert result is mock_conn
+
+
+# ── _cache_get / _cache_set ──────────────────────────────────────────────────
+
+
+class TestCaching:
+    def test_memory_cache_hit(self):
+        svc._memory_cache["key1"] = (True, time.monotonic())
+        with patch("deep_agent.src.ldap.service.ldap_settings") as ms:
+            ms.LDAP_CACHE_TTL_SECONDS = 300
+            with patch("deep_agent.aegra.redis.cache_get", return_value=None):
+                assert svc._cache_get("key1") is True
+
+    def test_memory_cache_expired(self):
+        svc._memory_cache["key1"] = (True, time.monotonic() - 400)
+        with patch("deep_agent.src.ldap.service.ldap_settings") as ms:
+            ms.LDAP_CACHE_TTL_SECONDS = 300
+            with patch("deep_agent.aegra.redis.cache_get", return_value=None):
+                assert svc._cache_get("key1") is None
+
+    def test_redis_cache_hit_true(self):
+        with patch("deep_agent.aegra.redis.cache_get", return_value="1"):
+            assert svc._cache_get("key1") is True
+
+    def test_redis_cache_hit_false(self):
+        with patch("deep_agent.aegra.redis.cache_get", return_value="0"):
+            assert svc._cache_get("key1") is False
+
+    def test_cache_miss(self):
+        with patch("deep_agent.aegra.redis.cache_get", return_value=None):
+            assert svc._cache_get("key1") is None
+
+    def test_cache_set_writes_both(self):
+        with patch("deep_agent.aegra.redis.cache_set") as redis_set, \
+             patch("deep_agent.src.ldap.service.ldap_settings") as ms:
+            ms.LDAP_CACHE_TTL_SECONDS = 300
+            svc._cache_set("k", True)
+            redis_set.assert_called_once_with("k", "1", 300)
+            assert "k" in svc._memory_cache
+            assert svc._memory_cache["k"][0] is True
+
+    def test_cache_set_false_value(self):
+        with patch("deep_agent.aegra.redis.cache_set") as redis_set, \
+             patch("deep_agent.src.ldap.service.ldap_settings") as ms:
+            ms.LDAP_CACHE_TTL_SECONDS = 300
+            svc._cache_set("k", False)
+            redis_set.assert_called_once_with("k", "0", 300)
+
+
+# ── _is_user_in_group_sync ──────────────────────────────────────────────────
+
+
+class TestIsUserInGroupSync:
+    def test_cache_hit_returns_cached(self):
+        svc._memory_cache["ldap:membership:alice:team"] = (True, time.monotonic())
+        with patch("deep_agent.src.ldap.service.ldap_settings") as ms:
+            ms.LDAP_CACHE_TTL_SECONDS = 300
+            with patch("deep_agent.aegra.redis.cache_get", return_value=None):
+                assert svc._is_user_in_group_sync("alice", "team") is True
+
+    def test_no_conn_returns_false(self):
+        with patch.object(svc, "_ensure_bound", return_value=None), \
+             patch("deep_agent.aegra.redis.cache_get", return_value=None):
+            assert svc._is_user_in_group_sync("alice", "team") is False
+
+    def test_member_uid_match(self):
+        entry = _make_entry(member_uid=["alice"])
+        mock_conn = MagicMock()
+        mock_conn.entries = [entry]
+        ldap3_mock = MagicMock()
+
+        with patch.object(svc, "_ensure_bound", return_value=mock_conn), \
+             patch.object(svc, "_derive_base_dn", return_value="dc=example,dc=com"), \
+             patch("deep_agent.src.ldap.service.ldap_settings") as ms, \
+             patch("deep_agent.aegra.redis.cache_get", return_value=None), \
+             patch("deep_agent.aegra.redis.cache_set"), \
+             patch.dict("sys.modules", {"ldap3": ldap3_mock}):
+            ms.get_group_search_base.return_value = "ou=groups,dc=example,dc=com"
+            ms.LDAP_CACHE_TTL_SECONDS = 300
+            assert svc._is_user_in_group_sync("alice", "team-owners") is True
+
+    def test_member_dn_match(self):
+        entry = _make_entry(member=["uid=bob,ou=users,dc=example,dc=com"])
+        mock_conn = MagicMock()
+        mock_conn.entries = [entry]
+        ldap3_mock = MagicMock()
+
+        with patch.object(svc, "_ensure_bound", return_value=mock_conn), \
+             patch.object(svc, "_derive_base_dn", return_value="dc=example,dc=com"), \
+             patch("deep_agent.src.ldap.service.ldap_settings") as ms, \
+             patch("deep_agent.aegra.redis.cache_get", return_value=None), \
+             patch("deep_agent.aegra.redis.cache_set"), \
+             patch.dict("sys.modules", {"ldap3": ldap3_mock}):
+            ms.get_group_search_base.return_value = "ou=groups,dc=example,dc=com"
+            ms.LDAP_CACHE_TTL_SECONDS = 300
+            assert svc._is_user_in_group_sync("bob", "team") is True
+
+    def test_member_dn_prefix_match(self):
+        entry = _make_entry(member=["uid=carol,ou=people,dc=other,dc=com"])
+        mock_conn = MagicMock()
+        mock_conn.entries = [entry]
+        ldap3_mock = MagicMock()
+
+        with patch.object(svc, "_ensure_bound", return_value=mock_conn), \
+             patch.object(svc, "_derive_base_dn", return_value="dc=example,dc=com"), \
+             patch("deep_agent.src.ldap.service.ldap_settings") as ms, \
+             patch("deep_agent.aegra.redis.cache_get", return_value=None), \
+             patch("deep_agent.aegra.redis.cache_set"), \
+             patch.dict("sys.modules", {"ldap3": ldap3_mock}):
+            ms.get_group_search_base.return_value = "ou=groups,dc=example,dc=com"
+            ms.LDAP_CACHE_TTL_SECONDS = 300
+            assert svc._is_user_in_group_sync("carol", "team") is True
+
+    def test_no_match(self):
+        entry = _make_entry(member=["uid=other,ou=users,dc=example,dc=com"])
+        mock_conn = MagicMock()
+        mock_conn.entries = [entry]
+        ldap3_mock = MagicMock()
+
+        with patch.object(svc, "_ensure_bound", return_value=mock_conn), \
+             patch.object(svc, "_derive_base_dn", return_value="dc=example,dc=com"), \
+             patch("deep_agent.src.ldap.service.ldap_settings") as ms, \
+             patch("deep_agent.aegra.redis.cache_get", return_value=None), \
+             patch("deep_agent.aegra.redis.cache_set"), \
+             patch.dict("sys.modules", {"ldap3": ldap3_mock}):
+            ms.get_group_search_base.return_value = "ou=groups,dc=example,dc=com"
+            ms.LDAP_CACHE_TTL_SECONDS = 300
+            assert svc._is_user_in_group_sync("alice", "team") is False
+
+    def test_search_exception_returns_false(self):
+        mock_conn = MagicMock()
+        mock_conn.search.side_effect = Exception("timeout")
+        ldap3_mock = MagicMock()
+
+        with patch.object(svc, "_ensure_bound", return_value=mock_conn), \
+             patch("deep_agent.src.ldap.service.ldap_settings") as ms, \
+             patch("deep_agent.aegra.redis.cache_get", return_value=None), \
+             patch.dict("sys.modules", {"ldap3": ldap3_mock}):
+            ms.get_group_search_base.return_value = "ou=groups,dc=example,dc=com"
+            assert svc._is_user_in_group_sync("alice", "team") is False
+            assert svc._bind_failed is True
+
+    def test_case_insensitive_match(self):
+        entry = _make_entry(member_uid=["ALICE"])
+        mock_conn = MagicMock()
+        mock_conn.entries = [entry]
+        ldap3_mock = MagicMock()
+
+        with patch.object(svc, "_ensure_bound", return_value=mock_conn), \
+             patch.object(svc, "_derive_base_dn", return_value="dc=example,dc=com"), \
+             patch("deep_agent.src.ldap.service.ldap_settings") as ms, \
+             patch("deep_agent.aegra.redis.cache_get", return_value=None), \
+             patch("deep_agent.aegra.redis.cache_set"), \
+             patch.dict("sys.modules", {"ldap3": ldap3_mock}):
+            ms.get_group_search_base.return_value = "ou=groups,dc=example,dc=com"
+            ms.LDAP_CACHE_TTL_SECONDS = 300
+            assert svc._is_user_in_group_sync("alice", "team") is True
+
+    def test_empty_entries(self):
+        mock_conn = MagicMock()
+        mock_conn.entries = []
+        ldap3_mock = MagicMock()
+
+        with patch.object(svc, "_ensure_bound", return_value=mock_conn), \
+             patch.object(svc, "_derive_base_dn", return_value="dc=example,dc=com"), \
+             patch("deep_agent.src.ldap.service.ldap_settings") as ms, \
+             patch("deep_agent.aegra.redis.cache_get", return_value=None), \
+             patch("deep_agent.aegra.redis.cache_set"), \
+             patch.dict("sys.modules", {"ldap3": ldap3_mock}):
+            ms.get_group_search_base.return_value = "ou=groups,dc=example,dc=com"
+            ms.LDAP_CACHE_TTL_SECONDS = 300
+            assert svc._is_user_in_group_sync("alice", "team") is False
+
+    def test_unique_member_match(self):
+        entry = _make_entry(unique_member=["uid=dave,ou=users,dc=example,dc=com"])
+        mock_conn = MagicMock()
+        mock_conn.entries = [entry]
+        ldap3_mock = MagicMock()
+
+        with patch.object(svc, "_ensure_bound", return_value=mock_conn), \
+             patch.object(svc, "_derive_base_dn", return_value="dc=example,dc=com"), \
+             patch("deep_agent.src.ldap.service.ldap_settings") as ms, \
+             patch("deep_agent.aegra.redis.cache_get", return_value=None), \
+             patch("deep_agent.aegra.redis.cache_set"), \
+             patch.dict("sys.modules", {"ldap3": ldap3_mock}):
+            ms.get_group_search_base.return_value = "ou=groups,dc=example,dc=com"
+            ms.LDAP_CACHE_TTL_SECONDS = 300
+            assert svc._is_user_in_group_sync("dave", "team") is True
+
+
+# ── _resolve_user_role_sync ──────────────────────────────────────────────────
+
+
+class TestResolveUserRoleSync:
+    def test_highest_role_wins(self):
+        mappings = [
+            GroupRoleMapping(role="users", group="g1"),
+            GroupRoleMapping(role="owners", group="g2"),
+            GroupRoleMapping(role="builders", group="g3"),
+        ]
+        with patch.object(svc, "_is_user_in_group_sync", return_value=True):
+            assert svc._resolve_user_role_sync("alice", mappings) == "owners"
+
+    def test_no_membership_returns_denied(self):
+        mappings = [GroupRoleMapping(role="owners", group="g1")]
+        with patch.object(svc, "_is_user_in_group_sync", return_value=False):
+            assert svc._resolve_user_role_sync("alice", mappings) == "denied"
+
+    def test_single_match(self):
+        mappings = [
+            GroupRoleMapping(role="builders", group="g1"),
+            GroupRoleMapping(role="admins", group="g2"),
+        ]
+
+        def check(uid, group):
+            return group == "g1"
+
+        with patch.object(svc, "_is_user_in_group_sync", side_effect=check):
+            assert svc._resolve_user_role_sync("alice", mappings) == "builders"
+
+    def test_unknown_role_treated_as_zero_priority(self):
+        mappings = [
+            GroupRoleMapping(role="unknown", group="g1"),
+            GroupRoleMapping(role="users", group="g2"),
+        ]
+        with patch.object(svc, "_is_user_in_group_sync", return_value=True):
+            assert svc._resolve_user_role_sync("alice", mappings) == "users"
+
+
+# ── resolve_user_role (async) ────────────────────────────────────────────────
+
+
+class TestResolveUserRole:
+    @pytest.mark.asyncio
+    async def test_no_groups_returns_users(self):
+        config = PromptAccessConfig(groups=None)
+        with patch.object(svc, "get_prompt_access_config", return_value=config):
+            assert await svc.resolve_user_role("alice") == "users"
+
+    @pytest.mark.asyncio
+    async def test_no_ldap_url_private_returns_denied(self):
+        config = PromptAccessConfig(
+            groups=[GroupRoleMapping(role="owners", group="g1")],
+            accessibility="private",
+        )
+        with patch.object(svc, "get_prompt_access_config", return_value=config), \
+             patch("deep_agent.src.ldap.service.ldap_settings") as ms:
+            ms.LDAP_URL = ""
+            assert await svc.resolve_user_role("alice") == "denied"
+
+    @pytest.mark.asyncio
+    async def test_no_ldap_url_public_returns_users(self):
+        config = PromptAccessConfig(
+            groups=[GroupRoleMapping(role="owners", group="g1")],
+            accessibility="public",
+        )
+        with patch.object(svc, "get_prompt_access_config", return_value=config), \
+             patch("deep_agent.src.ldap.service.ldap_settings") as ms:
+            ms.LDAP_URL = ""
+            assert await svc.resolve_user_role("alice") == "users"
+
+    @pytest.mark.asyncio
+    async def test_public_denied_becomes_users(self):
+        config = PromptAccessConfig(
+            groups=[GroupRoleMapping(role="owners", group="g1")],
+            accessibility="public",
+        )
+        with patch.object(svc, "get_prompt_access_config", return_value=config), \
+             patch("deep_agent.src.ldap.service.ldap_settings") as ms, \
+             patch.object(svc, "_resolve_user_role_sync", return_value="denied"):
+            ms.LDAP_URL = "ldaps://ldap.example.com"
+            assert await svc.resolve_user_role("alice") == "users"
+
+    @pytest.mark.asyncio
+    async def test_private_denied_stays_denied(self):
+        config = PromptAccessConfig(
+            groups=[GroupRoleMapping(role="owners", group="g1")],
+            accessibility="private",
+        )
+        with patch.object(svc, "get_prompt_access_config", return_value=config), \
+             patch("deep_agent.src.ldap.service.ldap_settings") as ms, \
+             patch.object(svc, "_resolve_user_role_sync", return_value="denied"):
+            ms.LDAP_URL = "ldaps://ldap.example.com"
+            assert await svc.resolve_user_role("alice") == "denied"
+
+    @pytest.mark.asyncio
+    async def test_matched_role_returned(self):
+        config = PromptAccessConfig(
+            groups=[GroupRoleMapping(role="builders", group="g1")],
+            accessibility="private",
+        )
+        with patch.object(svc, "get_prompt_access_config", return_value=config), \
+             patch("deep_agent.src.ldap.service.ldap_settings") as ms, \
+             patch.object(svc, "_resolve_user_role_sync", return_value="builders"):
+            ms.LDAP_URL = "ldaps://ldap.example.com"
+            assert await svc.resolve_user_role("alice") == "builders"
+
+    @pytest.mark.asyncio
+    async def test_no_ldap_url_logs_warning_once(self):
+        config = PromptAccessConfig(
+            groups=[GroupRoleMapping(role="owners", group="g1")],
+            accessibility="private",
+        )
+        with patch.object(svc, "get_prompt_access_config", return_value=config), \
+             patch("deep_agent.src.ldap.service.ldap_settings") as ms:
+            ms.LDAP_URL = ""
+            await svc.resolve_user_role("alice")
+            assert svc._startup_warning_logged is True
+            await svc.resolve_user_role("bob")
+
+
+# ── close_ldap ───────────────────────────────────────────────────────────────
+
+
+class TestCloseLdap:
+    def test_unbinds_and_clears(self):
+        mock_conn = MagicMock()
+        svc._ldap_conn = mock_conn
+        svc._bind_failed = True
+        svc._memory_cache["k"] = (True, 0)
+
+        svc.close_ldap()
+
+        mock_conn.unbind.assert_called_once()
+        assert svc._ldap_conn is None
+        assert svc._bind_failed is False
+        assert len(svc._memory_cache) == 0
+
+    def test_no_conn_still_clears(self):
+        svc._ldap_conn = None
+        svc._bind_failed = True
+        svc._memory_cache["k"] = (True, 0)
+
+        svc.close_ldap()
+
+        assert svc._bind_failed is False
+        assert len(svc._memory_cache) == 0
+
+    def test_unbind_exception_swallowed(self):
+        mock_conn = MagicMock()
+        mock_conn.unbind.side_effect = Exception("already closed")
+        svc._ldap_conn = mock_conn
+
+        svc.close_ldap()
+        assert svc._ldap_conn is None
+
+
+# ── _derive_base_dn ─────────────────────────────────────────────────────────
+
+
+class TestDeriveBaseDn:
+    def test_delegates_to_settings(self):
+        with patch("deep_agent.src.ldap.service.ldap_settings") as ms:
+            ms.derive_base_dn.return_value = "dc=a,dc=b"
+            assert svc._derive_base_dn() == "dc=a,dc=b"

--- a/tests/unit/ldap/test_service.py
+++ b/tests/unit/ldap/test_service.py
@@ -178,8 +178,10 @@ class TestCaching:
             assert svc._cache_get("key1") is None
 
     def test_cache_set_writes_both(self):
-        with patch("deep_agent.aegra.redis.cache_set") as redis_set, \
-             patch("deep_agent.src.ldap.service.ldap_settings") as ms:
+        with (
+            patch("deep_agent.aegra.redis.cache_set") as redis_set,
+            patch("deep_agent.src.ldap.service.ldap_settings") as ms,
+        ):
             ms.LDAP_CACHE_TTL_SECONDS = 300
             svc._cache_set("k", True)
             redis_set.assert_called_once_with("k", "1", 300)
@@ -187,8 +189,10 @@ class TestCaching:
             assert svc._memory_cache["k"][0] is True
 
     def test_cache_set_false_value(self):
-        with patch("deep_agent.aegra.redis.cache_set") as redis_set, \
-             patch("deep_agent.src.ldap.service.ldap_settings") as ms:
+        with (
+            patch("deep_agent.aegra.redis.cache_set") as redis_set,
+            patch("deep_agent.src.ldap.service.ldap_settings") as ms,
+        ):
             ms.LDAP_CACHE_TTL_SECONDS = 300
             svc._cache_set("k", False)
             redis_set.assert_called_once_with("k", "0", 300)
@@ -206,8 +210,10 @@ class TestIsUserInGroupSync:
                 assert svc._is_user_in_group_sync("alice", "team") is True
 
     def test_no_conn_returns_false(self):
-        with patch.object(svc, "_ensure_bound", return_value=None), \
-             patch("deep_agent.aegra.redis.cache_get", return_value=None):
+        with (
+            patch.object(svc, "_ensure_bound", return_value=None),
+            patch("deep_agent.aegra.redis.cache_get", return_value=None),
+        ):
             assert svc._is_user_in_group_sync("alice", "team") is False
 
     def test_member_uid_match(self):
@@ -216,12 +222,14 @@ class TestIsUserInGroupSync:
         mock_conn.entries = [entry]
         ldap3_mock = MagicMock()
 
-        with patch.object(svc, "_ensure_bound", return_value=mock_conn), \
-             patch.object(svc, "_derive_base_dn", return_value="dc=example,dc=com"), \
-             patch("deep_agent.src.ldap.service.ldap_settings") as ms, \
-             patch("deep_agent.aegra.redis.cache_get", return_value=None), \
-             patch("deep_agent.aegra.redis.cache_set"), \
-             patch.dict("sys.modules", {"ldap3": ldap3_mock}):
+        with (
+            patch.object(svc, "_ensure_bound", return_value=mock_conn),
+            patch.object(svc, "_derive_base_dn", return_value="dc=example,dc=com"),
+            patch("deep_agent.src.ldap.service.ldap_settings") as ms,
+            patch("deep_agent.aegra.redis.cache_get", return_value=None),
+            patch("deep_agent.aegra.redis.cache_set"),
+            patch.dict("sys.modules", {"ldap3": ldap3_mock}),
+        ):
             ms.get_group_search_base.return_value = "ou=groups,dc=example,dc=com"
             ms.LDAP_CACHE_TTL_SECONDS = 300
             assert svc._is_user_in_group_sync("alice", "team-owners") is True
@@ -232,12 +240,14 @@ class TestIsUserInGroupSync:
         mock_conn.entries = [entry]
         ldap3_mock = MagicMock()
 
-        with patch.object(svc, "_ensure_bound", return_value=mock_conn), \
-             patch.object(svc, "_derive_base_dn", return_value="dc=example,dc=com"), \
-             patch("deep_agent.src.ldap.service.ldap_settings") as ms, \
-             patch("deep_agent.aegra.redis.cache_get", return_value=None), \
-             patch("deep_agent.aegra.redis.cache_set"), \
-             patch.dict("sys.modules", {"ldap3": ldap3_mock}):
+        with (
+            patch.object(svc, "_ensure_bound", return_value=mock_conn),
+            patch.object(svc, "_derive_base_dn", return_value="dc=example,dc=com"),
+            patch("deep_agent.src.ldap.service.ldap_settings") as ms,
+            patch("deep_agent.aegra.redis.cache_get", return_value=None),
+            patch("deep_agent.aegra.redis.cache_set"),
+            patch.dict("sys.modules", {"ldap3": ldap3_mock}),
+        ):
             ms.get_group_search_base.return_value = "ou=groups,dc=example,dc=com"
             ms.LDAP_CACHE_TTL_SECONDS = 300
             assert svc._is_user_in_group_sync("bob", "team") is True
@@ -248,12 +258,14 @@ class TestIsUserInGroupSync:
         mock_conn.entries = [entry]
         ldap3_mock = MagicMock()
 
-        with patch.object(svc, "_ensure_bound", return_value=mock_conn), \
-             patch.object(svc, "_derive_base_dn", return_value="dc=example,dc=com"), \
-             patch("deep_agent.src.ldap.service.ldap_settings") as ms, \
-             patch("deep_agent.aegra.redis.cache_get", return_value=None), \
-             patch("deep_agent.aegra.redis.cache_set"), \
-             patch.dict("sys.modules", {"ldap3": ldap3_mock}):
+        with (
+            patch.object(svc, "_ensure_bound", return_value=mock_conn),
+            patch.object(svc, "_derive_base_dn", return_value="dc=example,dc=com"),
+            patch("deep_agent.src.ldap.service.ldap_settings") as ms,
+            patch("deep_agent.aegra.redis.cache_get", return_value=None),
+            patch("deep_agent.aegra.redis.cache_set"),
+            patch.dict("sys.modules", {"ldap3": ldap3_mock}),
+        ):
             ms.get_group_search_base.return_value = "ou=groups,dc=example,dc=com"
             ms.LDAP_CACHE_TTL_SECONDS = 300
             assert svc._is_user_in_group_sync("carol", "team") is True
@@ -264,12 +276,14 @@ class TestIsUserInGroupSync:
         mock_conn.entries = [entry]
         ldap3_mock = MagicMock()
 
-        with patch.object(svc, "_ensure_bound", return_value=mock_conn), \
-             patch.object(svc, "_derive_base_dn", return_value="dc=example,dc=com"), \
-             patch("deep_agent.src.ldap.service.ldap_settings") as ms, \
-             patch("deep_agent.aegra.redis.cache_get", return_value=None), \
-             patch("deep_agent.aegra.redis.cache_set"), \
-             patch.dict("sys.modules", {"ldap3": ldap3_mock}):
+        with (
+            patch.object(svc, "_ensure_bound", return_value=mock_conn),
+            patch.object(svc, "_derive_base_dn", return_value="dc=example,dc=com"),
+            patch("deep_agent.src.ldap.service.ldap_settings") as ms,
+            patch("deep_agent.aegra.redis.cache_get", return_value=None),
+            patch("deep_agent.aegra.redis.cache_set"),
+            patch.dict("sys.modules", {"ldap3": ldap3_mock}),
+        ):
             ms.get_group_search_base.return_value = "ou=groups,dc=example,dc=com"
             ms.LDAP_CACHE_TTL_SECONDS = 300
             assert svc._is_user_in_group_sync("alice", "team") is False
@@ -279,10 +293,12 @@ class TestIsUserInGroupSync:
         mock_conn.search.side_effect = Exception("timeout")
         ldap3_mock = MagicMock()
 
-        with patch.object(svc, "_ensure_bound", return_value=mock_conn), \
-             patch("deep_agent.src.ldap.service.ldap_settings") as ms, \
-             patch("deep_agent.aegra.redis.cache_get", return_value=None), \
-             patch.dict("sys.modules", {"ldap3": ldap3_mock}):
+        with (
+            patch.object(svc, "_ensure_bound", return_value=mock_conn),
+            patch("deep_agent.src.ldap.service.ldap_settings") as ms,
+            patch("deep_agent.aegra.redis.cache_get", return_value=None),
+            patch.dict("sys.modules", {"ldap3": ldap3_mock}),
+        ):
             ms.get_group_search_base.return_value = "ou=groups,dc=example,dc=com"
             assert svc._is_user_in_group_sync("alice", "team") is False
             assert svc._bind_failed is True
@@ -293,12 +309,14 @@ class TestIsUserInGroupSync:
         mock_conn.entries = [entry]
         ldap3_mock = MagicMock()
 
-        with patch.object(svc, "_ensure_bound", return_value=mock_conn), \
-             patch.object(svc, "_derive_base_dn", return_value="dc=example,dc=com"), \
-             patch("deep_agent.src.ldap.service.ldap_settings") as ms, \
-             patch("deep_agent.aegra.redis.cache_get", return_value=None), \
-             patch("deep_agent.aegra.redis.cache_set"), \
-             patch.dict("sys.modules", {"ldap3": ldap3_mock}):
+        with (
+            patch.object(svc, "_ensure_bound", return_value=mock_conn),
+            patch.object(svc, "_derive_base_dn", return_value="dc=example,dc=com"),
+            patch("deep_agent.src.ldap.service.ldap_settings") as ms,
+            patch("deep_agent.aegra.redis.cache_get", return_value=None),
+            patch("deep_agent.aegra.redis.cache_set"),
+            patch.dict("sys.modules", {"ldap3": ldap3_mock}),
+        ):
             ms.get_group_search_base.return_value = "ou=groups,dc=example,dc=com"
             ms.LDAP_CACHE_TTL_SECONDS = 300
             assert svc._is_user_in_group_sync("alice", "team") is True
@@ -308,12 +326,14 @@ class TestIsUserInGroupSync:
         mock_conn.entries = []
         ldap3_mock = MagicMock()
 
-        with patch.object(svc, "_ensure_bound", return_value=mock_conn), \
-             patch.object(svc, "_derive_base_dn", return_value="dc=example,dc=com"), \
-             patch("deep_agent.src.ldap.service.ldap_settings") as ms, \
-             patch("deep_agent.aegra.redis.cache_get", return_value=None), \
-             patch("deep_agent.aegra.redis.cache_set"), \
-             patch.dict("sys.modules", {"ldap3": ldap3_mock}):
+        with (
+            patch.object(svc, "_ensure_bound", return_value=mock_conn),
+            patch.object(svc, "_derive_base_dn", return_value="dc=example,dc=com"),
+            patch("deep_agent.src.ldap.service.ldap_settings") as ms,
+            patch("deep_agent.aegra.redis.cache_get", return_value=None),
+            patch("deep_agent.aegra.redis.cache_set"),
+            patch.dict("sys.modules", {"ldap3": ldap3_mock}),
+        ):
             ms.get_group_search_base.return_value = "ou=groups,dc=example,dc=com"
             ms.LDAP_CACHE_TTL_SECONDS = 300
             assert svc._is_user_in_group_sync("alice", "team") is False
@@ -324,12 +344,14 @@ class TestIsUserInGroupSync:
         mock_conn.entries = [entry]
         ldap3_mock = MagicMock()
 
-        with patch.object(svc, "_ensure_bound", return_value=mock_conn), \
-             patch.object(svc, "_derive_base_dn", return_value="dc=example,dc=com"), \
-             patch("deep_agent.src.ldap.service.ldap_settings") as ms, \
-             patch("deep_agent.aegra.redis.cache_get", return_value=None), \
-             patch("deep_agent.aegra.redis.cache_set"), \
-             patch.dict("sys.modules", {"ldap3": ldap3_mock}):
+        with (
+            patch.object(svc, "_ensure_bound", return_value=mock_conn),
+            patch.object(svc, "_derive_base_dn", return_value="dc=example,dc=com"),
+            patch("deep_agent.src.ldap.service.ldap_settings") as ms,
+            patch("deep_agent.aegra.redis.cache_get", return_value=None),
+            patch("deep_agent.aegra.redis.cache_set"),
+            patch.dict("sys.modules", {"ldap3": ldap3_mock}),
+        ):
             ms.get_group_search_base.return_value = "ou=groups,dc=example,dc=com"
             ms.LDAP_CACHE_TTL_SECONDS = 300
             assert svc._is_user_in_group_sync("dave", "team") is True
@@ -390,8 +412,10 @@ class TestResolveUserRole:
             groups=[GroupRoleMapping(role="owners", group="g1")],
             accessibility="private",
         )
-        with patch.object(svc, "get_prompt_access_config", return_value=config), \
-             patch("deep_agent.src.ldap.service.ldap_settings") as ms:
+        with (
+            patch.object(svc, "get_prompt_access_config", return_value=config),
+            patch("deep_agent.src.ldap.service.ldap_settings") as ms,
+        ):
             ms.LDAP_URL = ""
             assert await svc.resolve_user_role("alice") == "denied"
 
@@ -401,8 +425,10 @@ class TestResolveUserRole:
             groups=[GroupRoleMapping(role="owners", group="g1")],
             accessibility="public",
         )
-        with patch.object(svc, "get_prompt_access_config", return_value=config), \
-             patch("deep_agent.src.ldap.service.ldap_settings") as ms:
+        with (
+            patch.object(svc, "get_prompt_access_config", return_value=config),
+            patch("deep_agent.src.ldap.service.ldap_settings") as ms,
+        ):
             ms.LDAP_URL = ""
             assert await svc.resolve_user_role("alice") == "users"
 
@@ -412,9 +438,11 @@ class TestResolveUserRole:
             groups=[GroupRoleMapping(role="owners", group="g1")],
             accessibility="public",
         )
-        with patch.object(svc, "get_prompt_access_config", return_value=config), \
-             patch("deep_agent.src.ldap.service.ldap_settings") as ms, \
-             patch.object(svc, "_resolve_user_role_sync", return_value="denied"):
+        with (
+            patch.object(svc, "get_prompt_access_config", return_value=config),
+            patch("deep_agent.src.ldap.service.ldap_settings") as ms,
+            patch.object(svc, "_resolve_user_role_sync", return_value="denied"),
+        ):
             ms.LDAP_URL = "ldaps://ldap.example.com"
             assert await svc.resolve_user_role("alice") == "users"
 
@@ -424,9 +452,11 @@ class TestResolveUserRole:
             groups=[GroupRoleMapping(role="owners", group="g1")],
             accessibility="private",
         )
-        with patch.object(svc, "get_prompt_access_config", return_value=config), \
-             patch("deep_agent.src.ldap.service.ldap_settings") as ms, \
-             patch.object(svc, "_resolve_user_role_sync", return_value="denied"):
+        with (
+            patch.object(svc, "get_prompt_access_config", return_value=config),
+            patch("deep_agent.src.ldap.service.ldap_settings") as ms,
+            patch.object(svc, "_resolve_user_role_sync", return_value="denied"),
+        ):
             ms.LDAP_URL = "ldaps://ldap.example.com"
             assert await svc.resolve_user_role("alice") == "denied"
 
@@ -436,9 +466,11 @@ class TestResolveUserRole:
             groups=[GroupRoleMapping(role="builders", group="g1")],
             accessibility="private",
         )
-        with patch.object(svc, "get_prompt_access_config", return_value=config), \
-             patch("deep_agent.src.ldap.service.ldap_settings") as ms, \
-             patch.object(svc, "_resolve_user_role_sync", return_value="builders"):
+        with (
+            patch.object(svc, "get_prompt_access_config", return_value=config),
+            patch("deep_agent.src.ldap.service.ldap_settings") as ms,
+            patch.object(svc, "_resolve_user_role_sync", return_value="builders"),
+        ):
             ms.LDAP_URL = "ldaps://ldap.example.com"
             assert await svc.resolve_user_role("alice") == "builders"
 
@@ -448,8 +480,10 @@ class TestResolveUserRole:
             groups=[GroupRoleMapping(role="owners", group="g1")],
             accessibility="private",
         )
-        with patch.object(svc, "get_prompt_access_config", return_value=config), \
-             patch("deep_agent.src.ldap.service.ldap_settings") as ms:
+        with (
+            patch.object(svc, "get_prompt_access_config", return_value=config),
+            patch("deep_agent.src.ldap.service.ldap_settings") as ms,
+        ):
             ms.LDAP_URL = ""
             await svc.resolve_user_role("alice")
             assert svc._startup_warning_logged is True


### PR DESCRIPTION
Signed-off-by: Srichand Vishnu S <31935898+vishnusrichand@users.noreply.github.com>

## What

Add LDAP group-based access control that resolves user roles from PROMPT.md front matter and enforces role-based gating on chat (LangGraph auth) and eval/dataset (FastAPI dependency) endpoints.

Fixes #

## How

Adds an LDAP module (deep_agent/src/ldap/) that resolves user roles from PROMPT.md group mappings via ldap3, caches results in Redis, and enforces access through two layers: LangGraph auth for chat endpoints and a FastAPI dependency for eval endpoints. Privileged roles (owners/admins/builders) get full access; users role is chat-only; denied blocks everything. Dev mode (ENABLE_AUTH=false) bypasses LDAP entirely.

## Testing

<!-- How did you verify this works? -->

- [x] Unit tests added/updated
- [x] Ran locally (`uv run pytest tests/unit -x`)
- [ ] Manual verification (describe below if applicable)

## Rollback

Revert the commit. No database migrations or persistent state changes. Remove `LDAP_*` env vars from deployment.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `ci:`, etc.)
- [x] No secrets, credentials, or PII in the diff
- [x] No breaking changes (or documented above with a migration path)
- [x] Pre-commit hooks pass (`uv run pre-commit run --all-files`)
