### PR TITLE
feat: add feedback comments for thumbs down

### DIFF
--- a/deep_agent/aegra/feedback.py
+++ b/deep_agent/aegra/feedback.py
@@ -56,6 +56,7 @@ async def _persist_feedback_to_postgres(req: FeedbackRequest) -> None:
         return
     polarity = _score_to_feedback_polarity(req)
     user_id = req.user_id if req.user_id else "anonymous"
+    comment = (req.kwargs or {}).get("comment") if req.kwargs else None
     repo = FeedbackRepository(settings.database_uri)
     await repo.upsert_feedback(
         req.thread_id,
@@ -63,6 +64,7 @@ async def _persist_feedback_to_postgres(req: FeedbackRequest) -> None:
         user_id,
         polarity,
         req.trace_id,
+        comment=comment,
     )
     logger.info(
         "feedback_recorded_postgres",

--- a/deep_agent/src/feedback/repository.py
+++ b/deep_agent/src/feedback/repository.py
@@ -20,12 +20,23 @@ CREATE TABLE IF NOT EXISTS message_feedback (
     message_id  TEXT NOT NULL,
     user_id     TEXT NOT NULL DEFAULT 'anonymous',
     feedback    TEXT NOT NULL CHECK (feedback IN ('up', 'down')),
+    comment     TEXT,
     trace_id    TEXT,
     created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
     UNIQUE (thread_id, message_id, user_id)
 );
 CREATE INDEX IF NOT EXISTS idx_feedback_thread ON message_feedback (thread_id);
+
+-- Migration: add comment column to existing tables
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'message_feedback' AND column_name = 'comment'
+    ) THEN
+        ALTER TABLE message_feedback ADD COLUMN comment TEXT;
+    END IF;
+END $$;
 """
 
 
@@ -54,6 +65,7 @@ class FeedbackRepository:
         user_id: str,
         feedback: Literal["up", "down"],
         trace_id: str | None = None,
+        comment: str | None = None,
     ) -> None:
         """Insert or update feedback for a message (per thread and user)."""
         await self.ensure_table()
@@ -62,16 +74,17 @@ class FeedbackRepository:
             await conn.execute(
                 """
                 INSERT INTO message_feedback (
-                    thread_id, message_id, user_id, feedback, trace_id, updated_at
+                    thread_id, message_id, user_id, feedback, comment, trace_id, updated_at
                 )
-                VALUES (%s, %s, %s, %s, %s, now())
+                VALUES (%s, %s, %s, %s, %s, %s, now())
                 ON CONFLICT (thread_id, message_id, user_id)
                 DO UPDATE SET
                     feedback = EXCLUDED.feedback,
+                    comment = EXCLUDED.comment,
                     trace_id = EXCLUDED.trace_id,
                     updated_at = now()
                 """,
-                (thread_id, message_id, uid, feedback, trace_id),
+                (thread_id, message_id, uid, feedback, comment, trace_id),
             )
             await conn.commit()
 
@@ -100,7 +113,7 @@ class FeedbackRepository:
         thread_id: str,
         user_id: str,
     ) -> list[dict[str, Any]]:
-        """Return feedback entries for the thread and user as ``{message_id, feedback}``."""
+        """Return feedback entries for the thread and user."""
         await self.ensure_table()
         uid = user_id if user_id else "anonymous"
         async with await psycopg.AsyncConnection.connect(
@@ -108,7 +121,7 @@ class FeedbackRepository:
         ) as conn:
             cur = await conn.execute(
                 """
-                SELECT message_id, feedback
+                SELECT message_id, feedback, comment
                 FROM message_feedback
                 WHERE thread_id = %s AND user_id = %s
                 ORDER BY updated_at ASC
@@ -116,7 +129,13 @@ class FeedbackRepository:
                 (thread_id, uid),
             )
             rows = await cur.fetchall()
-            return [
-                {"message_id": str(r["message_id"]), "feedback": r["feedback"]}
-                for r in rows
-            ]
+            result = []
+            for r in rows:
+                entry: dict[str, Any] = {
+                    "message_id": str(r["message_id"]),
+                    "feedback": r["feedback"],
+                }
+                if r.get("comment"):
+                    entry["comment"] = r["comment"]
+                result.append(entry)
+            return result

--- a/tests/unit/aegra/test_feedback.py
+++ b/tests/unit/aegra/test_feedback.py
@@ -108,6 +108,42 @@ class TestRecordFeedback:
             "user-42",
             "up",
             "a" * 32,
+            comment=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_persists_comment_to_postgres(self):
+        payload = {
+            "trace_id": "b" * 32,
+            "name": "thumbs-down",
+            "value": 0.0,
+            "thread_id": "thread-2",
+            "message_id": "msg-2",
+            "user_id": "user-42",
+            "kwargs": {"comment": "The SQL was incorrect"},
+        }
+        mock_upsert = AsyncMock()
+        mock_repo = MagicMock()
+        mock_repo.upsert_feedback = mock_upsert
+
+        with patch(
+            "deep_agent.aegra.feedback.get_langfuse_client",
+            return_value=None,
+        ):
+            with patch(
+                "deep_agent.aegra.feedback.FeedbackRepository",
+                return_value=mock_repo,
+            ):
+                result = await record_feedback(payload)
+
+        assert result.status == "success"
+        mock_upsert.assert_awaited_once_with(
+            "thread-2",
+            "msg-2",
+            "user-42",
+            "down",
+            "b" * 32,
+            comment="The SQL was incorrect",
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/feedback/test_repository.py
+++ b/tests/unit/feedback/test_repository.py
@@ -80,6 +80,25 @@ class TestUpsertFeedback:
             mock_conn.commit.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_insert_with_comment(self, repo, mock_conn):
+        feedback_repo_mod._TABLE_ENSURED = True
+        with patch(
+            "deep_agent.src.feedback.repository.psycopg.AsyncConnection.connect",
+            return_value=mock_conn,
+        ):
+            await repo.upsert_feedback(
+                "t1",
+                "m1",
+                "u1",
+                "down",
+                "trace-1",
+                comment="The answer was wrong",
+            )
+            mock_conn.execute.assert_awaited_once()
+            args = mock_conn.execute.call_args
+            assert "The answer was wrong" in args[0][1]
+
+    @pytest.mark.asyncio
     async def test_update_second_upsert(self, repo, mock_conn):
         """Second upsert with same keys runs ON CONFLICT UPDATE (still one execute)."""
         feedback_repo_mod._TABLE_ENSURED = True
@@ -125,8 +144,8 @@ class TestListFeedback:
         feedback_repo_mod._TABLE_ENSURED = True
         mock_conn._cursor.fetchall = AsyncMock(
             return_value=[
-                {"message_id": "m1", "feedback": "up"},
-                {"message_id": "m2", "feedback": "down"},
+                {"message_id": "m1", "feedback": "up", "comment": None},
+                {"message_id": "m2", "feedback": "down", "comment": None},
             ]
         )
         with patch(
@@ -137,6 +156,23 @@ class TestListFeedback:
             assert rows == [
                 {"message_id": "m1", "feedback": "up"},
                 {"message_id": "m2", "feedback": "down"},
+            ]
+
+    @pytest.mark.asyncio
+    async def test_returns_comment_when_present(self, repo, mock_conn):
+        feedback_repo_mod._TABLE_ENSURED = True
+        mock_conn._cursor.fetchall = AsyncMock(
+            return_value=[
+                {"message_id": "m1", "feedback": "down", "comment": "Wrong answer"},
+            ]
+        )
+        with patch(
+            "deep_agent.src.feedback.repository.psycopg.AsyncConnection.connect",
+            return_value=mock_conn,
+        ):
+            rows = await repo.list_feedback("t1", "u1")
+            assert rows == [
+                {"message_id": "m1", "feedback": "down", "comment": "Wrong answer"},
             ]
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What

This PR adds the optional comment field (text) in the feedback table. This will allow the UI to store and retrieve feedback comments associated with a thumbs down feedback submission in https://github.com/redhat-data-and-ai/template-ui/pull/221

Fixes #332 

## How

- `deep_agent/aegra/feedback.py`: the comment string is extracted from req.kwards and is only sent to the upsert_feedback method if it is a string. It guards agains non-string values.
- `deep_agent/src/feedback/repository.py`: the comment field is added to the table as a 'text' type . a migration is added to include the comment column/field into existing tables. comment field added to upsert_feedback and list_feedback methods

## Testing

- [x] Unit tests added/updated
- [x] Ran locally (`uv run pytest tests/unit -x`)
- [x] Manual verification (describe below if applicable)

## Rollback

revert the commit

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `ci:`, etc.)
- [x] No secrets, credentials, or PII in the diff
- [x] No breaking changes (or documented above with a migration path)
- [x] Pre-commit hooks pass (`uv run pre-commit run --all-files`)
