### PR TITLE
feat(dcr): add deregister handler and update tests

### DIFF
--- a/deep_agent/aegra/mcp_oauth_handlers.py
+++ b/deep_agent/aegra/mcp_oauth_handlers.py
@@ -398,12 +398,14 @@ async def handle_mcp_connections(user_id: str) -> dict[str, Any]:
     connections: list[dict[str, Any]] = []
     for mcp_name, server_cfg in _interactive_oauth_servers():
         description = server_cfg.get("description")
+        display_name = server_cfg.get("display_name")
         connected = await resolver.has_valid_token(user_id, mcp_name, server_cfg)
         connections.append(
             {
                 "mcp_name": mcp_name,
                 "auth_mode": server_cfg.get("auth_mode"),
                 "description": description if isinstance(description, str) else "",
+                "display_name": display_name if isinstance(display_name, str) else "",
                 "connected": connected,
             }
         )

--- a/tests/unit/aegra/test_mcp_oauth_handlers.py
+++ b/tests/unit/aegra/test_mcp_oauth_handlers.py
@@ -560,6 +560,7 @@ _INTERACTIVE_SERVERS = {
         "enabled": True,
         "auth_mode": "oauth",
         "description": "Alpha tools",
+        "display_name": "Alpha",
         "oauth": {"grant_type": "authorization_code"},
     },
     "bravo-dcr": {
@@ -608,12 +609,14 @@ class TestHandleMcpConnections:
                     "mcp_name": "alpha-oauth",
                     "auth_mode": "oauth",
                     "description": "Alpha tools",
+                    "display_name": "Alpha",
                     "connected": True,
                 },
                 {
                     "mcp_name": "bravo-dcr",
                     "auth_mode": "dcr",
                     "description": "Bravo DCR",
+                    "display_name": "",
                     "connected": False,
                 },
             ]
@@ -666,6 +669,65 @@ class TestHandleMcpConnections:
             result = await handle_mcp_connections("user-1")
 
         assert result["connections"][0]["description"] == ""
+        assert result["connections"][0]["display_name"] == ""
+
+    async def test_returns_display_name_when_present(self):
+        resolver = MagicMock()
+        resolver.has_valid_token = AsyncMock(return_value=True)
+        servers = {
+            "named": {
+                "enabled": True,
+                "auth_mode": "oauth",
+                "description": "Long description",
+                "display_name": "Short Name",
+                "oauth": {"grant_type": "authorization_code"},
+            }
+        }
+
+        with (
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.agent_config.get_mcp_servers",
+                return_value=servers,
+            ),
+            patch("deep_agent.aegra.mcp_oauth_handlers.settings") as mock_settings,
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.get_mcp_credential_resolver",
+                return_value=resolver,
+            ),
+        ):
+            mock_settings.MCP_DCR_ENABLED = True
+            result = await handle_mcp_connections("user-1")
+
+        assert result["connections"][0]["display_name"] == "Short Name"
+        assert result["connections"][0]["description"] == "Long description"
+
+    async def test_defaults_non_string_display_name_to_empty_string(self):
+        resolver = MagicMock()
+        resolver.has_valid_token = AsyncMock(return_value=True)
+        servers = {
+            "bad-name": {
+                "enabled": True,
+                "auth_mode": "oauth",
+                "display_name": 42,
+                "oauth": {"grant_type": "authorization_code"},
+            }
+        }
+
+        with (
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.agent_config.get_mcp_servers",
+                return_value=servers,
+            ),
+            patch("deep_agent.aegra.mcp_oauth_handlers.settings") as mock_settings,
+            patch(
+                "deep_agent.aegra.mcp_oauth_handlers.get_mcp_credential_resolver",
+                return_value=resolver,
+            ),
+        ):
+            mock_settings.MCP_DCR_ENABLED = True
+            result = await handle_mcp_connections("user-1")
+
+        assert result["connections"][0]["display_name"] == ""
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Add `display_name` to the MCP OAuth connections API so the UI can show a user-friendly label instead of the raw server key or description. 

Fixes #330

## How

- Added optional `display_name` field to `slack-mcp-gateway` and `atlassian` entries in `config/agent/mcp.json`.
- Extended `handle_mcp_connections` in `mcp_oauth_handlers.py` to read `display_name` from server config and include it in the response — returns `""` if missing or not a string, same pattern as `description`.
- No fallback resolution on the API side — the UI decides the display logic.

## Testing

- [x] Unit tests added/updated
- [x] Ran locally (`uv run pytest tests/unit -x`)
- [ ] Manual verification (describe below if applicable)

**New tests:**
- `test_returns_display_name_when_present` — verifies the field is passed through when set
- `test_defaults_non_string_display_name_to_empty_string` — verifies non-string values (e.g. `42`) are coerced to `""`

**Updated tests:**
- `test_lists_interactive_oauth_and_dcr_with_status` — expected output now includes `display_name`
- `test_defaults_missing_description_to_empty_string` — now also asserts `display_name` defaults to `""`

## Rollback

Revert the commit. The UI treats `display_name` as optional, so removing it from the API response is safe.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `ci:`, etc.)
- [x] No secrets, credentials, or PII in the diff
- [x] No breaking changes (or documented above with a migration path)
- [ ] Pre-commit hooks pass (`uv run pre-commit run --all-files`)
